### PR TITLE
docker compose exec を docker exec に変更

### DIFF
--- a/.github/workflows/setup.yaml
+++ b/.github/workflows/setup.yaml
@@ -79,7 +79,7 @@ jobs:
           HASH_SERVER_DOCKERFILE="${{ hashFiles('./docker/php/Dockerfile') }}"
           KEY_SERVER_DOCKER_CACHE="docker-server-${HASH_SERVER_DOCKERFILE}"
           SERVER_DOCKER_CACHE="${PATH_SERVER_DOCKER_CACHE}/${HASH_SERVER_DOCKERFILE}.tar.gz"
-          SERVER_CONTAINER="isekai-journey-admin-panel-php-1"
+          SERVER_CONTAINER="isekai-journey-admin-php"
           echo "PATH_SERVER_DOCKER_CACHE=${PATH_SERVER_DOCKER_CACHE}" >> $GITHUB_OUTPUT
           echo "KEY_SERVER_DOCKER_CACHE=${KEY_SERVER_DOCKER_CACHE}" >> $GITHUB_OUTPUT
           echo "SERVER_DOCKER_CACHE=${SERVER_DOCKER_CACHE}" >> $GITHUB_OUTPUT
@@ -89,7 +89,7 @@ jobs:
           HASH_CLIENT_DOCKERFILE="${{ hashFiles('./docker/node/Dockerfile') }}"
           KEY_CLIENT_DOCKER_CACHE="docker-client-${HASH_CLIENT_DOCKERFILE}"
           CLIENT_DOCKER_CACHE="${PATH_CLIENT_DOCKER_CACHE}/${HASH_CLIENT_DOCKERFILE}.tar.gz"
-          CLIENT_CONTAINER="isekai-journey-admin-panel-php-1"
+          CLIENT_CONTAINER="isekai-journey-admin-php"
           echo "PATH_CLIENT_DOCKER_CACHE=${PATH_CLIENT_DOCKER_CACHE}" >> $GITHUB_OUTPUT
           echo "KEY_CLIENT_DOCKER_CACHE=${KEY_CLIENT_DOCKER_CACHE}" >> $GITHUB_OUTPUT
           echo "CLIENT_DOCKER_CACHE=${CLIENT_DOCKER_CACHE}" >> $GITHUB_OUTPUT

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ down: ## Delete the container
 
 .PHONY: php
 php: ## Enter php container
-	docker compose exec php bash
+	docker exec isekai-journey-admin-php bash
 
 .PHONY: composer-install
 composer-install: ## Install composer packages
@@ -41,67 +41,67 @@ composer-install: ## Install composer packages
 
 .PHONY: phpstan
 phpstan: ## Run PHPStan
-	docker compose exec php composer phpstan
+	docker exec isekai-journey-admin-php composer phpstan
 
 .PHONY: phpstan-clear-cache
 phpstan-clear-cache: ## Clear PHPStan cache
-	docker compose exec php composer phpstan-clear-cache
+	docker exec isekai-journey-admin-php composer phpstan-clear-cache
 
 .PHONY: arkitect
 arkitect: ## Run arkitect
-	docker compose exec php composer arkitect
+	docker exec isekai-journey-admin-php composer arkitect
 
 .PHONY: ecs
 ecs: ## Run ecs
-	docker compose exec php composer ecs
+	docker exec isekai-journey-admin-php composer ecs
 
 .PHONY: ecs-fix
 ecs-fix: ## Run ecs fix
-	docker compose exec php composer ecs-fix
+	docker exec isekai-journey-admin-php composer ecs-fix
 
 .PHONY: test-all
 test-all: ## Run all tests
-	docker compose exec php composer test-all
+	docker exec isekai-journey-admin-php composer test-all
 
 .PHONY: test-unit
 test-unit: ## Run PHPUnit
-	docker compose exec php composer test-unit
+	docker exec isekai-journey-admin-php composer test-unit
 
 .PHONY: test-feature
 test-feature: ## Run PHPUnit
-	docker compose exec php composer test-feature
+	docker exec isekai-journey-admin-php composer test-feature
 
 .PHONY: coverage
 coverage: ## Export coverage
-	docker compose exec php composer coverage
+	docker exec isekai-journey-admin-php composer coverage
 
 .PHONY: infection
 infection: ## Run infection
