### PR TITLE
Result 型をリファクタリング

### DIFF
--- a/src/app/Http/Controllers/Web/Creator/EditCreatorController.php
+++ b/src/app/Http/Controllers/Web/Creator/EditCreatorController.php
@@ -24,7 +24,7 @@ class EditCreatorController extends Controller
     ): RedirectResponse|View {
         $result = $getInteractor->handle(new GetRequest($creatorId));
 
-        if (! $result->isOk()) {
+        if ($result->isErr()) {
             return redirect()
                 ->route(RouteMap::ListCreators)
                 ->withErrors([

--- a/src/app/Http/Controllers/Web/Creator/EditCreatorController.php
+++ b/src/app/Http/Controllers/Web/Creator/EditCreatorController.php
@@ -28,11 +28,11 @@ class EditCreatorController extends Controller
             return redirect()
                 ->route(RouteMap::ListCreators)
                 ->withErrors([
-                    'message' => $result->getErr(),
+                    'message' => $result->unwrapErr(),
                 ]);
         }
 
-        $creator = $presenter->present($result->getValue());
+        $creator = $presenter->present($result->unwrap());
 
         return view('creators.edit.index', compact('creator'));
     }

--- a/src/app/Http/Controllers/Web/JourneyLog/EditJourneyLogController.php
+++ b/src/app/Http/Controllers/Web/JourneyLog/EditJourneyLogController.php
@@ -32,11 +32,11 @@ class EditJourneyLogController extends Controller
             return redirect()
                 ->route(RouteMap::ListJourneyLogs)
                 ->withErrors([
-                    'message' => $result->getErr(),
+                    'message' => $result->unwrapErr(),
                 ]);
         }
 
-        $journeyLog = $presenter->present($result->getValue());
+        $journeyLog = $presenter->present($result->unwrap());
         $journeyLogLinkTypes = $journeyLogLinkTypeListPresenter->present($listInteractor->handle());
 
         return view('journeyLogs.edit.index', compact('journeyLog', 'journeyLogLinkTypes'));

--- a/src/app/Http/Controllers/Web/JourneyLog/EditJourneyLogController.php
+++ b/src/app/Http/Controllers/Web/JourneyLog/EditJourneyLogController.php
@@ -28,7 +28,7 @@ class EditJourneyLogController extends Controller
     ): RedirectResponse|View {
         $result = $getInteractor->handle(new GetRequest($journeyLogId));
 
-        if (! $result->isOk()) {
+        if ($result->isErr()) {
             return redirect()
                 ->route(RouteMap::ListJourneyLogs)
                 ->withErrors([

--- a/src/app/Http/Controllers/Web/JourneyLogLinkType/EditJourneyLogLinkTypeController.php
+++ b/src/app/Http/Controllers/Web/JourneyLogLinkType/EditJourneyLogLinkTypeController.php
@@ -25,11 +25,11 @@ class EditJourneyLogLinkTypeController extends Controller
             return redirect()
                 ->route(RouteMap::ListJourneyLogLinkType)
                 ->withErrors([
-                    'message' => $result->getErr(),
+                    'message' => $result->unwrapErr(),
                 ]);
         }
 
-        $journeyLogLinkType = $presenter->present($result->getValue());
+        $journeyLogLinkType = $presenter->present($result->unwrap());
 
         return view('journeyLogLinkTypes.edit.index', compact('journeyLogLinkType'));
     }

--- a/src/app/Http/Controllers/Web/JourneyLogLinkType/EditJourneyLogLinkTypeController.php
+++ b/src/app/Http/Controllers/Web/JourneyLogLinkType/EditJourneyLogLinkTypeController.php
@@ -21,7 +21,7 @@ class EditJourneyLogLinkTypeController extends Controller
     {
         $result = $interactor->handle(new GetRequest($journeyLogLinkTypeId));
 
-        if (! $result->isOk()) {
+        if ($result->isErr()) {
             return redirect()
                 ->route(RouteMap::ListJourneyLogLinkType)
                 ->withErrors([

--- a/src/packages/Creator/Application/Get/GetInteractor.php
+++ b/src/packages/Creator/Application/Get/GetInteractor.php
@@ -9,9 +9,9 @@ use Creator\Domain\Repositories\CreatorRepositoryInterface;
 use Creator\UseCases\Get\GetRequest;
 use Creator\UseCases\Get\GetResponse;
 use Creator\UseCases\Get\GetUseCaseInterface;
-use Support\Result\Err;
-use Support\Result\Ok;
-use Support\Result\Result;
+use Support\ResultType\Err;
+use Support\ResultType\Ok;
+use Support\ResultType\Result;
 
 class GetInteractor implements GetUseCaseInterface
 {

--- a/src/packages/Creator/UseCases/Get/GetUseCaseInterface.php
+++ b/src/packages/Creator/UseCases/Get/GetUseCaseInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Creator\UseCases\Get;
 
-use Support\Result\Result;
+use Support\ResultType\Result;
 
 interface GetUseCaseInterface
 {

--- a/src/packages/JourneyLog/Application/Get/GetInteractor.php
+++ b/src/packages/JourneyLog/Application/Get/GetInteractor.php
@@ -9,9 +9,9 @@ use JourneyLog\Domain\Repositories\JourneyLogRepositoryInterface;
 use JourneyLog\UseCases\Get\GetRequest;
 use JourneyLog\UseCases\Get\GetResponse;
 use JourneyLog\UseCases\Get\GetUseCaseInterface;
-use Support\Result\Err;
-use Support\Result\Ok;
-use Support\Result\Result;
+use Support\ResultType\Err;
+use Support\ResultType\Ok;
+use Support\ResultType\Result;
 
 class GetInteractor implements GetUseCaseInterface
 {

--- a/src/packages/JourneyLog/UseCases/Get/GetUseCaseInterface.php
+++ b/src/packages/JourneyLog/UseCases/Get/GetUseCaseInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace JourneyLog\UseCases\Get;
 
-use Support\Result\Result;
+use Support\ResultType\Result;
 
 interface GetUseCaseInterface
 {

--- a/src/packages/JourneyLogLinkType/Application/Get/GetInteractor.php
+++ b/src/packages/JourneyLogLinkType/Application/Get/GetInteractor.php
@@ -9,9 +9,9 @@ use JourneyLogLinkType\Domain\Repositories\JourneyLogLinkTypeRepositoryInterface
 use JourneyLogLinkType\UseCases\Get\GetRequest;
 use JourneyLogLinkType\UseCases\Get\GetResponse;
 use JourneyLogLinkType\UseCases\Get\GetUseCaseInterface;
-use Support\Result\Err;
-use Support\Result\Ok;
-use Support\Result\Result;
+use Support\ResultType\Err;
+use Support\ResultType\Ok;
+use Support\ResultType\Result;
 
 class GetInteractor implements GetUseCaseInterface
 {

--- a/src/packages/JourneyLogLinkType/UseCases/Get/GetUseCaseInterface.php
+++ b/src/packages/JourneyLogLinkType/UseCases/Get/GetUseCaseInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace JourneyLogLinkType\UseCases\Get;
 
-use Support\Result\Result;
+use Support\ResultType\Result;
 
 interface GetUseCaseInterface
 {

--- a/src/packages/Support/ResultType/Err.php
+++ b/src/packages/Support/ResultType/Err.php
@@ -25,6 +25,11 @@ class Err implements Result
         return false;
     }
 
+    public function isErr(): bool
+    {
+        return true;
+    }
+
     public function unwrap(): mixed
     {
         throw new LogicException('Cannot get value from Err result');

--- a/src/packages/Support/ResultType/Err.php
+++ b/src/packages/Support/ResultType/Err.php
@@ -25,7 +25,7 @@ class Err implements Result
         return false;
     }
 
-    public function getValue(): mixed
+    public function unwrap(): mixed
     {
         throw new LogicException('Cannot get value from Err result');
     }
@@ -33,7 +33,7 @@ class Err implements Result
     /**
      * @return E
      */
-    public function getErr(): mixed
+    public function unwrapErr(): mixed
     {
         return $this->value;
     }

--- a/src/packages/Support/ResultType/Err.php
+++ b/src/packages/Support/ResultType/Err.php
@@ -2,19 +2,19 @@
 
 declare(strict_types=1);
 
-namespace Support\Result;
+namespace Support\ResultType;
 
 use LogicException;
 
 /**
- * @template-covariant T
+ * @template-covariant E
  *
- * @template-implements Result<T, never>
+ * @template-implements Result<never, E>
  */
-class Ok implements Result
+class Err implements Result
 {
     /**
-     * @param T $value
+     * @param E $value
      */
     public function __construct(private readonly mixed $value)
     {
@@ -22,19 +22,19 @@ class Ok implements Result
 
     public function isOk(): bool
     {
-        return true;
+        return false;
+    }
+
+    public function getValue(): mixed
+    {
+        throw new LogicException('Cannot get value from Err result');
     }
 
     /**
-     * @return T
+     * @return E
      */
-    public function getValue(): mixed
-    {
-        return $this->value;
-    }
-
     public function getErr(): mixed
     {
-        throw new LogicException('Cannot get error from Ok result');
+        return $this->value;
     }
 }

--- a/src/packages/Support/ResultType/Ok.php
+++ b/src/packages/Support/ResultType/Ok.php
@@ -2,19 +2,19 @@
 
 declare(strict_types=1);
 
-namespace Support\Result;
+namespace Support\ResultType;
 
 use LogicException;
 
 /**
- * @template-covariant E
+ * @template-covariant T
  *
- * @template-implements Result<never, E>
+ * @template-implements Result<T, never>
  */
-class Err implements Result
+class Ok implements Result
 {
     /**
-     * @param E $value
+     * @param T $value
      */
     public function __construct(private readonly mixed $value)
     {
@@ -22,19 +22,19 @@ class Err implements Result
 
     public function isOk(): bool
     {
-        return false;
-    }
-
-    public function getValue(): mixed
-    {
-        throw new LogicException('Cannot get value from Err result');
+        return true;
     }
 
     /**
-     * @return E
+     * @return T
      */
-    public function getErr(): mixed
+    public function getValue(): mixed
     {
         return $this->value;
+    }
+
+    public function getErr(): mixed
+    {
+        throw new LogicException('Cannot get error from Ok result');
     }
 }

--- a/src/packages/Support/ResultType/Ok.php
+++ b/src/packages/Support/ResultType/Ok.php
@@ -25,6 +25,11 @@ class Ok implements Result
         return true;
     }
 
+    public function isErr(): bool
+    {
+        return false;
+    }
+
     /**
      * @return T
      */

--- a/src/packages/Support/ResultType/Ok.php
+++ b/src/packages/Support/ResultType/Ok.php
@@ -28,12 +28,12 @@ class Ok implements Result
     /**
      * @return T
      */
-    public function getValue(): mixed
+    public function unwrap(): mixed
     {
         return $this->value;
     }
 
-    public function getErr(): mixed
+    public function unwrapErr(): mixed
     {
         throw new LogicException('Cannot get error from Ok result');
     }

--- a/src/packages/Support/ResultType/Result.php
+++ b/src/packages/Support/ResultType/Result.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Support\Result;
+namespace Support\ResultType;
 
 /**
  * @template-covariant T

--- a/src/packages/Support/ResultType/Result.php
+++ b/src/packages/Support/ResultType/Result.php
@@ -12,6 +12,8 @@ interface Result
 {
     public function isOk(): bool;
 
+    public function isErr(): bool;
+
     /**
      * @return T
      */

--- a/src/packages/Support/ResultType/Result.php
+++ b/src/packages/Support/ResultType/Result.php
@@ -15,10 +15,10 @@ interface Result
     /**
      * @return T
      */
-    public function getValue(): mixed;
+    public function unwrap(): mixed;
 
     /**
      * @return E
      */
-    public function getErr(): mixed;
+    public function unwrapErr(): mixed;
 }

--- a/src/phparkitect.php
+++ b/src/phparkitect.php
@@ -30,13 +30,13 @@ return static function (Config $config): void {
             ->component('Creator.UseCase')->definedBy('Creator\UseCases\*')
 
             ->component('Support.Domain')->definedBy('Support\Domain\*')
-            ->component('Support.Result')->definedBy('Support\Result\*')
+            ->component('Support.ResultType')->definedBy('Support\ResultType\*')
 
             ->where('JourneyLog.Domain')->shouldOnlyDependOnComponents('JourneyLog.Domain', 'JourneyLogLinkType.Domain', 'Support.Domain')
-            ->where('JourneyLog.UseCase')->shouldOnlyDependOnComponents('JourneyLog.Domain', 'Support.Result')
+            ->where('JourneyLog.UseCase')->shouldOnlyDependOnComponents('JourneyLog.Domain', 'Support.ResultType')
 
             ->where('JourneyLogLinkType.Domain')->shouldOnlyDependOnComponents('JourneyLogLinkType.Domain', 'Support.Domain')
-            ->where('JourneyLogLinkType.UseCase')->shouldOnlyDependOnComponents('JourneyLogLinkType.Domain', 'Support.Result')
+            ->where('JourneyLogLinkType.UseCase')->shouldOnlyDependOnComponents('JourneyLogLinkType.Domain', 'Support.ResultType')
 
             ->where('Song.Domain')->shouldOnlyDependOnComponents('Song.Domain', 'SongType.Domain', 'Creator.Domain', 'Support.Domain')
             ->where('Song.UseCase')->shouldOnlyDependOnComponents('Song.Domain')
@@ -44,10 +44,10 @@ return static function (Config $config): void {
             ->where('SongType.Domain')->shouldOnlyDependOnComponents('SongType.Domain', 'Support.Domain')
 
             ->where('Creator.Domain')->shouldOnlyDependOnComponents('Creator.Domain', 'Support.Domain')
-            ->where('Creator.UseCase')->shouldOnlyDependOnComponents('Creator.Domain', 'Support.Result')
+            ->where('Creator.UseCase')->shouldOnlyDependOnComponents('Creator.Domain', 'Support.ResultType')
 
             ->where('Support.Domain')->shouldNotDependOnAnyComponent()
-            ->where('Support.Result')->shouldNotDependOnAnyComponent()
+            ->where('Support.ResultType')->shouldNotDependOnAnyComponent()
 
             ->rules()
     );

--- a/src/tests/Unit/Creator/Application/Get/GetInteractorTest.php
+++ b/src/tests/Unit/Creator/Application/Get/GetInteractorTest.php
@@ -15,7 +15,7 @@ use Creator\UseCases\Get\GetUseCaseInterface;
 use Mockery;
 use Mockery\MockInterface;
 use PHPUnit\Framework\Attributes\Test;
-use Support\Result\Result;
+use Support\ResultType\Result;
 use Tests\TestCase;
 
 class GetInteractorTest extends TestCase

--- a/src/tests/Unit/Creator/Application/Get/GetInteractorTest.php
+++ b/src/tests/Unit/Creator/Application/Get/GetInteractorTest.php
@@ -59,7 +59,7 @@ class GetInteractorTest extends TestCase
         $this->assertInstanceOf(Result::class, $result);
         $this->assertTrue($result->isOk());
 
-        $response = $result->getValue();
+        $response = $result->unwrap();
 
         $this->assertInstanceOf(GetResponse::class, $response);
 
@@ -84,6 +84,6 @@ class GetInteractorTest extends TestCase
         $this->assertInstanceOf(Result::class, $result);
         $this->assertFalse($result->isOk());
 
-        $this->assertSame('Creator not found: BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB', $result->getErr());
+        $this->assertSame('Creator not found: BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB', $result->unwrapErr());
     }
 }

--- a/src/tests/Unit/JourneyLog/Application/Get/GetInteractorTest.php
+++ b/src/tests/Unit/JourneyLog/Application/Get/GetInteractorTest.php
@@ -25,7 +25,7 @@ use Mockery;
 use Mockery\MockInterface;
 use PHPUnit\Framework\Attributes\Test;
 use Support\Domain\ValueObjects\OrderNo;
-use Support\Result\Result;
+use Support\ResultType\Result;
 use Tests\TestCase;
 
 class GetInteractorTest extends TestCase

--- a/src/tests/Unit/JourneyLog/Application/Get/GetInteractorTest.php
+++ b/src/tests/Unit/JourneyLog/Application/Get/GetInteractorTest.php
@@ -73,7 +73,7 @@ class GetInteractorTest extends TestCase
 
         $this->assertTrue($result->isOk());
 
-        $response = $result->getValue();
+        $response = $result->unwrap();
 
         $this->assertInstanceOf(GetResponse::class, $response);
 
@@ -118,7 +118,7 @@ class GetInteractorTest extends TestCase
         $this->assertInstanceOf(Result::class, $result);
         $this->assertTrue($result->isOk());
 
-        $response = $result->getValue();
+        $response = $result->unwrap();
 
         $this->assertInstanceOf(GetResponse::class, $response);
 
@@ -152,6 +152,6 @@ class GetInteractorTest extends TestCase
         $this->assertInstanceOf(Result::class, $result);
         $this->assertFalse($result->isOk());
 
-        $this->assertSame('JourneyLog not found: BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB', $result->getErr());
+        $this->assertSame('JourneyLog not found: BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB', $result->unwrapErr());
     }
 }

--- a/src/tests/Unit/JourneyLogLinkType/Application/Get/GetInteractorTest.php
+++ b/src/tests/Unit/JourneyLogLinkType/Application/Get/GetInteractorTest.php
@@ -15,7 +15,7 @@ use Mockery;
 use Mockery\MockInterface;
 use PHPUnit\Framework\Attributes\Test;
 use Support\Domain\ValueObjects\OrderNo;
-use Support\Result\Result;
+use Support\ResultType\Result;
 use Tests\TestCase;
 
 class GetInteractorTest extends TestCase

--- a/src/tests/Unit/JourneyLogLinkType/Application/Get/GetInteractorTest.php
+++ b/src/tests/Unit/JourneyLogLinkType/Application/Get/GetInteractorTest.php
@@ -60,7 +60,7 @@ class GetInteractorTest extends TestCase
         $this->assertInstanceOf(Result::class, $result);
         $this->assertTrue($result->isOk());
 
-        $response = $result->getValue();
+        $response = $result->unwrap();
 
         $this->assertSame('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA', $response->journeyLogLinkType->journeyLogLinkTypeId->value);
         $this->assertSame('リンク', $response->journeyLogLinkType->journeyLogLinkTypeName->value);
@@ -83,6 +83,6 @@ class GetInteractorTest extends TestCase
         $this->assertInstanceOf(Result::class, $result);
         $this->assertFalse($result->isOk());
 
-        $this->assertSame('JourneyLogLinkType not found: AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA', $result->getErr());
+        $this->assertSame('JourneyLogLinkType not found: AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA', $result->unwrapErr());
     }
 }

--- a/src/tests/Unit/Support/ResultType/ErrTest.php
+++ b/src/tests/Unit/Support/ResultType/ErrTest.php
@@ -27,6 +27,12 @@ class ErrTest extends TestCase
     }
 
     #[Test]
+    public function isErr(): void
+    {
+        $this->assertTrue(new Err(null)->isErr());
+    }
+
+    #[Test]
     #[DataProvider('provideUnwrapErr')]
     public function unwrapErr(mixed $value): void
     {

--- a/src/tests/Unit/Support/ResultType/ErrTest.php
+++ b/src/tests/Unit/Support/ResultType/ErrTest.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Tests\Unit\Support\Result;
+namespace Tests\Unit\Support\ResultType;
 
 use LogicException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use stdClass;
-use Support\Result\Err;
-use Support\Result\Result;
+use Support\ResultType\Err;
+use Support\ResultType\Result;
 use Tests\TestCase;
 
 class ErrTest extends TestCase

--- a/src/tests/Unit/Support/ResultType/ErrTest.php
+++ b/src/tests/Unit/Support/ResultType/ErrTest.php
@@ -27,13 +27,13 @@ class ErrTest extends TestCase
     }
 
     #[Test]
-    #[DataProvider('provideGetErr')]
-    public function getErr(mixed $value): void
+    #[DataProvider('provideUnwrapErr')]
+    public function unwrapErr(mixed $value): void
     {
-        $this->assertSame($value, new Err($value)->getErr());
+        $this->assertSame($value, new Err($value)->unwrapErr());
     }
 
-    public static function provideGetErr(): array
+    public static function provideUnwrapErr(): array
     {
         return [
             [null],
@@ -45,12 +45,12 @@ class ErrTest extends TestCase
     }
 
     #[Test]
-    public function throwInGetValue(): void
+    public function throwWhenUnwrap(): void
     {
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Cannot get value from Err result');
 
-        new Err(null)->getValue();
+        new Err(null)->unwrap();
     }
 }
 

--- a/src/tests/Unit/Support/ResultType/OkTest.php
+++ b/src/tests/Unit/Support/ResultType/OkTest.php
@@ -27,6 +27,12 @@ class OkTest extends TestCase
     }
 
     #[Test]
+    public function isErr(): void
+    {
+        $this->assertFalse(new Ok(null)->isErr());
+    }
+
+    #[Test]
     #[DataProvider('provideUnwrap')]
     public function unwrap(mixed $value): void
     {

--- a/src/tests/Unit/Support/ResultType/OkTest.php
+++ b/src/tests/Unit/Support/ResultType/OkTest.php
@@ -27,13 +27,13 @@ class OkTest extends TestCase
     }
 
     #[Test]
-    #[DataProvider('provideGetValue')]
-    public function getValue(mixed $value): void
+    #[DataProvider('provideUnwrap')]
+    public function unwrap(mixed $value): void
     {
-        $this->assertSame($value, new Ok($value)->getValue());
+        $this->assertSame($value, new Ok($value)->unwrap());
     }
 
-    public static function provideGetValue(): array
+    public static function provideUnwrap(): array
     {
         return [
             [null],
@@ -45,12 +45,12 @@ class OkTest extends TestCase
     }
 
     #[Test]
-    public function throwInGetErr(): void
+    public function throwWhenUnwrapErr(): void
     {
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Cannot get error from Ok result');
 
-        new Ok(null)->getErr();
+        new Ok(null)->unwrapErr();
     }
 }
 

--- a/src/tests/Unit/Support/ResultType/OkTest.php
+++ b/src/tests/Unit/Support/ResultType/OkTest.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Tests\Unit\Support\Result;
+namespace Tests\Unit\Support\ResultType;
 
 use LogicException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use stdClass;
-use Support\Result\Ok;
-use Support\Result\Result;
+use Support\ResultType\Ok;
+use Support\ResultType\Result;
 use Tests\TestCase;
 
 class OkTest extends TestCase


### PR DESCRIPTION
- 名前空間の変更
  - `Result` -> `ResultType`
- メソッド名の変更
  - `getValue()` -> `unwrap()`
  - `getErr()` -> `unwrapErr()`
- メソッドの追加
  - `isErr()`
- `isOk()` を `isErr()` に置き換え