### PR TITLE
テストのあれこれをリファクタ

### DIFF
--- a/src/tests/Feature/Web/Creator/CreateCreatorTest.php
+++ b/src/tests/Feature/Web/Creator/CreateCreatorTest.php
@@ -21,7 +21,7 @@ class CreateCreatorTest extends TestCase
 
     private User $user;
 
-    private CreatorRepositoryInterface&MockInterface $creatorRepository;
+    private CreatorRepositoryInterface&MockInterface $repository;
 
     public function setUp(): void
     {
@@ -31,7 +31,9 @@ class CreateCreatorTest extends TestCase
             'user_id' => Str::uuid()->toString(),
         ]);
 
-        $this->creatorRepository = Mockery::mock(CreatorRepositoryInterface::class);
+        $this->repository = Mockery::mock(CreatorRepositoryInterface::class);
+
+        $this->app->bind(CreatorRepositoryInterface::class, fn (): CreatorRepositoryInterface => $this->repository);
     }
 
     #[Test]
@@ -45,7 +47,7 @@ class CreateCreatorTest extends TestCase
     #[Test]
     public function showCreateForm(): void
     {
-        $response = $this->actingAs($this->user)
+        $this->actingAs($this->user)
             ->get(route(RouteMap::ShowCreateCreatorForm))
             ->assertStatus(200);
     }