-	docker compose exec php composer infection
+	docker exec isekai-journey-admin-php composer infection
 
 .PHONY: ide-gen
 ide-gen: ## Generate ide helper file
-	docker compose exec php composer ide-gen
+	docker exec isekai-journey-admin-php composer ide-gen
 
 .PHONY: ide-model
 ide-model: ## Write ide helper to model files
-	docker compose exec php composer ide-model
+	docker exec isekai-journey-admin-php composer ide-model
 
 .PHONY: ide-meta
 ide-meta: ## Generate ide helper meta file
-	docker compose exec php composer ide-meta
+	docker exec isekai-journey-admin-php composer ide-meta
 
 .PHONY: migrate
 migrate: ## Migrate database
-	docker compose exec php php artisan migrate
+	docker exec isekai-journey-admin-php php artisan migrate
 
 .PHONY: migrate-test
 migrate-test: ## Migrate database for test db
-	docker compose exec php php artisan migrate --env=testing
+	docker exec isekai-journey-admin-php php artisan migrate --env=testing
 
 .PHONY: tinker
 tinker: ## Run tinker
-	docker compose exec php php artisan tinker
+	docker exec isekai-journey-admin-php php artisan tinker
 
 .PHONY: copy-root-ca
 copy-root-ca: ## Copy local rootCA.pem
@@ -110,11 +110,11 @@ copy-root-ca: ## Copy local rootCA.pem
 
 .PHONY: generate-grpc-stub
 generate-grpc-stub: ## Generate gRPC Stub files
-	docker compose exec php ./gen-stub.sh
+	docker exec isekai-journey-admin-php ./gen-stub.sh
 
 .PHONY: node
 node: ## Enter node container
-	docker compose exec node bash
+	docker exec isekai-journey-admin-node bash
 
 .PHONY: npm-install
 npm-install: ## Install npm packages

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ USERNAME := $(shell id -u -n)
 GID := $(shell id -g)
 GROUPNAME := $(shell id -g -n)
 
+SERVER_CONTAINER := isekai-journey-admin-php
+CLIENT_CONTAINER := isekai-journey-admin-node
+
 PROTOC_VERSION := "27.3"
 GRPC_VERSION := "v1.65.5"
 
@@ -33,7 +36,7 @@ down: ## Delete the container
 
 .PHONY: php
 php: ## Enter php container
-	docker exec isekai-journey-admin-php bash
+	docker exec ${SERVER_CONTAINER} bash
 
 .PHONY: composer-install
 composer-install: ## Install composer packages
@@ -41,67 +44,67 @@ composer-install: ## Install composer packages
 
 .PHONY: phpstan
 phpstan: ## Run PHPStan
-	docker exec isekai-journey-admin-php composer phpstan
+	docker exec ${SERVER_CONTAINER} composer phpstan
 
 .PHONY: phpstan-clear-cache
 phpstan-clear-cache: ## Clear PHPStan cache
-	docker exec isekai-journey-admin-php composer phpstan-clear-cache
+	docker exec ${SERVER_CONTAINER} composer phpstan-clear-cache
 
 .PHONY: arkitect
 arkitect: ## Run arkitect
-	docker exec isekai-journey-admin-php composer arkitect
+	docker exec ${SERVER_CONTAINER} composer arkitect
 
 .PHONY: ecs
 ecs: ## Run ecs
-	docker exec isekai-journey-admin-php composer ecs
+	docker exec ${SERVER_CONTAINER} composer ecs
 
 .PHONY: ecs-fix
 ecs-fix: ## Run ecs fix
-	docker exec isekai-journey-admin-php composer ecs-fix
+	docker exec ${SERVER_CONTAINER} composer ecs-fix
 
 .PHONY: test-all
 test-all: ## Run all tests
-	docker exec isekai-journey-admin-php composer test-all
+	docker exec ${SERVER_CONTAINER} composer test-all
 
 .PHONY: test-unit
 test-unit: ## Run PHPUnit
-	docker exec isekai-journey-admin-php composer test-unit
+	docker exec ${SERVER_CONTAINER} composer test-unit
 
 .PHONY: test-feature
 test-feature: ## Run PHPUnit
-	docker exec isekai-journey-admin-php composer test-feature
+	docker exec ${SERVER_CONTAINER} composer test-feature
 
 .PHONY: coverage
 coverage: ## Export coverage
-	docker exec isekai-journey-admin-php composer coverage
+	docker exec ${SERVER_CONTAINER} composer coverage
 
 .PHONY: infection
 infection: ## Run infection
-	docker exec isekai-journey-admin-php composer infection
+	docker exec ${SERVER_CONTAINER} composer infection
 
 .PHONY: ide-gen
 ide-gen: ## Generate ide helper file
-	docker exec isekai-journey-admin-php composer ide-gen
+	docker exec ${SERVER_CONTAINER} composer ide-gen
 
 .PHONY: ide-model
 ide-model: ## Write ide helper to model files
-	docker exec isekai-journey-admin-php composer ide-model
+	docker exec ${SERVER_CONTAINER} composer ide-model
 
 .PHONY: ide-meta
 ide-meta: ## Generate ide helper meta file
-	docker exec isekai-journey-admin-php composer ide-meta
+	docker exec ${SERVER_CONTAINER} composer ide-meta
 
 .PHONY: migrate
 migrate: ## Migrate database
-	docker exec isekai-journey-admin-php php artisan migrate
+	docker exec ${SERVER_CONTAINER} php artisan migrate
 
 .PHONY: migrate-test
 migrate-test: ## Migrate database for test db
-	docker exec isekai-journey-admin-php php artisan migrate --env=testing
+	docker exec ${SERVER_CONTAINER} php artisan migrate --env=testing
 
 .PHONY: tinker
 tinker: ## Run tinker
-	docker exec isekai-journey-admin-php php artisan tinker
+	docker exec ${SERVER_CONTAINER} php artisan tinker
 
 .PHONY: copy-root-ca
 copy-root-ca: ## Copy local rootCA.pem
@@ -110,11 +113,11 @@ copy-root-ca: ## Copy local rootCA.pem
 
 .PHONY: generate-grpc-stub
 generate-grpc-stub: ## Generate gRPC Stub files
-	docker exec isekai-journey-admin-php ./gen-stub.sh
+	docker exec ${SERVER_CONTAINER} ./gen-stub.sh
 
 .PHONY: node
 node: ## Enter node container
-	docker exec isekai-journey-admin-node bash
+	docker exec ${CLIENT_CONTAINER} bash
 
 .PHONY: npm-install
 npm-install: ## Install npm packages

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,7 @@
 services:
   web:
     image: isekai-journey-admin-web:1.25
+    container_name: isekai-journey-admin-web
     environment:
       LANG: ja_JP.UTF-8
       TZ: Asia/Tokyo
@@ -12,6 +13,7 @@ services:
 
   php:
     image: isekai-journey-admin-php:8.4
+    container_name: isekai-journey-admin-php
     environment:
       LANG: ja_JP.UTF-8
       TZ: Asia/Tokyo
@@ -26,6 +28,7 @@ services:
 
   node:
     image: isekai-journey-admin-node:22
+    container_name: isekai-journey-admin-node
     environment:
       LANG: ja_JP.UTF-8
       TZ: Asia/Tokyo
@@ -40,6 +43,7 @@ services:
 
   db:
     image: isekai-journey-admin-db:16
+    container_name: isekai-journey-admin-db
     environment:
       POSTGRES_USER: ${DB_USER}
       POSTGRES_PASSWORD: ${DB_PASSWORD}
@@ -52,6 +56,7 @@ services:
 
   test-db:
     image: isekai-journey-admin-db:16
+    container_name: isekai-journey-admin-test-db
     environment:
       POSTGRES_USER: ${DB_USER}
       POSTGRES_PASSWORD: ${DB_PASSWORD}


### PR DESCRIPTION
## 概要

`docker compose exec` は速度が出ないので `docker exec` に置き換えた

## やったこと

- Makefile 内の `docker compose exec`  を  `docker exec` に置き換え
- compose.yaml でコンテナ名を固定化した
- CI で利用するコンテナ名を変更

## やってないこと

- `docker compose run` の `docker run` 化
  - 単純な置き換えではパーミッションエラーが出たので対応していない
  - そもそも `run` 系のコマンドはそこまで実行することがないので多少遅くても問題ない
- ~Makefile のリファクタ~
  - ~コンテナ名を変数化とかしたいけどいったんしてない~
    - レビューで指摘もらったのでついでに対応

## 関連

- #226 