@@ -55,14 +57,12 @@ class CreateCreatorTest extends TestCase
     {
         $uuid = $this->generateUuid();
 
-        $this->creatorRepository->shouldReceive('insert')
+        $this->repository->shouldReceive('insert')
             ->with(Mockery::on(
                 fn (Creator $arg): bool => $arg->creatorId->value === $uuid
                     && $arg->creatorName->value === 'クリエイター'
             ))
             ->once();
-
-        $this->app->bind(CreatorRepositoryInterface::class, fn (): CreatorRepositoryInterface => $this->creatorRepository);
 
         $this->actingAs($this->user)
             ->post(route(RouteMap::CreateCreator), [

--- a/src/tests/Feature/Web/Creator/DeleteCreatorTest.php
+++ b/src/tests/Feature/Web/Creator/DeleteCreatorTest.php
@@ -21,7 +21,7 @@ class DeleteCreatorTest extends TestCase
 
     private User $user;
 
-    private CreatorRepositoryInterface&MockInterface $creatorRepository;
+    private CreatorRepositoryInterface&MockInterface $repository;
 
     public function setUp(): void
     {
@@ -31,7 +31,9 @@ class DeleteCreatorTest extends TestCase
             'user_id' => Str::uuid()->toString(),
         ]);
 
-        $this->creatorRepository = Mockery::mock(CreatorRepositoryInterface::class);
+        $this->repository = Mockery::mock(CreatorRepositoryInterface::class);
+
+        $this->app->bind(CreatorRepositoryInterface::class, fn (): CreatorRepositoryInterface => $this->repository);
     }
 
     #[Test]
@@ -47,14 +49,9 @@ class DeleteCreatorTest extends TestCase
     {
         $uuid = $this->generateUuid();
 
-        $this->creatorRepository->shouldReceive('delete')
+        $this->repository->shouldReceive('delete')
             ->with(Mockery::on(fn ($arg) => $arg instanceof CreatorId && $arg->value === $uuid))
             ->once();
-
-        $this->app->bind(
-            CreatorRepositoryInterface::class,
-            fn (): CreatorRepositoryInterface => $this->creatorRepository,
-        );
 
         $this->actingAs($this->user)
             ->delete(route(RouteMap::DeleteCreator), [

--- a/src/tests/Feature/Web/Creator/EditCreatorTest.php
+++ b/src/tests/Feature/Web/Creator/EditCreatorTest.php
@@ -24,7 +24,7 @@ class EditCreatorTest extends TestCase
 
     private User $user;
 
-    private CreatorRepositoryInterface&MockInterface $creatorRepository;
+    private CreatorRepositoryInterface&MockInterface $repository;
 
     public function setUp(): void
     {
@@ -34,7 +34,9 @@ class EditCreatorTest extends TestCase
             'user_id' => Str::uuid()->toString(),
         ]);
 
-        $this->creatorRepository = Mockery::mock(CreatorRepositoryInterface::class);
+        $this->repository = Mockery::mock(CreatorRepositoryInterface::class);
+
+        $this->app->bind(CreatorRepositoryInterface::class, fn (): CreatorRepositoryInterface => $this->repository);
     }
 
     #[Test]
@@ -59,18 +61,13 @@ class EditCreatorTest extends TestCase
     {
         $uuid = $this->generateUuid();
 
-        $this->creatorRepository->shouldReceive('find')
-            ->with(Mockery::on(fn ($arg) => $arg instanceof CreatorId && $arg->value === $uuid))
+        $this->repository->shouldReceive('find')
+            ->with(Mockery::on(fn (CreatorId $arg): bool => $arg->value === $uuid))
             ->andReturn(new Creator(
                 new CreatorId($uuid),
                 new CreatorName('クリエイター名'),
             ))
             ->once();
-
-        $this->app->bind(
-            CreatorRepositoryInterface::class,
-            fn (): CreatorRepositoryInterface => $this->creatorRepository,
-        );
 
         $response = $this->actingAs($this->user)
             ->get(route(RouteMap::ShowEditCreatorForm, ['creatorId' => $uuid]))
@@ -86,15 +83,10 @@ class EditCreatorTest extends TestCase
     {
         $uuid = $this->generateUuid();
 
-        $this->creatorRepository->shouldReceive('find')
-            ->with(Mockery::on(fn ($arg) => $arg instanceof CreatorId && $arg->value === $uuid))
+        $this->repository->shouldReceive('find')
+            ->with(Mockery::on(fn (CreatorId $arg): bool => $arg->value === $uuid))
             ->andReturnNull()
             ->once();
-
-        $this->app->bind(
-            CreatorRepositoryInterface::class,
-            fn (): CreatorRepositoryInterface => $this->creatorRepository,
-        );
 
         $this->actingAs($this->user)
             ->get(route(RouteMap::ShowEditCreatorForm, ['creatorId' => $uuid]))
@@ -108,19 +100,13 @@ class EditCreatorTest extends TestCase
     {
         $uuid = $this->generateUuid();
 
-        $this->creatorRepository->shouldReceive('update')
+        $this->repository->shouldReceive('update')
             ->with(Mockery::on(
-                fn ($arg) => $arg instanceof Creator
-                && $arg->creatorId->value === $uuid
-                && $arg->creatorName->value === 'クリエイター名'
+                fn (Creator $arg): bool => $arg->creatorId->value === $uuid
+                    && $arg->creatorName->value === 'クリエイター名'
             ))
             ->andReturn(new CreatorId($uuid))
             ->once();
-
-        $this->app->bind(
-            CreatorRepositoryInterface::class,
-            fn (): CreatorRepositoryInterface => $this->creatorRepository,
-        );
 
         $this->actingAs($this->user)
             ->post(route(RouteMap::EditCreator), [

--- a/src/tests/Feature/Web/Creator/ListCreatorTest.php
+++ b/src/tests/Feature/Web/Creator/ListCreatorTest.php
@@ -23,7 +23,7 @@ class ListCreatorTest extends TestCase
 
     private User $user;
 
-    private CreatorRepositoryInterface&MockInterface $creatorRepository;
+    private CreatorRepositoryInterface&MockInterface $repository;
 
     public function setUp(): void
     {
@@ -33,7 +33,9 @@ class ListCreatorTest extends TestCase
             'user_id' => Str::uuid()->toString(),
         ]);
 
-        $this->creatorRepository = Mockery::mock(CreatorRepositoryInterface::class);
+        $this->repository = Mockery::mock(CreatorRepositoryInterface::class);
+
+        $this->app->bind(CreatorRepositoryInterface::class, fn (): CreatorRepositoryInterface => $this->repository);
     }
 
     #[Test]
@@ -49,7 +51,7 @@ class ListCreatorTest extends TestCase
     {
         $uuid = $this->generateUuid();
 
-        $this->creatorRepository->shouldReceive('all')
+        $this->repository->shouldReceive('all')
             ->andReturn([
                 new Creator(
                     new CreatorId($uuid),
@@ -61,8 +63,6 @@ class ListCreatorTest extends TestCase
                 ),
             ])
             ->once();
-
-        $this->app->bind(CreatorRepositoryInterface::class, fn (): CreatorRepositoryInterface => $this->creatorRepository);
 
         $response = $this->actingAs($this->user)
             ->get(route(RouteMap::ListCreators))
@@ -86,11 +86,9 @@ class ListCreatorTest extends TestCase
     #[Test]
     public function showEmptyList(): void
     {
-        $this->creatorRepository->shouldReceive('all')
+        $this->repository->shouldReceive('all')
             ->andReturn([])
             ->once();
-
-        $this->app->bind(CreatorRepositoryInterface::class, fn (): CreatorRepositoryInterface => $this->creatorRepository);
 
         $response = $this->actingAs($this->user)
             ->get(route(RouteMap::ListCreators))

--- a/src/tests/Feature/Web/JourneyLog/CreateJourneyLogTest.php
+++ b/src/tests/Feature/Web/JourneyLog/CreateJourneyLogTest.php
@@ -11,7 +11,7 @@ use JourneyLog\Domain\Models\JourneyLog;
 use JourneyLog\Domain\Repositories\JourneyLogRepositoryInterface;
 use JourneyLogLinkType\Domain\Repositories\JourneyLogLinkTypeRepositoryInterface;
 use Mockery;
-use Mockery\LegacyMockInterface;
+use Mockery\MockInterface;
 use PHPUnit\Framework\Attributes\Test;
 use Support\Route\RouteMap;
 use Tests\TestCase;
@@ -22,9 +22,9 @@ class CreateJourneyLogTest extends TestCase
 
     private User $user;
 
-    private JourneyLogRepositoryInterface&LegacyMockInterface $journeyLogRepository;
+    private JourneyLogRepositoryInterface&MockInterface $journeyLogRepository;
 
-    private JourneyLogLinkTypeRepositoryInterface&LegacyMockInterface $journeyLogLinkTypeRepository;
+    private JourneyLogLinkTypeRepositoryInterface&MockInterface $journeyLogLinkTypeRepository;
 
     public function setUp(): void
     {
@@ -36,6 +36,16 @@ class CreateJourneyLogTest extends TestCase
 
         $this->journeyLogRepository = Mockery::mock(JourneyLogRepositoryInterface::class);
         $this->journeyLogLinkTypeRepository = Mockery::mock(JourneyLogLinkTypeRepositoryInterface::class);
+
+        $this->app->bind(
+            JourneyLogLinkTypeRepositoryInterface::class,
+            fn (): JourneyLogLinkTypeRepositoryInterface => $this->journeyLogLinkTypeRepository,
+        );
+
+        $this->app->bind(
+            JourneyLogRepositoryInterface::class,
+            fn (): JourneyLogRepositoryInterface => $this->journeyLogRepository,
+        );
     }
 
     #[Test]
@@ -53,11 +63,6 @@ class CreateJourneyLogTest extends TestCase
             ->andReturn([])
             ->once();
 
-        $this->app->bind(
-            JourneyLogLinkTypeRepositoryInterface::class,
-            fn (): JourneyLogLinkTypeRepositoryInterface => $this->journeyLogLinkTypeRepository,
-        );
-
         $response = $this->actingAs($this->user)
             ->get(route(RouteMap::ShowCreateJourneyLogForm))
             ->assertStatus(200);
@@ -73,8 +78,8 @@ class CreateJourneyLogTest extends TestCase
         $uuid = $this->generateUuid();
 
         $this->journeyLogRepository->shouldReceive('insert')
-            ->with(Mockery::on(function (JourneyLog $arg) use ($uuid): bool {
-                return $arg->journeyLogId->value === $uuid
+            ->with(Mockery::on(
+                fn (JourneyLog $arg): bool => $arg->journeyLogId->value === $uuid
                     && $arg->story->value === '軌跡'
                     && $arg->period->fromOn->value->format('Y-m-d') === '2019-12-09'
                     && $arg->period->toOn->value->format('Y-m-d') === '2019-12-09'
@@ -84,14 +89,9 @@ class CreateJourneyLogTest extends TestCase
                     && $arg->journeyLogLinks[0]->journeyLogLinkName->value === '管理画面'
                     && $arg->journeyLogLinks[0]->url->value === 'https://local.admin.journey.isekaijoucho.fan'
                     && $arg->journeyLogLinks[0]->orderNo->value === 1
-                    && $arg->journeyLogLinks[0]->journeyLogLinkTypeId->value === $uuid;
-            }))
+                    && $arg->journeyLogLinks[0]->journeyLogLinkTypeId->value === $uuid
+            ))
             ->once();
-
-        $this->app->bind(
-            JourneyLogRepositoryInterface::class,
-            fn (): JourneyLogRepositoryInterface => $this->journeyLogRepository,
-        );
 
         $this->actingAs($this->user)
             ->post(route(RouteMap::CreateJourneyLog), [

--- a/src/tests/Feature/Web/JourneyLog/DeleteJourneyLogTest.php
+++ b/src/tests/Feature/Web/JourneyLog/DeleteJourneyLogTest.php
@@ -10,7 +10,7 @@ use Illuminate\Support\Str;
 use JourneyLog\Domain\Models\JourneyLogId;
 use JourneyLog\Domain\Repositories\JourneyLogRepositoryInterface;
 use Mockery;
-use Mockery\LegacyMockInterface;
+use Mockery\MockInterface;
 use PHPUnit\Framework\Attributes\Test;
 use Support\Route\RouteMap;
 use Tests\TestCase;
@@ -21,7 +21,7 @@ class DeleteJourneyLogTest extends TestCase
 
     private User $user;
 
-    private JourneyLogRepositoryInterface&LegacyMockInterface $journeyLogRepository;
+    private JourneyLogRepositoryInterface&MockInterface $repository;
 
     public function setUp(): void
     {
@@ -31,7 +31,9 @@ class DeleteJourneyLogTest extends TestCase
             'user_id' => Str::uuid()->toString(),
         ]);
 
-        $this->journeyLogRepository = Mockery::mock(JourneyLogRepositoryInterface::class);
+        $this->repository = Mockery::mock(JourneyLogRepositoryInterface::class);
+
+        $this->app->bind(JourneyLogRepositoryInterface::class, fn (): JourneyLogRepositoryInterface => $this->repository);
     }
 
     #[Test]
@@ -47,16 +49,9 @@ class DeleteJourneyLogTest extends TestCase
     {
         $uuid = $this->generateUuid();
 
-        $this->journeyLogRepository->shouldReceive('delete')
-            ->with(Mockery::on(function (JourneyLogId $arg) use ($uuid): bool {
-                return $arg->value === $uuid;
-            }))
+        $this->repository->shouldReceive('delete')
+            ->with(Mockery::on(fn (JourneyLogId $arg): bool => $arg->value === $uuid))
             ->once();
-
-        $this->app->bind(
-            JourneyLogRepositoryInterface::class,
-            fn (): JourneyLogRepositoryInterface => $this->journeyLogRepository,
-        );
 
         $this->actingAs($this->user)
             ->delete(route(RouteMap::DeleteJourneyLog), [

--- a/src/tests/Feature/Web/JourneyLog/EditJourneyLogTest.php
+++ b/src/tests/Feature/Web/JourneyLog/EditJourneyLogTest.php
@@ -18,7 +18,7 @@ use JourneyLog\Domain\Models\ToOn;
 use JourneyLog\Domain\Repositories\JourneyLogRepositoryInterface;
 use JourneyLogLinkType\Domain\Repositories\JourneyLogLinkTypeRepositoryInterface;
 use Mockery;
-use Mockery\LegacyMockInterface;
+use Mockery\MockInterface;
 use PHPUnit\Framework\Attributes\Test;
 use Support\Domain\ValueObjects\OrderNo;
 use Support\Route\RouteMap;
@@ -30,9 +30,9 @@ class EditJourneyLogTest extends TestCase
 
     private User $user;
 
-    private JourneyLogRepositoryInterface&LegacyMockInterface $journeyLogRepository;
+    private JourneyLogRepositoryInterface&MockInterface $journeyLogRepository;
 
-    private JourneyLogLinkTypeRepositoryInterface&LegacyMockInterface $journeyLogLinkTypeRepository;
+    private JourneyLogLinkTypeRepositoryInterface&MockInterface $journeyLogLinkTypeRepository;
 
     public function setUp(): void
     {
@@ -44,6 +44,16 @@ class EditJourneyLogTest extends TestCase
 
         $this->journeyLogRepository = Mockery::mock(JourneyLogRepositoryInterface::class);
         $this->journeyLogLinkTypeRepository = Mockery::mock(JourneyLogLinkTypeRepositoryInterface::class);
+
+        $this->app->bind(
+            JourneyLogLinkTypeRepositoryInterface::class,
+            fn (): JourneyLogLinkTypeRepositoryInterface => $this->journeyLogLinkTypeRepository,
+        );
+
+        $this->app->bind(
+            JourneyLogRepositoryInterface::class,
+            fn (): JourneyLogRepositoryInterface => $this->journeyLogRepository,
+        );
     }
 
     #[Test]
@@ -72,30 +82,16 @@ class EditJourneyLogTest extends TestCase
             ->andReturn([])
             ->once();
 
-        $this->app->bind(
-            JourneyLogLinkTypeRepositoryInterface::class,
-            fn (): JourneyLogLinkTypeRepositoryInterface => $this->journeyLogLinkTypeRepository,
-        );
-
         $this->journeyLogRepository->shouldReceive('find')
-            ->with(Mockery::on(function (JourneyLogId $arg) use ($uuid): bool {
-                return $arg->value === $uuid;
-            }))
-            ->andReturn(
-                new JourneyLog(
-                    new JourneyLogId($uuid),
-                    new Story('軌跡'),
-                    new Period(new FromOn(new DateTimeImmutable()), new ToOn(new DateTimeImmutable())),
-                    new OrderNo(1),
-                    []
-                )
-            )
+            ->with(Mockery::on(fn (JourneyLogId $arg): bool => $arg->value === $uuid))
+            ->andReturn(new JourneyLog(
+                new JourneyLogId($uuid),
+                new Story('軌跡'),
+                new Period(new FromOn(new DateTimeImmutable()), new ToOn(new DateTimeImmutable())),
+                new OrderNo(1),
+                []
+            ))
             ->once();
-
-        $this->app->bind(
-            JourneyLogRepositoryInterface::class,
-            fn (): JourneyLogRepositoryInterface => $this->journeyLogRepository,
-        );
 
         $response = $this->actingAs($this->user)
             ->get(route(RouteMap::ShowEditJourneyLogForm, ['journeyLogId' => $uuid]))
@@ -114,22 +110,10 @@ class EditJourneyLogTest extends TestCase
 
         $this->journeyLogLinkTypeRepository->shouldNotReceive('all');
 
-        $this->app->bind(
-            JourneyLogLinkTypeRepositoryInterface::class,
-            fn (): JourneyLogLinkTypeRepositoryInterface => $this->journeyLogLinkTypeRepository,
-        );
-
         $this->journeyLogRepository->shouldReceive('find')
-            ->with(Mockery::on(function (JourneyLogId $arg) use ($uuid): bool {
-                return $arg->value === $uuid;
-            }))
+            ->with(Mockery::on(fn (JourneyLogId $arg): bool => $arg->value === $uuid))
             ->andReturnNull()
             ->once();
-
-        $this->app->bind(
-            JourneyLogRepositoryInterface::class,
-            fn (): JourneyLogRepositoryInterface => $this->journeyLogRepository,
-        );
 
         $this->actingAs($this->user)
             ->get(route(RouteMap::ShowEditJourneyLogForm, ['journeyLogId' => $uuid]))
@@ -144,26 +128,21 @@ class EditJourneyLogTest extends TestCase
         $uuid = $this->generateUuid();
 
         $this->journeyLogRepository->shouldReceive('update')
-            ->with(Mockery::on(function (JourneyLog $arg) use ($uuid): bool {
-                return $arg->journeyLogId->value === $uuid
-                     && $arg->story->value === '軌跡'
-                     && $arg->period->fromOn->value->format('Y-m-d') === '2019-12-09'
-                     && $arg->period->toOn->value->format('Y-m-d') === '2019-12-09'
-                     && $arg->orderNo->value === 1
-                     && count($arg->journeyLogLinks) === 1
-                     && $arg->journeyLogLinks[0]->journeyLogLinkId->value === $uuid
-                     && $arg->journeyLogLinks[0]->journeyLogLinkName->value === '管理画面'
-                     && $arg->journeyLogLinks[0]->url->value === 'https://local.admin.journey.isekaijoucho.fan'
-                     && $arg->journeyLogLinks[0]->orderNo->value === 1
-                     && $arg->journeyLogLinks[0]->journeyLogLinkTypeId->value === $uuid;
-            }))
+            ->with(Mockery::on(
+                fn (JourneyLog $arg): bool => $arg->journeyLogId->value === $uuid
+                    && $arg->story->value === '軌跡'
+                    && $arg->period->fromOn->value->format('Y-m-d') === '2019-12-09'
+                    && $arg->period->toOn->value->format('Y-m-d') === '2019-12-09'
+                    && $arg->orderNo->value === 1
+                    && count($arg->journeyLogLinks) === 1
+                    && $arg->journeyLogLinks[0]->journeyLogLinkId->value === $uuid
+                    && $arg->journeyLogLinks[0]->journeyLogLinkName->value === '管理画面'
+                    && $arg->journeyLogLinks[0]->url->value === 'https://local.admin.journey.isekaijoucho.fan'
+                    && $arg->journeyLogLinks[0]->orderNo->value === 1
+                    && $arg->journeyLogLinks[0]->journeyLogLinkTypeId->value === $uuid
+            ))
             ->andReturn(new JourneyLogId($uuid))
             ->once();
-
-        $this->app->bind(
-            JourneyLogRepositoryInterface::class,
-            fn (): JourneyLogRepositoryInterface => $this->journeyLogRepository,
-        );
 
         $this->actingAs($this->user)
             ->post(route(RouteMap::EditJourneyLog), [

--- a/src/tests/Feature/Web/JourneyLog/ListJourneyLogTest.php
+++ b/src/tests/Feature/Web/JourneyLog/ListJourneyLogTest.php
@@ -21,7 +21,7 @@ use JourneyLog\Domain\Models\Url;
 use JourneyLog\Domain\Repositories\JourneyLogRepositoryInterface;
 use JourneyLogLinkType\Domain\Models\JourneyLogLinkTypeId;
 use Mockery;
-use Mockery\LegacyMockInterface;
+use Mockery\MockInterface;
 use PHPUnit\Framework\Attributes\Test;
 use Support\Domain\ValueObjects\OrderNo;
 use Support\Route\RouteMap;
@@ -33,7 +33,7 @@ class ListJourneyLogTest extends TestCase
 
     private User $user;
 
-    private JourneyLogRepositoryInterface&LegacyMockInterface $journeyLogRepository;
+    private JourneyLogRepositoryInterface&MockInterface $repository;
 
     public function setUp(): void
     {
@@ -43,7 +43,9 @@ class ListJourneyLogTest extends TestCase
             'user_id' => Str::uuid()->toString(),
         ]);
 
-        $this->journeyLogRepository = Mockery::mock(JourneyLogRepositoryInterface::class);
+        $this->repository = Mockery::mock(JourneyLogRepositoryInterface::class);
+
+        $this->app->bind(JourneyLogRepositoryInterface::class, fn (): JourneyLogRepositoryInterface => $this->repository);
     }
 
     #[Test]
@@ -59,7 +61,7 @@ class ListJourneyLogTest extends TestCase
     {
         $uuid = $this->generateUuid();
 
-        $this->journeyLogRepository->shouldReceive('all')
+        $this->repository->shouldReceive('all')
             ->andReturn([
                 new JourneyLog(
                     new JourneyLogId($uuid),
@@ -86,11 +88,6 @@ class ListJourneyLogTest extends TestCase
             ])
             ->once();
 
-        $this->app->bind(
-            JourneyLogRepositoryInterface::class,
-            fn (): JourneyLogRepositoryInterface => $this->journeyLogRepository,
-        );
-
         $response = $this->actingAs($this->user)
             ->get(route(RouteMap::ListJourneyLogs))
             ->assertStatus(200)
@@ -115,14 +112,9 @@ class ListJourneyLogTest extends TestCase
     #[Test]
     public function showEmptyList(): void
     {
-        $this->journeyLogRepository->shouldReceive('all')
+        $this->repository->shouldReceive('all')
             ->andReturn([])
             ->once();
-
-        $this->app->bind(
-            JourneyLogRepositoryInterface::class,
-            fn (): JourneyLogRepositoryInterface => $this->journeyLogRepository,
-        );
 
         $response = $this->actingAs($this->user)
             ->get(route(RouteMap::ListJourneyLogs))

--- a/src/tests/Feature/Web/JourneyLogLinkType/CreateJourneyLogLinkTypeTest.php
+++ b/src/tests/Feature/Web/JourneyLogLinkType/CreateJourneyLogLinkTypeTest.php
@@ -10,7 +10,7 @@ use Illuminate\Support\Str;
 use JourneyLogLinkType\Domain\Models\JourneyLogLinkType;
 use JourneyLogLinkType\Domain\Repositories\JourneyLogLinkTypeRepositoryInterface;
 use Mockery;
-use Mockery\LegacyMockInterface;
+use Mockery\MockInterface;
 use PHPUnit\Framework\Attributes\Test;
 use Support\Route\RouteMap;
 use Tests\TestCase;
@@ -21,7 +21,7 @@ class CreateJourneyLogLinkTypeTest extends TestCase
 
     private User $user;
 
-    private JourneyLogLinkTypeRepositoryInterface&LegacyMockInterface $journeyLogLinkTypeRepository;
+    private JourneyLogLinkTypeRepositoryInterface&MockInterface $repository;
 
     public function setUp(): void
     {
@@ -31,7 +31,12 @@ class CreateJourneyLogLinkTypeTest extends TestCase
             'user_id' => Str::uuid()->toString(),
         ]);
 
-        $this->journeyLogLinkTypeRepository = Mockery::mock(JourneyLogLinkTypeRepositoryInterface::class);
+        $this->repository = Mockery::mock(JourneyLogLinkTypeRepositoryInterface::class);
+
+        $this->app->bind(
+            JourneyLogLinkTypeRepositoryInterface::class,
+            fn (): JourneyLogLinkTypeRepositoryInterface => $this->repository
+        );
     }
 
     #[Test]
@@ -55,18 +60,13 @@ class CreateJourneyLogLinkTypeTest extends TestCase
     {
         $uuid = $this->generateUuid();
 
-        $this->journeyLogLinkTypeRepository->shouldReceive('insert')
-            ->with(Mockery::on(function (JourneyLogLinkType $arg) use ($uuid): bool {
-                return $arg->journeyLogLinkTypeId->value === $uuid
+        $this->repository->shouldReceive('insert')
+            ->with(Mockery::on(
+                fn (JourneyLogLinkType $arg): bool => $arg->journeyLogLinkTypeId->value === $uuid
                     && $arg->journeyLogLinkTypeName->value === '軌跡リンク種別A'
-                    && $arg->orderNo->value === 1;
-            }))
+                    && $arg->orderNo->value === 1
+            ))
             ->once();
-
-        $this->app->bind(
-            JourneyLogLinkTypeRepositoryInterface::class,
-            fn (): JourneyLogLinkTypeRepositoryInterface => $this->journeyLogLinkTypeRepository,
-        );
 
         $this->actingAs($this->user)
             ->post(route(RouteMap::CreateJourneyLogLinkType), [

--- a/src/tests/Feature/Web/JourneyLogLinkType/DeleteJourneyLogLinkTypeTest.php
+++ b/src/tests/Feature/Web/JourneyLogLinkType/DeleteJourneyLogLinkTypeTest.php
@@ -10,7 +10,7 @@ use Illuminate\Support\Str;
 use JourneyLogLinkType\Domain\Models\JourneyLogLinkTypeId;
 use JourneyLogLinkType\Domain\Repositories\JourneyLogLinkTypeRepositoryInterface;
 use Mockery;
-use Mockery\LegacyMockInterface;
+use Mockery\MockInterface;
 use PHPUnit\Framework\Attributes\Test;
 use Support\Route\RouteMap;
 use Tests\TestCase;
@@ -21,7 +21,7 @@ class DeleteJourneyLogLinkTypeTest extends TestCase
 
     private User $user;
 
-    private JourneyLogLinkTypeRepositoryInterface&LegacyMockInterface $journeyLogLinkTypeRepository;
+    private JourneyLogLinkTypeRepositoryInterface&MockInterface $repository;
 
     public function setUp(): void
     {
@@ -31,7 +31,12 @@ class DeleteJourneyLogLinkTypeTest extends TestCase
             'user_id' => Str::uuid()->toString(),
         ]);
 
-        $this->journeyLogLinkTypeRepository = Mockery::mock(JourneyLogLinkTypeRepositoryInterface::class);
+        $this->repository = Mockery::mock(JourneyLogLinkTypeRepositoryInterface::class);
+
+        $this->app->bind(
+            JourneyLogLinkTypeRepositoryInterface::class,
+            fn (): JourneyLogLinkTypeRepositoryInterface => $this->repository
+        );
     }
 
     #[Test]
@@ -47,16 +52,9 @@ class DeleteJourneyLogLinkTypeTest extends TestCase
     {
         $uuid = $this->generateUuid();
 
-        $this->journeyLogLinkTypeRepository->shouldReceive('delete')
-            ->with(Mockery::on(function (JourneyLogLinkTypeId $arg) use ($uuid): bool {
-                return $arg->value === $uuid;
-            }))
+        $this->repository->shouldReceive('delete')
+            ->with(Mockery::on(fn (JourneyLogLinkTypeId $arg): bool => $arg->value === $uuid))
             ->once();
-
-        $this->app->bind(
-            JourneyLogLinkTypeRepositoryInterface::class,
-            fn (): JourneyLogLinkTypeRepositoryInterface => $this->journeyLogLinkTypeRepository,
-        );
 
         $this->actingAs($this->user)
             ->delete(route(RouteMap::DeleteJourneyLogLinkType), [

--- a/src/tests/Feature/Web/JourneyLogLinkType/EditJourneyLogLinkTypeTest.php
+++ b/src/tests/Feature/Web/JourneyLogLinkType/EditJourneyLogLinkTypeTest.php
@@ -13,7 +13,7 @@ use JourneyLogLinkType\Domain\Models\JourneyLogLinkTypeId;
 use JourneyLogLinkType\Domain\Models\JourneyLogLinkTypeName;
 use JourneyLogLinkType\Domain\Repositories\JourneyLogLinkTypeRepositoryInterface;
 use Mockery;
-use Mockery\LegacyMockInterface;
+use Mockery\MockInterface;
 use PHPUnit\Framework\Attributes\Test;
 use Support\Domain\ValueObjects\OrderNo;
 use Support\Route\RouteMap;
@@ -25,7 +25,7 @@ class EditJourneyLogLinkTypeTest extends TestCase
 
     private User $user;
 
-    private JourneyLogLinkTypeRepositoryInterface&LegacyMockInterface $journeyLogLinkTypeRepository;
+    private JourneyLogLinkTypeRepositoryInterface&MockInterface $repository;
 
     public function setUp(): void
     {
@@ -35,7 +35,12 @@ class EditJourneyLogLinkTypeTest extends TestCase
             'user_id' => Str::uuid()->toString(),
         ]);
 
-        $this->journeyLogLinkTypeRepository = Mockery::mock(JourneyLogLinkTypeRepositoryInterface::class);
+        $this->repository = Mockery::mock(JourneyLogLinkTypeRepositoryInterface::class);
+
+        $this->app->bind(
+            JourneyLogLinkTypeRepositoryInterface::class,
+            fn (): JourneyLogLinkTypeRepositoryInterface => $this->repository
+        );
     }
 
     #[Test]
@@ -62,21 +67,14 @@ class EditJourneyLogLinkTypeTest extends TestCase
     {
         $uuid = $this->generateUuid();
 
-        $this->journeyLogLinkTypeRepository->shouldReceive('find')
-            ->with(Mockery::on(function (JourneyLogLinkTypeId $arg) use ($uuid): bool {
-                return $arg->value === $uuid;
-            }))
+        $this->repository->shouldReceive('find')
+            ->with(Mockery::on(fn (JourneyLogLinkTypeId $arg): bool => $arg->value === $uuid))
             ->andReturn(new JourneyLogLinkType(
                 new JourneyLogLinkTypeId($uuid),
                 new JourneyLogLinkTypeName('名前'),
                 new OrderNo(1),
             ))
             ->once();
-
-        $this->app->bind(
-            JourneyLogLinkTypeRepositoryInterface::class,
-            fn (): JourneyLogLinkTypeRepositoryInterface => $this->journeyLogLinkTypeRepository,
-        );
 
         $response = $this->actingAs($this->user)
             ->get(route(RouteMap::ShowEditJourneyLogLinkTypeForm, ['journeyLogLinkTypeId' => $uuid]))
@@ -92,15 +90,10 @@ class EditJourneyLogLinkTypeTest extends TestCase
     {
         $uuid = $this->generateUuid();
 
-        $this->journeyLogLinkTypeRepository->shouldReceive('find')
+        $this->repository->shouldReceive('find')
             ->with(Mockery::on(fn (JourneyLogLinkTypeId $arg): bool => $arg->value === $uuid))
             ->andReturnNull()
             ->once();
-
-        $this->app->bind(
-            JourneyLogLinkTypeRepositoryInterface::class,
-            fn (): JourneyLogLinkTypeRepositoryInterface => $this->journeyLogLinkTypeRepository,
-        );
 
         $this->actingAs($this->user)
             ->get(route(RouteMap::ShowEditJourneyLogLinkTypeForm, ['journeyLogLinkTypeId' => $uuid]))
@@ -114,18 +107,13 @@ class EditJourneyLogLinkTypeTest extends TestCase
     {
         $uuid = $this->generateUuid();
 
-        $this->journeyLogLinkTypeRepository->shouldReceive('update')
-            ->with(Mockery::on(function (JourneyLogLinkType $arg) use ($uuid): bool {
-                return $arg->journeyLogLinkTypeId->value === $uuid
+        $this->repository->shouldReceive('update')
+            ->with(Mockery::on(
+                fn (JourneyLogLinkType $arg): bool => $arg->journeyLogLinkTypeId->value === $uuid
                     && $arg->journeyLogLinkTypeName->value === '動画'
-                    && $arg->orderNo->value === 1;
-            }))
+                    && $arg->orderNo->value === 1
+            ))
             ->once();
-
-        $this->app->bind(
-            JourneyLogLinkTypeRepositoryInterface::class,
-            fn (): JourneyLogLinkTypeRepositoryInterface => $this->journeyLogLinkTypeRepository,
-        );
 
         $this->actingAs($this->user)
             ->post(route(RouteMap::EditJourneyLogLinkType), [

--- a/src/tests/Feature/Web/JourneyLogLinkType/ListJourneyLogLinkTypeTest.php
+++ b/src/tests/Feature/Web/JourneyLogLinkType/ListJourneyLogLinkTypeTest.php
@@ -12,7 +12,7 @@ use JourneyLogLinkType\Domain\Models\JourneyLogLinkTypeId;
 use JourneyLogLinkType\Domain\Models\JourneyLogLinkTypeName;
 use JourneyLogLinkType\Domain\Repositories\JourneyLogLinkTypeRepositoryInterface;
 use Mockery;
-use Mockery\LegacyMockInterface;
+use Mockery\MockInterface;
 use PHPUnit\Framework\Attributes\Test;
 use Support\Domain\ValueObjects\OrderNo;
 use Support\Route\RouteMap;
@@ -24,7 +24,7 @@ class ListJourneyLogLinkTypeTest extends TestCase
 
     private User $user;
 
-    private JourneyLogLinkTypeRepositoryInterface&LegacyMockInterface $journeyLogLinkTypeRepository;
+    private JourneyLogLinkTypeRepositoryInterface&MockInterface $repository;
 
     public function setUp(): void
     {
@@ -34,7 +34,12 @@ class ListJourneyLogLinkTypeTest extends TestCase
             'user_id' => Str::uuid()->toString(),
         ]);
 
-        $this->journeyLogLinkTypeRepository = Mockery::mock(JourneyLogLinkTypeRepositoryInterface::class);
+        $this->repository = Mockery::mock(JourneyLogLinkTypeRepositoryInterface::class);
+
+        $this->app->bind(
+            JourneyLogLinkTypeRepositoryInterface::class,
+            fn (): JourneyLogLinkTypeRepositoryInterface => $this->repository
+        );
     }
 
     #[Test]
@@ -50,7 +55,7 @@ class ListJourneyLogLinkTypeTest extends TestCase
     {
         $uuid = $this->generateUuid();
 
-        $this->journeyLogLinkTypeRepository->shouldReceive('all')
+        $this->repository->shouldReceive('all')
             ->andReturn([
                 new JourneyLogLinkType(
                     new JourneyLogLinkTypeId($uuid),
@@ -64,11 +69,6 @@ class ListJourneyLogLinkTypeTest extends TestCase
                 ),
             ])
             ->once();
-
-        $this->app->bind(
-            JourneyLogLinkTypeRepositoryInterface::class,
-            fn (): JourneyLogLinkTypeRepositoryInterface => $this->journeyLogLinkTypeRepository,
-        );
 
         $response = $this->actingAs($this->user)
             ->get(route(RouteMap::ListJourneyLogLinkType))
@@ -89,14 +89,9 @@ class ListJourneyLogLinkTypeTest extends TestCase
     #[Test]
     public function showEmptyList(): void
     {
-        $this->journeyLogLinkTypeRepository->shouldReceive('all')
+        $this->repository->shouldReceive('all')
             ->andReturn([])
             ->once();
-
-        $this->app->bind(
-            JourneyLogLinkTypeRepositoryInterface::class,
-            fn (): JourneyLogLinkTypeRepositoryInterface => $this->journeyLogLinkTypeRepository,
-        );
 
         $response = $this->actingAs($this->user)
             ->get(route(RouteMap::ListJourneyLogLinkType))

--- a/src/tests/Feature/Web/Song/ListSongTest.php
+++ b/src/tests/Feature/Web/Song/ListSongTest.php
@@ -7,7 +7,7 @@ namespace Tests\Feature\Web\Song;
 use App\Models\User;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Mockery;
-use Mockery\LegacyMockInterface;
+use Mockery\MockInterface;
 use PHPUnit\Framework\Attributes\Test;
 use Song\Domain\Models\Description;
 use Song\Domain\Models\Song;
@@ -25,7 +25,7 @@ class ListSongTest extends TestCase
 
     private User $user;
 
-    private LegacyMockInterface&SongRepositoryInterface $songRepository;
+    private MockInterface&SongRepositoryInterface $repository;
 
     protected function setUp(): void
     {
@@ -35,7 +35,9 @@ class ListSongTest extends TestCase
             'user_id' => $this->generateUuid(),
         ]);
 
-        $this->songRepository = Mockery::mock(SongRepositoryInterface::class);
+        $this->repository = Mockery::mock(SongRepositoryInterface::class);
+
+        $this->app->bind(SongRepositoryInterface::class, fn (): SongRepositoryInterface => $this->repository);
     }
 
     #[Test]
@@ -51,7 +53,7 @@ class ListSongTest extends TestCase
     {
         $uuid = $this->generateUuid();
 
-        $this->songRepository->shouldReceive('all')
+        $this->repository->shouldReceive('all')
             ->andReturn([
                 new Song(
                     new SongId($uuid),
@@ -78,8 +80,6 @@ class ListSongTest extends TestCase
             ])
             ->once();
 
-        $this->app->bind(SongRepositoryInterface::class, fn (): SongRepositoryInterface => $this->songRepository);
-
         $response = $this->actingAs($this->user)
             ->get(route(RouteMap::ListSongs))
             ->assertStatus(200)
@@ -100,11 +100,9 @@ class ListSongTest extends TestCase
     #[Test]
     public function showEmptyList(): void
     {
-        $this->songRepository->shouldReceive('all')
+        $this->repository->shouldReceive('all')
             ->andReturn([])
             ->once();
-
-        $this->app->bind(SongRepositoryInterface::class, fn (): SongRepositoryInterface => $this->songRepository);
 
         $response = $this->actingAs($this->user)
             ->get(route(RouteMap::ListSongs))

--- a/src/tests/Unit/Auth/Application/Login/LoginInteractorTest.php
+++ b/src/tests/Unit/Auth/Application/Login/LoginInteractorTest.php
@@ -26,6 +26,7 @@ class LoginInteractorTest extends TestCase
         parent::setUp();
 
         $this->authManager = Mockery::mock(AuthManager::class);
+
         $this->interactor = new LoginInteractor($this->authManager);
     }
 
@@ -39,7 +40,7 @@ class LoginInteractorTest extends TestCase
     public function successLoginAttempt(): void
     {
         $this->authManager->shouldReceive('guard')
-            ->andReturnUsing(function () {
+            ->andReturnUsing(function (): MockInterface&StatefulGuard {
                 $guard = Mockery::mock(StatefulGuard::class);
 
                 $guard->shouldReceive('attempt')
@@ -69,7 +70,7 @@ class LoginInteractorTest extends TestCase
     public function failureLoginAttempt(): void
     {
         $this->authManager->shouldReceive('guard')
-            ->andReturnUsing(function () {
+            ->andReturnUsing(function (): MockInterface&StatefulGuard {
                 $guard = Mockery::mock(StatefulGuard::class);
 
                 $guard->shouldReceive('attempt')

--- a/src/tests/Unit/Creator/Application/Create/CreateInteractorTest.php
+++ b/src/tests/Unit/Creator/Application/Create/CreateInteractorTest.php
@@ -19,7 +19,7 @@ use Tests\TestCase;
 
 class CreateInteractorTest extends TestCase
 {
-    private CreatorRepositoryInterface&MockInterface $creatorRepository;
+    private CreatorRepositoryInterface&MockInterface $repository;
 
     private CreatorFactoryInterface&MockInterface $factory;
 
@@ -29,9 +29,10 @@ class CreateInteractorTest extends TestCase
     {
         parent::setUp();
 
-        $this->creatorRepository = Mockery::mock(CreatorRepositoryInterface::class);
+        $this->repository = Mockery::mock(CreatorRepositoryInterface::class);
         $this->factory = Mockery::mock(CreatorFactoryInterface::class);
-        $this->interactor = new CreateInteractor($this->creatorRepository, $this->factory);
+
+        $this->interactor = new CreateInteractor($this->repository, $this->factory);
     }
 
     #[Test]
@@ -45,13 +46,13 @@ class CreateInteractorTest extends TestCase
     {
         $this->factory->shouldReceive('create')
             ->with('クリエイター')
-            ->andReturnUsing(fn (): Creator => new Creator(
+            ->andReturn(new Creator(
                 new CreatorId('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'),
                 new CreatorName('クリエイター')
             ))
             ->once();
 
-        $this->creatorRepository->shouldReceive('insert')
+        $this->repository->shouldReceive('insert')
             ->with(Mockery::on(
                 fn (Creator $arg): bool => $arg->creatorId->value === 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'
                     && $arg->creatorName->value === 'クリエイター'

--- a/src/tests/Unit/Creator/Application/Delete/DeleteInteractorTest.php
+++ b/src/tests/Unit/Creator/Application/Delete/DeleteInteractorTest.php
@@ -16,7 +16,7 @@ use Tests\TestCase;
 
 class DeleteInteractorTest extends TestCase
 {
-    private CreatorRepositoryInterface&MockInterface $creatorRepository;
+    private CreatorRepositoryInterface&MockInterface $repository;
 
     private DeleteInteractor $interactor;
 
@@ -24,8 +24,9 @@ class DeleteInteractorTest extends TestCase
     {
         parent::setUp();
 
-        $this->creatorRepository = Mockery::mock(CreatorRepositoryInterface::class);
-        $this->interactor = new DeleteInteractor($this->creatorRepository);
+        $this->repository = Mockery::mock(CreatorRepositoryInterface::class);
+
+        $this->interactor = new DeleteInteractor($this->repository);
     }
 
     #[Test]
@@ -37,11 +38,8 @@ class DeleteInteractorTest extends TestCase
     #[Test]
     public function deleteJourneyLog(): void
     {
-        $this->creatorRepository->shouldReceive('delete')
-            ->with(Mockery::on(
-                fn ($arg) => $arg instanceof CreatorId
-                    && $arg->value === 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'
-            ))
+        $this->repository->shouldReceive('delete')
+            ->with(Mockery::on(fn (CreatorId $arg): bool => $arg->value === 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'))
             ->once();
 
         $this->interactor->handle(new DeleteRequest('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'));

--- a/src/tests/Unit/Creator/Application/Edit/EditInteractorTest.php
+++ b/src/tests/Unit/Creator/Application/Edit/EditInteractorTest.php
@@ -19,7 +19,7 @@ use Tests\TestCase;
 
 class EditInteractorTest extends TestCase
 {
-    private CreatorRepositoryInterface&MockInterface $creatorRepository;
+    private CreatorRepositoryInterface&MockInterface $repository;
 
     private CreatorFactoryInterface&MockInterface $factory;
 
@@ -29,9 +29,10 @@ class EditInteractorTest extends TestCase
     {
         parent::setUp();
 
-        $this->creatorRepository = Mockery::mock(CreatorRepositoryInterface::class);
+        $this->repository = Mockery::mock(CreatorRepositoryInterface::class);
         $this->factory = Mockery::mock(CreatorFactoryInterface::class);
-        $this->interactor = new EditInteractor($this->creatorRepository, $this->factory);
+
+        $this->interactor = new EditInteractor($this->repository, $this->factory);
     }
 
     #[Test]
@@ -45,13 +46,13 @@ class EditInteractorTest extends TestCase
     {
         $this->factory->shouldReceive('reconstitute')
             ->with('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA', 'クリエイター')
-            ->andReturnUsing(fn (): Creator => new Creator(
+            ->andReturn(new Creator(
                 new CreatorId('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'),
                 new CreatorName('クリエイター')
             ))
             ->once();
 
-        $this->creatorRepository->shouldReceive('update')
+        $this->repository->shouldReceive('update')
             ->with(Mockery::on(
                 fn (Creator $arg): bool => $arg->creatorId->value === 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'
                     && $arg->creatorName->value === 'クリエイター'

--- a/src/tests/Unit/Creator/Application/Get/GetInteractorTest.php
+++ b/src/tests/Unit/Creator/Application/Get/GetInteractorTest.php
@@ -20,7 +20,7 @@ use Tests\TestCase;
 
 class GetInteractorTest extends TestCase
 {
-    private CreatorRepositoryInterface&MockInterface $creatorRepository;
+    private CreatorRepositoryInterface&MockInterface $repository;
 
     private GetInteractor $interactor;
 
@@ -28,8 +28,9 @@ class GetInteractorTest extends TestCase
     {
         parent::setUp();
 
-        $this->creatorRepository = Mockery::mock(CreatorRepositoryInterface::class);
-        $this->interactor = new GetInteractor($this->creatorRepository);
+        $this->repository = Mockery::mock(CreatorRepositoryInterface::class);
+
+        $this->interactor = new GetInteractor($this->repository);
     }
 
     #[Test]
@@ -41,17 +42,12 @@ class GetInteractorTest extends TestCase
     #[Test]
     public function getCreator(): void
     {
-        $this->creatorRepository->shouldReceive('find')
-            ->with(Mockery::on(
-                fn ($arg) => $arg instanceof CreatorId
-                    && $arg->value === 'BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB'
+        $this->repository->shouldReceive('find')
+            ->with(Mockery::on(fn (CreatorId $arg): bool => $arg->value === 'BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB'))
+            ->andReturn(new Creator(
+                new CreatorId('BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB'),
+                new CreatorName('クリエイター名'),
             ))
-            ->andReturnUsing(
-                fn () => new Creator(
-                    new CreatorId('BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB'),
-                    new CreatorName('クリエイター名'),
-                )
-            )
             ->once();
 
         $result = $this->interactor->handle(new GetRequest('BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB'));
@@ -71,11 +67,8 @@ class GetInteractorTest extends TestCase
     #[Test]
     public function failureGetCreator(): void
     {
-        $this->creatorRepository->shouldReceive('find')
-            ->with(Mockery::on(
-                fn ($arg) => $arg instanceof CreatorId
-                    && $arg->value === 'BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB'
-            ))
+        $this->repository->shouldReceive('find')
+            ->with(Mockery::on(fn (CreatorId $arg): bool => $arg->value === 'BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB'))
             ->andReturnNull()
             ->once();
 

--- a/src/tests/Unit/Creator/Application/List/ListInteractorTest.php
+++ b/src/tests/Unit/Creator/Application/List/ListInteractorTest.php
@@ -18,7 +18,7 @@ use Tests\TestCase;
 
 class ListInteractorTest extends TestCase
 {
-    private CreatorRepositoryInterface&MockInterface $creatorRepository;
+    private CreatorRepositoryInterface&MockInterface $repository;
 
     private ListInteractor $interactor;
 
@@ -26,8 +26,9 @@ class ListInteractorTest extends TestCase
     {
         parent::setUp();
 
-        $this->creatorRepository = Mockery::mock(CreatorRepositoryInterface::class);
-        $this->interactor = new ListInteractor($this->creatorRepository);
+        $this->repository = Mockery::mock(CreatorRepositoryInterface::class);
+
+        $this->interactor = new ListInteractor($this->repository);
     }
 
     #[Test]
@@ -39,8 +40,8 @@ class ListInteractorTest extends TestCase
     #[Test]
     public function emptyCreators(): void
     {
-        $this->creatorRepository->shouldReceive('all')
-            ->andReturnUsing(fn () => [])
+        $this->repository->shouldReceive('all')
+            ->andReturn([])
             ->once();
 
         $response = $this->interactor->handle();
@@ -53,8 +54,8 @@ class ListInteractorTest extends TestCase
     #[Test]
     public function nonEmptyCreators(): void
     {
-        $this->creatorRepository->shouldReceive('all')
-            ->andReturnUsing(fn () => [
+        $this->repository->shouldReceive('all')
+            ->andReturn([
                 new Creator(
                     new CreatorId('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'),
                     new CreatorName('クリエイターA')

--- a/src/tests/Unit/JourneyLog/Application/Create/CreateInteractorTest.php
+++ b/src/tests/Unit/JourneyLog/Application/Create/CreateInteractorTest.php
@@ -31,7 +31,7 @@ use Tests\TestCase;
 
 class CreateInteractorTest extends TestCase
 {
-    private JourneyLogRepositoryInterface&MockInterface $journeyLogRepository;
+    private JourneyLogRepositoryInterface&MockInterface $repository;
 
     private JourneyLogFactoryInterface&MockInterface $factory;
 
@@ -41,9 +41,10 @@ class CreateInteractorTest extends TestCase
     {
         parent::setUp();
 
-        $this->journeyLogRepository = Mockery::mock(JourneyLogRepositoryInterface::class);
+        $this->repository = Mockery::mock(JourneyLogRepositoryInterface::class);
         $this->factory = Mockery::mock(JourneyLogFactoryInterface::class);
-        $this->interactor = new CreateInteractor($this->journeyLogRepository, $this->factory);
+
+        $this->interactor = new CreateInteractor($this->repository, $this->factory);
     }
 
     #[Test]
@@ -63,7 +64,7 @@ class CreateInteractorTest extends TestCase
                 1,
                 [],
             )
-            ->andReturnUsing(fn (): JourneyLog => new JourneyLog(
+            ->andReturn(new JourneyLog(
                 new JourneyLogId('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'),
                 new Story('story'),
                 new Period(new FromOn(new DateTimeImmutable('2019-12-08')), new ToOn(new DateTimeImmutable('2019-12-09'))),
@@ -72,7 +73,7 @@ class CreateInteractorTest extends TestCase
             ))
             ->once();
 
-        $this->journeyLogRepository->shouldReceive('insert')
+        $this->repository->shouldReceive('insert')
             ->with(Mockery::on(
                 fn (JourneyLog $arg): bool => $arg->journeyLogId->value === 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'
                     && $arg->story->value === 'story'
@@ -115,7 +116,7 @@ class CreateInteractorTest extends TestCase
                         && $args[1]->journeyLogLinkTypeId === 'CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC'
                 ),
             )
-            ->andReturnUsing(fn (): JourneyLog => new JourneyLog(
+            ->andReturn(new JourneyLog(
                 new JourneyLogId('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'),
                 new Story('story'),
                 new Period(new FromOn(new DateTimeImmutable('2019-12-08')), new ToOn(new DateTimeImmutable('2019-12-09'))),
@@ -139,10 +140,9 @@ class CreateInteractorTest extends TestCase
             ))
             ->once();
 
-        $this->journeyLogRepository->shouldReceive('insert')
+        $this->repository->shouldReceive('insert')
             ->with(Mockery::on(
-                fn ($arg) => $arg instanceof JourneyLog
-                    && $arg->journeyLogId->value === 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'
+                fn (JourneyLog $arg): bool => $arg->journeyLogId->value === 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'
                     && $arg->story->value === 'story'
                     && $arg->period->fromOn->value->format('Y-m-d') === '2019-12-08'
                     && $arg->period->toOn->value->format('Y-m-d') === '2019-12-09'

--- a/src/tests/Unit/JourneyLog/Application/Delete/DeleteInteractorTest.php
+++ b/src/tests/Unit/JourneyLog/Application/Delete/DeleteInteractorTest.php
@@ -16,7 +16,7 @@ use Tests\TestCase;
 
 class DeleteInteractorTest extends TestCase
 {
-    private JourneyLogRepositoryInterface&MockInterface $journeyLogRepository;
+    private JourneyLogRepositoryInterface&MockInterface $repository;
 
     private DeleteInteractor $interactor;
 
@@ -24,8 +24,9 @@ class DeleteInteractorTest extends TestCase
     {
         parent::setUp();
 
-        $this->journeyLogRepository = Mockery::mock(JourneyLogRepositoryInterface::class);
-        $this->interactor = new DeleteInteractor($this->journeyLogRepository);
+        $this->repository = Mockery::mock(JourneyLogRepositoryInterface::class);
+
+        $this->interactor = new DeleteInteractor($this->repository);
     }
 
     #[Test]
@@ -37,11 +38,8 @@ class DeleteInteractorTest extends TestCase
     #[Test]
     public function deleteJourneyLog(): void
     {
-        $this->journeyLogRepository->shouldReceive('delete')
-            ->with(Mockery::on(
-                fn ($arg) => $arg instanceof JourneyLogId
-                    && $arg->value === 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'
-            ))
+        $this->repository->shouldReceive('delete')
+            ->with(Mockery::on(fn (JourneyLogId $arg): bool => $arg->value === 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'))
             ->once();
 
         $this->interactor->handle(new DeleteRequest('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'));

--- a/src/tests/Unit/JourneyLog/Application/Edit/EditInteractorTest.php
+++ b/src/tests/Unit/JourneyLog/Application/Edit/EditInteractorTest.php
@@ -31,7 +31,7 @@ use Tests\TestCase;
 
 class EditInteractorTest extends TestCase
 {
-    private JourneyLogRepositoryInterface&MockInterface $journeyLogRepository;
+    private JourneyLogRepositoryInterface&MockInterface $repository;
 
     private JourneyLogFactoryInterface&MockInterface $factory;
 
@@ -41,9 +41,10 @@ class EditInteractorTest extends TestCase
     {
         parent::setUp();
 
-        $this->journeyLogRepository = Mockery::mock(JourneyLogRepositoryInterface::class);
+        $this->repository = Mockery::mock(JourneyLogRepositoryInterface::class);
         $this->factory = Mockery::mock(JourneyLogFactoryInterface::class);
-        $this->interactor = new EditInteractor($this->journeyLogRepository, $this->factory);
+
+        $this->interactor = new EditInteractor($this->repository, $this->factory);
     }
 
     #[Test]
@@ -64,7 +65,7 @@ class EditInteractorTest extends TestCase
                 1,
                 [],
             )
-            ->andReturnUsing(fn (): JourneyLog => new JourneyLog(
+            ->andReturn(new JourneyLog(
                 new JourneyLogId('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'),
                 new Story('story'),
                 new Period(new FromOn(new DateTimeImmutable('2019-12-08')), new ToOn(new DateTimeImmutable('2019-12-09'))),
@@ -73,7 +74,7 @@ class EditInteractorTest extends TestCase
             ))
             ->once();
 
-        $this->journeyLogRepository->shouldReceive('update')
+        $this->repository->shouldReceive('update')
             ->with(Mockery::on(
                 fn (JourneyLog $arg): bool => $arg->journeyLogId->value === 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'
                     && $arg->story->value === 'story'
@@ -118,7 +119,7 @@ class EditInteractorTest extends TestCase
                         && $args[1]->journeyLogLinkTypeId === 'CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC'
                 ),
             )
-            ->andReturnUsing(fn (): JourneyLog => new JourneyLog(
+            ->andReturn(new JourneyLog(
                 new JourneyLogId('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'),
                 new Story('story'),
                 new Period(new FromOn(new DateTimeImmutable('2019-12-08')), new ToOn(new DateTimeImmutable('2019-12-09'))),
@@ -142,7 +143,7 @@ class EditInteractorTest extends TestCase
             ))
             ->once();
 
-        $this->journeyLogRepository->shouldReceive('update')
+        $this->repository->shouldReceive('update')
             ->with(Mockery::on(
                 fn (JourneyLog $arg): bool => $arg->journeyLogId->value === 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'
                     && $arg->story->value === 'story'

--- a/src/tests/Unit/JourneyLog/Application/Get/GetInteractorTest.php
+++ b/src/tests/Unit/JourneyLog/Application/Get/GetInteractorTest.php
@@ -30,7 +30,7 @@ use Tests\TestCase;
 
 class GetInteractorTest extends TestCase
 {
-    private JourneyLogRepositoryInterface&MockInterface $journeyLogRepository;
+    private JourneyLogRepositoryInterface&MockInterface $repository;
 
     private GetInteractor $interactor;
 
@@ -38,8 +38,9 @@ class GetInteractorTest extends TestCase
     {
         parent::setUp();
 
-        $this->journeyLogRepository = Mockery::mock(JourneyLogRepositoryInterface::class);
-        $this->interactor = new GetInteractor($this->journeyLogRepository);
+        $this->repository = Mockery::mock(JourneyLogRepositoryInterface::class);
+
+        $this->interactor = new GetInteractor($this->repository);
     }
 
     #[Test]
@@ -51,20 +52,15 @@ class GetInteractorTest extends TestCase
     #[Test]
     public function getJourneyLogWithoutLinks(): void
     {
-        $this->journeyLogRepository->shouldReceive('find')
-            ->with(Mockery::on(
-                fn ($arg) => $arg instanceof JourneyLogId
-                    && $arg->value === 'BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB'
+        $this->repository->shouldReceive('find')
+            ->with(Mockery::on(fn (JourneyLogId $arg): bool => $arg->value === 'BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB'))
+            ->andReturn(new JourneyLog(
+                new JourneyLogId('BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB'),
+                new Story('ストーリー'),
+                new Period(new FromOn(new DateTime('2019-12-08')), new ToOn(new DateTime('2019-12-08'))),
+                new OrderNo(1),
+                []
             ))
-            ->andReturnUsing(
-                fn () => new JourneyLog(
-                    new JourneyLogId('BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB'),
-                    new Story('ストーリー'),
-                    new Period(new FromOn(new DateTime('2019-12-08')), new ToOn(new DateTime('2019-12-08'))),
-                    new OrderNo(1),
-                    []
-                )
-            )
             ->once();
 
         $result = $this->interactor->handle(new GetRequest('BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB'));
@@ -89,28 +85,26 @@ class GetInteractorTest extends TestCase
     #[Test]
     public function getJourneyLogWithLinks(): void
     {
-        $this->journeyLogRepository->shouldReceive('find')
+        $this->repository->shouldReceive('find')
             ->with(Mockery::on(
                 fn ($arg) => $arg instanceof JourneyLogId
                     && $arg->value === 'BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB'
             ))
-            ->andReturnUsing(
-                fn () => new JourneyLog(
-                    new JourneyLogId('BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB'),
-                    new Story('ストーリー'),
-                    new Period(new FromOn(new DateTime('2019-12-08')), new ToOn(new DateTime('2019-12-08'))),
-                    new OrderNo(1),
-                    [
-                        new JourneyLogLink(
-                            new JourneyLogLinkId('CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC'),
-                            new JourneyLogLinkName('リンク'),
-                            new Url('https://example.com'),
-                            new OrderNo(1),
-                            new JourneyLogLinkTypeId('DDDDDDDD-DDDD-DDDD-DDDD-DDDDDDDDDDDD')
-                        ),
-                    ]
-                )
-            )
+            ->andReturn(new JourneyLog(
+                new JourneyLogId('BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB'),
+                new Story('ストーリー'),
+                new Period(new FromOn(new DateTime('2019-12-08')), new ToOn(new DateTime('2019-12-08'))),
+                new OrderNo(1),
+                [
+                    new JourneyLogLink(
+                        new JourneyLogLinkId('CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC'),
+                        new JourneyLogLinkName('リンク'),
+                        new Url('https://example.com'),
+                        new OrderNo(1),
+                        new JourneyLogLinkTypeId('DDDDDDDD-DDDD-DDDD-DDDD-DDDDDDDDDDDD')
+                    ),
+                ]
+            ))
             ->once();
 
         $result = $this->interactor->handle(new GetRequest('BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB'));
@@ -139,11 +133,8 @@ class GetInteractorTest extends TestCase
     #[Test]
     public function failureGetJourneyLog(): void
     {
-        $this->journeyLogRepository->shouldReceive('find')
-            ->with(Mockery::on(
-                fn ($arg) => $arg instanceof JourneyLogId
-                    && $arg->value === 'BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB'
-            ))
+        $this->repository->shouldReceive('find')
+            ->with(Mockery::on(fn (JourneyLogId $arg): bool => $arg->value === 'BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB'))
             ->andReturnNull()
             ->once();
 

--- a/src/tests/Unit/JourneyLog/Application/List/ListInteractorTest.php
+++ b/src/tests/Unit/JourneyLog/Application/List/ListInteractorTest.php
@@ -28,7 +28,7 @@ use Tests\TestCase;
 
 class ListInteractorTest extends TestCase
 {
-    private JourneyLogRepositoryInterface&MockInterface $journeyLogRepository;
+    private JourneyLogRepositoryInterface&MockInterface $repository;
 
     private ListInteractor $interactor;
 
@@ -36,8 +36,9 @@ class ListInteractorTest extends TestCase
     {
         parent::setUp();
 
-        $this->journeyLogRepository = Mockery::mock(JourneyLogRepositoryInterface::class);
-        $this->interactor = new ListInteractor($this->journeyLogRepository);
+        $this->repository = Mockery::mock(JourneyLogRepositoryInterface::class);
+
+        $this->interactor = new ListInteractor($this->repository);
     }
 
     #[Test]
@@ -49,8 +50,8 @@ class ListInteractorTest extends TestCase
     #[Test]
     public function emptyJourneyLogs(): void
     {
-        $this->journeyLogRepository->shouldReceive('all')
-            ->andReturnUsing(fn () => [])
+        $this->repository->shouldReceive('all')
+            ->andReturn([])
             ->once();
 
         $response = $this->interactor->handle();
@@ -63,33 +64,31 @@ class ListInteractorTest extends TestCase
     #[Test]
     public function nonEmptyJourneyLogs(): void
     {
-        $this->journeyLogRepository->shouldReceive('all')
-            ->andReturnUsing(
-                fn () => [
-                    new JourneyLog(
-                        new JourneyLogId('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'),
-                        new Story('ストーリー1'),
-                        new Period(new FromOn(new DateTime('2019-12-08')), new ToOn(new DateTime('2019-12-08'))),
-                        new OrderNo(1),
-                        []
-                    ),
-                    new JourneyLog(
-                        new JourneyLogId('BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB'),
-                        new Story('ストーリー2'),
-                        new Period(new FromOn(new DateTime('2019-12-09')), new ToOn(new DateTime('2019-12-09'))),
-                        new OrderNo(2),
-                        [
-                            new JourneyLogLink(
-                                new JourneyLogLinkId('CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC'),
-                                new JourneyLogLinkName('リンク'),
-                                new Url('https://example.com'),
-                                new OrderNo(1),
-                                new JourneyLogLinkTypeId('DDDDDDDD-DDDD-DDDD-DDDD-DDDDDDDDDDDD')
-                            ),
-                        ]
-                    ),
-                ]
-            )
+        $this->repository->shouldReceive('all')
+            ->andReturn([
+                new JourneyLog(
+                    new JourneyLogId('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'),
+                    new Story('ストーリー1'),
+                    new Period(new FromOn(new DateTime('2019-12-08')), new ToOn(new DateTime('2019-12-08'))),
+                    new OrderNo(1),
+                    []
+                ),
+                new JourneyLog(
+                    new JourneyLogId('BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB'),
+                    new Story('ストーリー2'),
+                    new Period(new FromOn(new DateTime('2019-12-09')), new ToOn(new DateTime('2019-12-09'))),
+                    new OrderNo(2),
+                    [
+                        new JourneyLogLink(
+                            new JourneyLogLinkId('CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC'),
+                            new JourneyLogLinkName('リンク'),
+                            new Url('https://example.com'),
+                            new OrderNo(1),
+                            new JourneyLogLinkTypeId('DDDDDDDD-DDDD-DDDD-DDDD-DDDDDDDDDDDD')
+                        ),
+                    ]
+                ),
+            ])
             ->once();
 
         $response = $this->interactor->handle();

--- a/src/tests/Unit/JourneyLogLinkType/Application/Create/CreateInteractorTest.php
+++ b/src/tests/Unit/JourneyLogLinkType/Application/Create/CreateInteractorTest.php
@@ -20,7 +20,7 @@ use Tests\TestCase;
 
 class CreateInteractorTest extends TestCase
 {
-    private JourneyLogLinkTypeRepositoryInterface&MockInterface $journeyLogLinkTypeRepository;
+    private JourneyLogLinkTypeRepositoryInterface&MockInterface $repository;
 
     private JourneyLogLinkTypeFactoryInterface&MockInterface $factory;
 
@@ -30,9 +30,10 @@ class CreateInteractorTest extends TestCase
     {
         parent::setup();
 
-        $this->journeyLogLinkTypeRepository = Mockery::mock(JourneyLogLinkTypeRepositoryInterface::class);
+        $this->repository = Mockery::mock(JourneyLogLinkTypeRepositoryInterface::class);
         $this->factory = Mockery::mock(JourneyLogLinkTypeFactoryInterface::class);
-        $this->interactor = new CreateInteractor($this->journeyLogLinkTypeRepository, $this->factory);
+
+        $this->interactor = new CreateInteractor($this->repository, $this->factory);
     }
 
     #[Test]
@@ -46,14 +47,14 @@ class CreateInteractorTest extends TestCase
     {
         $this->factory->shouldReceive('create')
             ->with('リンク', 1)
-            ->andReturnUsing(fn (): JourneyLogLinkType => new JourneyLogLinkType(
+            ->andReturn(new JourneyLogLinkType(
                 new JourneyLogLinkTypeId('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'),
                 new JourneyLogLinkTypeName('リンク'),
                 new OrderNo(1),
             ))
             ->once();
 
-        $this->journeyLogLinkTypeRepository->shouldReceive('insert')
+        $this->repository->shouldReceive('insert')
             ->with(Mockery::on(
                 fn (JourneyLogLinkType $arg): bool => $arg->journeyLogLinkTypeId->value === 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'
                     && $arg->journeyLogLinkTypeName->value === 'リンク'

--- a/src/tests/Unit/JourneyLogLinkType/Application/Delete/DeleteInteractorTest.php
+++ b/src/tests/Unit/JourneyLogLinkType/Application/Delete/DeleteInteractorTest.php
@@ -16,7 +16,7 @@ use Tests\TestCase;
 
 class DeleteInteractorTest extends TestCase
 {
-    private JourneyLogLinkTypeRepositoryInterface&MockInterface $journeyLogLinkTypeRepository;
+    private JourneyLogLinkTypeRepositoryInterface&MockInterface $repository;
 
     private DeleteInteractor $interactor;
 
@@ -24,8 +24,9 @@ class DeleteInteractorTest extends TestCase
     {
         parent::setUp();
 
-        $this->journeyLogLinkTypeRepository = Mockery::mock(JourneyLogLinkTypeRepositoryInterface::class);
-        $this->interactor = new DeleteInteractor($this->journeyLogLinkTypeRepository);
+        $this->repository = Mockery::mock(JourneyLogLinkTypeRepositoryInterface::class);
+
+        $this->interactor = new DeleteInteractor($this->repository);
     }
 
     #[Test]
@@ -37,11 +38,8 @@ class DeleteInteractorTest extends TestCase
     #[Test]
     public function deleteJourneyLogLinkType(): void
     {
-        $this->journeyLogLinkTypeRepository->shouldReceive('delete')
-            ->with(Mockery::on(
-                fn ($arg) => $arg instanceof JourneyLogLinkTypeId
-                    && $arg->value === 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'
-            ))
+        $this->repository->shouldReceive('delete')
+            ->with(Mockery::on(fn (JourneyLogLinkTypeId $arg): bool => $arg->value === 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'))
             ->once();
 
         $this->interactor->handle(new DeleteRequest('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'));

--- a/src/tests/Unit/JourneyLogLinkType/Application/Edit/EditInteractorTest.php
+++ b/src/tests/Unit/JourneyLogLinkType/Application/Edit/EditInteractorTest.php
@@ -20,7 +20,7 @@ use Tests\TestCase;
 
 class EditInteractorTest extends TestCase
 {
-    private JourneyLogLinkTypeRepositoryInterface&MockInterface $journeyLogLinkTypeRepository;
+    private JourneyLogLinkTypeRepositoryInterface&MockInterface $repository;
 
     private JourneyLogLinkTypeFactoryInterface&MockInterface $factory;
 
@@ -30,9 +30,10 @@ class EditInteractorTest extends TestCase
     {
         parent::setUp();
 
-        $this->journeyLogLinkTypeRepository = Mockery::mock(JourneyLogLinkTypeRepositoryInterface::class);
+        $this->repository = Mockery::mock(JourneyLogLinkTypeRepositoryInterface::class);
         $this->factory = Mockery::mock(JourneyLogLinkTypeFactoryInterface::class);
-        $this->interactor = new EditInteractor($this->journeyLogLinkTypeRepository, $this->factory);
+
+        $this->interactor = new EditInteractor($this->repository, $this->factory);
     }
 
     #[Test]
@@ -46,14 +47,14 @@ class EditInteractorTest extends TestCase
     {
         $this->factory->shouldReceive('reconstitute')
             ->with('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA', 'リンク', 1)
-            ->andReturnUsing(fn (): JourneyLogLinkType => new JourneyLogLinkType(
+            ->andReturn(new JourneyLogLinkType(
                 new JourneyLogLinkTypeId('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'),
                 new JourneyLogLinkTypeName('リンク'),
                 new OrderNo(1),
             ))
             ->once();
 
-        $this->journeyLogLinkTypeRepository->shouldReceive('update')
+        $this->repository->shouldReceive('update')
             ->with(Mockery::on(
                 fn (JourneyLogLinkType $arg): bool => $arg->journeyLogLinkTypeId->value === 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'
                     && $arg->journeyLogLinkTypeName->value === 'リンク'

--- a/src/tests/Unit/JourneyLogLinkType/Application/Get/GetInteractorTest.php
+++ b/src/tests/Unit/JourneyLogLinkType/Application/Get/GetInteractorTest.php
@@ -20,7 +20,7 @@ use Tests\TestCase;
 
 class GetInteractorTest extends TestCase
 {
-    private JourneyLogLinkTypeRepositoryInterface&MockInterface $journeyLogLinkTypeRepository;
+    private JourneyLogLinkTypeRepositoryInterface&MockInterface $repository;
 
     private GetInteractor $interactor;
 
@@ -28,8 +28,9 @@ class GetInteractorTest extends TestCase
     {
         parent::setUp();
 
-        $this->journeyLogLinkTypeRepository = Mockery::mock(JourneyLogLinkTypeRepositoryInterface::class);
-        $this->interactor = new GetInteractor($this->journeyLogLinkTypeRepository);
+        $this->repository = Mockery::mock(JourneyLogLinkTypeRepositoryInterface::class);
+
+        $this->interactor = new GetInteractor($this->repository);
     }
 
     #[Test]
@@ -41,18 +42,13 @@ class GetInteractorTest extends TestCase
     #[Test]
     public function getJourneyLogLinkType(): void
     {
-        $this->journeyLogLinkTypeRepository->shouldReceive('find')
-            ->with(Mockery::on(
-                fn ($arg) => $arg instanceof JourneyLogLinkTypeId
-                    && $arg->value === 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'
+        $this->repository->shouldReceive('find')
+            ->with(Mockery::on(fn (JourneyLogLinkTypeId $arg): bool => $arg->value === 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'))
+            ->andReturn(new JourneyLogLinkType(
+                new JourneyLogLinkTypeId('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'),
+                new JourneyLogLinkTypeName('リンク'),
+                new OrderNo(1)
             ))
-            ->andReturnUsing(
-                fn () => new JourneyLogLinkType(
-                    new JourneyLogLinkTypeId('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'),
-                    new JourneyLogLinkTypeName('リンク'),
-                    new OrderNo(1)
-                )
-            )
             ->once();
 
         $result = $this->interactor->handle(new GetRequest('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'));
@@ -70,11 +66,8 @@ class GetInteractorTest extends TestCase
     #[Test]
     public function failureGetJourneyLogLinkType(): void
     {
-        $this->journeyLogLinkTypeRepository->shouldReceive('find')
-            ->with(Mockery::on(
-                fn ($arg) => $arg instanceof JourneyLogLinkTypeId
-                    && $arg->value === 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'
-            ))
+        $this->repository->shouldReceive('find')
+            ->with(Mockery::on(fn (JourneyLogLinkTypeId $arg): bool => $arg->value === 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'))
             ->andReturnNull()
             ->once();
 

--- a/src/tests/Unit/JourneyLogLinkType/Application/List/ListInteractorTest.php
+++ b/src/tests/Unit/JourneyLogLinkType/Application/List/ListInteractorTest.php
@@ -11,6 +11,7 @@ use JourneyLogLinkType\Domain\Models\JourneyLogLinkTypeName;
 use JourneyLogLinkType\Domain\Repositories\JourneyLogLinkTypeRepositoryInterface;
 use JourneyLogLinkType\UseCases\List\ListResponse;
 use JourneyLogLinkType\UseCases\List\ListUseCaseInterface;
+use Mockery;
 use Mockery\MockInterface;
 use PHPUnit\Framework\Attributes\Test;
 use Support\Domain\ValueObjects\OrderNo;
@@ -18,7 +19,7 @@ use Tests\TestCase;
 
 class ListInteractorTest extends TestCase
 {
-    private JourneyLogLinkTypeRepositoryInterface&MockInterface $journeyLogLinkTypeRepository;
+    private JourneyLogLinkTypeRepositoryInterface&MockInterface $repository;
 
     private ListInteractor $interactor;
 
@@ -26,8 +27,9 @@ class ListInteractorTest extends TestCase
     {
         parent::setUp();
 
-        $this->journeyLogLinkTypeRepository = \Mockery::mock(JourneyLogLinkTypeRepositoryInterface::class);
-        $this->interactor = new ListInteractor($this->journeyLogLinkTypeRepository);
+        $this->repository = Mockery::mock(JourneyLogLinkTypeRepositoryInterface::class);
+
+        $this->interactor = new ListInteractor($this->repository);
     }
 
     #[Test]
@@ -39,8 +41,8 @@ class ListInteractorTest extends TestCase
     #[Test]
     public function emptyJourneyLogLinkTypes(): void
     {
-        $this->journeyLogLinkTypeRepository->shouldReceive('all')
-            ->andReturnUsing(fn () => [])
+        $this->repository->shouldReceive('all')
+            ->andReturn([])
             ->once();
 
         $response = $this->interactor->handle();
@@ -53,8 +55,8 @@ class ListInteractorTest extends TestCase
     #[Test]
     public function nonEmptyJourneyLogLinkTypes(): void
     {
-        $this->journeyLogLinkTypeRepository->shouldReceive('all')
-            ->andReturnUsing(fn () => [
+        $this->repository->shouldReceive('all')
+            ->andReturn([
                 new JourneyLogLinkType(
                     new JourneyLogLinkTypeId('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'),
                     new JourneyLogLinkTypeName('リンク'),

--- a/src/tests/Unit/Song/Application/List/ListInteractorTest.php
+++ b/src/tests/Unit/Song/Application/List/ListInteractorTest.php
@@ -35,7 +35,7 @@ use Tests\TestCase;
 
 class ListInteractorTest extends TestCase
 {
-    private MockInterface&SongRepositoryInterface $songRepository;
+    private MockInterface&SongRepositoryInterface $repository;
 
     private ListInteractor $interactor;
 
@@ -43,8 +43,9 @@ class ListInteractorTest extends TestCase
     {
         parent::setUp();
 
-        $this->songRepository = Mockery::mock(SongRepositoryInterface::class);
-        $this->interactor = new ListInteractor($this->songRepository);
+        $this->repository = Mockery::mock(SongRepositoryInterface::class);
+
+        $this->interactor = new ListInteractor($this->repository);
     }
 
     #[Test]
@@ -56,8 +57,8 @@ class ListInteractorTest extends TestCase
     #[Test]
     public function emptySongs(): void
     {
-        $this->songRepository->shouldReceive('all')
-            ->andReturnUsing(fn () => [])
+        $this->repository->shouldReceive('all')
+            ->andReturn([])
             ->once();
 
         $response = $this->interactor->handle();
@@ -70,120 +71,118 @@ class ListInteractorTest extends TestCase
     #[Test]
     public function nonEmptySongs(): void
     {
-        $this->songRepository->shouldReceive('all')
-            ->andReturnUsing(
-                fn () => [
-                    new Song(
-                        new SongId('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'),
-                        new Title('楽曲A'),
-                        new Description('楽曲Aの説明'),
-                        new SongTypeId('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAB'),
-                        [
-                            new Lyricist(
-                                new CreatorId('BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB'),
-                                new OrderNo(1)
-                            ),
-                        ],
-                        [
-                            new Composer(
-                                new CreatorId('CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC'),
-                                new OrderNo(1)
-                            ),
-                        ],
-                        [
-                            new Arranger(
-                                new CreatorId('DDDDDDDD-DDDD-DDDD-DDDD-DDDDDDDDDDDD'),
-                                new OrderNo(1)
-                            ),
-                        ],
-                        [
-                            new YouTubeArchive(
-                                new ArchiveId('EEEEEEEE-EEEE-EEEE-EEEE-EEEEEEEEEEEE'),
-                                new ArchiveName('MV'),
-                                new VideoUrl('https://example.com'),
-                                new ThumbnailUrl('https://example.com'),
-                                new ArchivedOn(new DateTime('2019-12-09')),
-                                new OrderNo(1),
-                            ),
-                            new YouTubeArchive(
-                                new ArchiveId('FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF'),
-                                new ArchiveName('LIVE'),
-                                new VideoUrl('https://example.com'),
-                                new ThumbnailUrl('https://example.com'),
-                                new ArchivedOn(new DateTime('2019-12-10')),
-                                new OrderNo(2),
-                            ),
-                        ],
-                        new OrderNo(1),
-                    ),
-                    new Song(
-                        new SongId('00000000-0000-0000-0000-000000000000'),
-                        new Title('楽曲B'),
-                        new Description('楽曲Bの説明'),
-                        new SongTypeId('11111111-1111-1111-1111-111111111111'),
-                        [
-                            new Lyricist(
-                                new CreatorId('22222222-2222-2222-2222-222222222222'),
-                                new OrderNo(1)
-                            ),
-                        ],
-                        [
-                            new Composer(
-                                new CreatorId('33333333-3333-3333-3333-333333333333'),
-                                new OrderNo(1)
-                            ),
-                        ],
-                        [
-                            new Arranger(
-                                new CreatorId('44444444-4444-4444-4444-444444444444'),
-                                new OrderNo(1)
-                            ),
-                        ],
-                        [
-                            new TwitterArchive(
-                                new ArchiveId('55555555-5555-5555-5555-555555555555'),
-                                new ArchiveName('Tweet'),
-                                new PostUrl('https://example.com'),
-                                new ArchivedOn(new DateTime('2019-12-11')),
-                                new OrderNo(1),
-                            ),
-                        ],
-                        new OrderNo(2),
-                    ),
-                    new Song(
-                        new SongId('66666666-6666-6666-6666-666666666666'),
-                        new Title('楽曲C'),
-                        new Description('楽曲Cの説明'),
-                        new SongTypeId('77777777-7777-7777-7777-777777777777'),
-                        [
-                            new Lyricist(
-                                new CreatorId('88888888-8888-8888-8888-888888888888'),
-                                new OrderNo(1)
-                            ),
-                        ],
-                        [
-                            new Composer(
-                                new CreatorId('99999999-9999-9999-9999-999999999999'),
-                                new OrderNo(1)
-                            ),
-                        ],
-                        [
-                            new Arranger(
-                                new CreatorId('10101010-1010-1010-1010-101010101010'),
-                                new OrderNo(1)
-                            ),
-                        ],
-                        [
-                            new NonLinkArchive(
-                                new ArchiveId('12121212-1212-1212-1212-121212121212'),
-                                new ArchivedOn(new DateTime('2019-12-12')),
-                                new OrderNo(1),
-                            ),
-                        ],
-                        new OrderNo(3),
-                    ),
-                ]
-            )
+        $this->repository->shouldReceive('all')
+            ->andReturn([
+                new Song(
+                    new SongId('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'),
+                    new Title('楽曲A'),
+                    new Description('楽曲Aの説明'),
+                    new SongTypeId('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAB'),
+                    [
+                        new Lyricist(
+                            new CreatorId('BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB'),
+                            new OrderNo(1)
+                        ),
+                    ],
+                    [
+                        new Composer(
+                            new CreatorId('CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC'),
+                            new OrderNo(1)
+                        ),
+                    ],
+                    [
+                        new Arranger(
+                            new CreatorId('DDDDDDDD-DDDD-DDDD-DDDD-DDDDDDDDDDDD'),
+                            new OrderNo(1)
+                        ),
+                    ],
+                    [
+                        new YouTubeArchive(
+                            new ArchiveId('EEEEEEEE-EEEE-EEEE-EEEE-EEEEEEEEEEEE'),
+                            new ArchiveName('MV'),
+                            new VideoUrl('https://example.com'),
+                            new ThumbnailUrl('https://example.com'),
+                            new ArchivedOn(new DateTime('2019-12-09')),
+                            new OrderNo(1),
+                        ),
+                        new YouTubeArchive(
+                            new ArchiveId('FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF'),
+                            new ArchiveName('LIVE'),
+                            new VideoUrl('https://example.com'),
+                            new ThumbnailUrl('https://example.com'),
+                            new ArchivedOn(new DateTime('2019-12-10')),
+                            new OrderNo(2),
+                        ),
+                    ],
+                    new OrderNo(1),
+                ),
+                new Song(
+                    new SongId('00000000-0000-0000-0000-000000000000'),
+                    new Title('楽曲B'),
+                    new Description('楽曲Bの説明'),
+                    new SongTypeId('11111111-1111-1111-1111-111111111111'),
+                    [
+                        new Lyricist(
+                            new CreatorId('22222222-2222-2222-2222-222222222222'),
+                            new OrderNo(1)
+                        ),
+                    ],
+                    [
+                        new Composer(
+                            new CreatorId('33333333-3333-3333-3333-333333333333'),
+                            new OrderNo(1)
+                        ),
+                    ],
+                    [
+                        new Arranger(
+                            new CreatorId('44444444-4444-4444-4444-444444444444'),
+                            new OrderNo(1)
+                        ),
+                    ],
+                    [
+                        new TwitterArchive(
+                            new ArchiveId('55555555-5555-5555-5555-555555555555'),
+                            new ArchiveName('Tweet'),
+                            new PostUrl('https://example.com'),
+                            new ArchivedOn(new DateTime('2019-12-11')),
+                            new OrderNo(1),
+                        ),
+                    ],
+                    new OrderNo(2),
+                ),
+                new Song(
+                    new SongId('66666666-6666-6666-6666-666666666666'),
+                    new Title('楽曲C'),
+                    new Description('楽曲Cの説明'),
+                    new SongTypeId('77777777-7777-7777-7777-777777777777'),
+                    [
+                        new Lyricist(
+                            new CreatorId('88888888-8888-8888-8888-888888888888'),
+                            new OrderNo(1)
+                        ),
+                    ],
+                    [
+                        new Composer(
+                            new CreatorId('99999999-9999-9999-9999-999999999999'),
+                            new OrderNo(1)
+                        ),
+                    ],
+                    [
+                        new Arranger(
+                            new CreatorId('10101010-1010-1010-1010-101010101010'),
+                            new OrderNo(1)
+                        ),
+                    ],
+                    [
+                        new NonLinkArchive(
+                            new ArchiveId('12121212-1212-1212-1212-121212121212'),
+                            new ArchivedOn(new DateTime('2019-12-12')),
+                            new OrderNo(1),
+                        ),
+                    ],
+                    new OrderNo(3),
+                ),
+            ])
             ->once();
 
         $response = $this->interactor->handle();


### PR DESCRIPTION
- プロパティ名を修正
- アロー関数に型宣言を追加
- 意味のない `andReturnUsing()` を `andReturn()` に置き換え
- `LegacyMockInterface` を `MockInterface` に置き換え
- 適宜改行を追加