### PR TITLE
setup を分割

### DIFF
--- a/.github/workflows/arkitect.yaml
+++ b/.github/workflows/arkitect.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   setup:
-    uses: ./.github/workflows/setup.yaml
+    uses: ./.github/workflows/setup-server.yaml
 
   check:
     needs: setup

--- a/.github/workflows/ecs.yaml
+++ b/.github/workflows/ecs.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   setup:
-    uses: ./.github/workflows/setup.yaml
+    uses: ./.github/workflows/setup-server.yaml
 
   lint:
     needs: setup

--- a/.github/workflows/eslint-and-build.yaml
+++ b/.github/workflows/eslint-and-build.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   setup:
-    uses: ./.github/workflows/setup.yaml
+    uses: ./.github/workflows/setup-client.yaml
 
   analyse:
     needs: setup

--- a/.github/workflows/phpstan.yaml
+++ b/.github/workflows/phpstan.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   setup:
-    uses: ./.github/workflows/setup.yaml
+    uses: ./.github/workflows/setup-server.yaml
 
   analyse:
     needs: setup

--- a/.github/workflows/phpunit.yaml
+++ b/.github/workflows/phpunit.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   setup:
-    uses: ./.github/workflows/setup.yaml
+    uses: ./.github/workflows/setup-server.yaml
 
   test:
     needs: setup

--- a/.github/workflows/setup-client.yaml
+++ b/.github/workflows/setup-client.yaml
@@ -19,7 +19,7 @@ on:
         value: ${{ jobs.setup.outputs.npm-cache }}
 
 jobs:
-  setup-client:
+  setup:
     name: Setup client
 
     runs-on: ubuntu-latest

--- a/.github/workflows/setup-client.yaml
+++ b/.github/workflows/setup-client.yaml
@@ -1,0 +1,107 @@
+name: setup client
+
+on:
+  workflow_call:
+    outputs:
+      path-client-docker-cache:
+        value: ${{ jobs.setup.outputs.path-client-docker-cache }}
+      key-client-docker-cache:
+        value: ${{ jobs.setup.outputs.key-client-docker-cache }}
+      client-docker-cache:
+        value: ${{ jobs.setup.outputs.client-docker-cache }}
+      client-container:
+        value: ${{ jobs.setup.outputs.client-container }}
+      path-npm-cache:
+        value: ${{ jobs.setup.outputs.path-npm-cache }}
+      key-npm-cache:
+        value: ${{ jobs.setup.outputs.key-npm-cache }}
+      npm-cache:
+        value: ${{ jobs.setup.outputs.npm-cache }}
+
+jobs:
+  setup-client:
+    name: Setup client
+
+    runs-on: ubuntu-latest
+
+    outputs:
+      path-client-docker-cache: ${{ steps.define-variables.outputs.PATH_CLIENT_DOCKER_CACHE }}
+      key-client-docker-cache: ${{ steps.define-variables.outputs.KEY_CLIENT_DOCKER_CACHE }}
+      client-docker-cache: ${{ steps.define-variables.outputs.CLIENT_DOCKER_CACHE }}
+      client-container: ${{ steps.define-variables.outputs.CLIENT_CONTAINER }}
+      path-npm-cache: ${{ steps.define-variables.outputs.PATH_NPM_CACHE }}
+      key-npm-cache: ${{ steps.define-variables.outputs.KEY_NPM_CACHE }}
+      npm-cache: ${{ steps.define-variables.outputs.NPM_CACHE }}
+
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+          submodules: true
+
+      - name: Define variables
+        id: define-variables
+        run: |
+          ROOT_CACHE="/tmp/cache"
+          # Docker 関連
+          PATH_CLIENT_DOCKER_CACHE="${ROOT_CACHE}/docker/client"
+          HASH_CLIENT_DOCKERFILE="${{ hashFiles('./docker/node/Dockerfile', './docker/node/Dockerfile.ci') }}"
+          KEY_CLIENT_DOCKER_CACHE="docker-client-${HASH_CLIENT_DOCKERFILE}"
+          CLIENT_DOCKER_CACHE="${PATH_CLIENT_DOCKER_CACHE}/${HASH_CLIENT_DOCKERFILE}.tar.gz"
+          CLIENT_CONTAINER="isekai-journey-admin-node"
+          echo "PATH_CLIENT_DOCKER_CACHE=${PATH_CLIENT_DOCKER_CACHE}" >> $GITHUB_OUTPUT
+          echo "KEY_CLIENT_DOCKER_CACHE=${KEY_CLIENT_DOCKER_CACHE}" >> $GITHUB_OUTPUT
+          echo "CLIENT_DOCKER_CACHE=${CLIENT_DOCKER_CACHE}" >> $GITHUB_OUTPUT
+          echo "CLIENT_CONTAINER=${CLIENT_CONTAINER}" >> $GITHUB_OUTPUT
+          # npm 関連
+          PATH_NPM_CACHE="${ROOT_CACHE}/npm"
+          HASH_NPM_LOCK="${{ hashFiles('./src/client/package-lock.json') }}"
+          KEY_NPM_CACHE="npm-${HASH_NPM_LOCK}"
+          NPM_CACHE="${PATH_NPM_CACHE}/${KEY_NPM_CACHE}.tar.gz"
+          echo "PATH_NPM_CACHE=${PATH_NPM_CACHE}" >> $GITHUB_OUTPUT
+          echo "KEY_NPM_CACHE=${KEY_NPM_CACHE}" >> $GITHUB_OUTPUT
+          echo "NPM_CACHE=${NPM_CACHE}" >> $GITHUB_OUTPUT
+
+      - name: Cache client docker image
+        id: cache-client-docker-image
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.define-variables.outputs.PATH_CLIENT_DOCKER_CACHE }}
+          key: ${{ steps.define-variables.outputs.KEY_CLIENT_DOCKER_CACHE }}
+
+      - name: Login to Docker Hub
+        if: steps.cache-client-docker-image.outputs.cache-hit != 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN  }}
+
+      - name: Build client image
+        if: steps.cache-client-docker-image.outputs.cache-hit != 'true'
+        run: |
+          docker build -t isekai-journey-admin-node:22 -f ./docker/node/Dockerfile.ci ./docker/node
+          mkdir -p ${{ steps.define-variables.outputs.PATH_CLIENT_DOCKER_CACHE }}
+          docker save isekai-journey-admin-node:22 | gzip > ${{ steps.define-variables.outputs.CLIENT_DOCKER_CACHE }}
+
+      - name: Load client image
+        if: steps.cache-client-docker-image.outputs.cache-hit == 'true'
+        run: gunzip -c ${{ steps.define-variables.outputs.CLIENT_DOCKER_CACHE }} | docker load
+
+      - name: Run Container
+        run: docker compose up -d node
+
+      - name: Cache npm
+        id: cache-npm
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.define-variables.outputs.PATH_NPM_CACHE }}
+          key: ${{ steps.define-variables.outputs.KEY_NPM_CACHE }}
+
+      - name: Npm install
+        if: steps.cache-npm.outputs.cache-hit != 'true'
+        run: |
+          docker exec ${{ steps.define-variables.outputs.CLIENT_CONTAINER }} npm i
+          mkdir -p ${{ steps.define-variables.outputs.PATH_NPM_CACHE }}
+          tar -czf ${{ steps.define-variables.outputs.NPM_CACHE }} src/client/node_modules

--- a/.github/workflows/setup-server.yaml
+++ b/.github/workflows/setup-server.yaml
@@ -25,7 +25,7 @@ on:
         value: ${{ jobs.setup.outputs.database-cache }}
 
 jobs:
-  setup-server:
+  setup:
     name: Setup server
 
     runs-on: ubuntu-latest

--- a/.github/workflows/setup-server.yaml
+++ b/.github/workflows/setup-server.yaml
@@ -55,7 +55,7 @@ jobs:
           ROOT_CACHE="/tmp/cache"
           # Docker 関連(Server)
           PATH_SERVER_DOCKER_CACHE="${ROOT_CACHE}/docker/server"
-          HASH_SERVER_DOCKERFILE="${{ hashFiles('./docker/php/Dockerfile') }}"
+          HASH_SERVER_DOCKERFILE="${{ hashFiles('./docker/php/Dockerfile', './docker/php/Dockerfile.ci') }}"
           KEY_SERVER_DOCKER_CACHE="docker-server-${HASH_SERVER_DOCKERFILE}"
           SERVER_DOCKER_CACHE="${PATH_SERVER_DOCKER_CACHE}/${HASH_SERVER_DOCKERFILE}.tar.gz"
           SERVER_CONTAINER="isekai-journey-admin-php"

--- a/.github/workflows/setup-server.yaml
+++ b/.github/workflows/setup-server.yaml
@@ -1,4 +1,4 @@
-name: setup
+name: setup server
 
 on:
   workflow_call:
@@ -25,8 +25,8 @@ on:
         value: ${{ jobs.setup.outputs.database-cache }}
 
 jobs:
-  setup:
-    name: Setup
+  setup-server:
+    name: Setup server
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/setup.yaml
+++ b/.github/workflows/setup.yaml
@@ -11,26 +11,12 @@ on:
         value: ${{ jobs.setup.outputs.server-docker-cache }}
       server-container:
         value: ${{ jobs.setup.outputs.server-container }}
-      path-client-docker-cache:
-        value: ${{ jobs.setup.outputs.path-client-docker-cache }}
-      key-client-docker-cache:
-        value: ${{ jobs.setup.outputs.key-client-docker-cache }}
-      client-docker-cache:
-        value: ${{ jobs.setup.outputs.client-docker-cache }}
-      client-container:
-        value: ${{ jobs.setup.outputs.client-container }}
       path-vendor-cache:
         value: ${{ jobs.setup.outputs.path-vendor-cache }}
       key-composer-cache:
         value: ${{ jobs.setup.outputs.key-composer-cache }}
       vendor-cache:
         value: ${{ jobs.setup.outputs.vendor-cache }}
-      path-npm-cache:
-        value: ${{ jobs.setup.outputs.path-npm-cache }}
-      key-npm-cache:
-        value: ${{ jobs.setup.outputs.key-npm-cache }}
-      npm-cache:
-        value: ${{ jobs.setup.outputs.npm-cache }}
       path-database-cache:
        value: ${{ jobs.setup.outputs.path-database-cache }}
       key-database-cache:
@@ -49,16 +35,9 @@ jobs:
       key-server-docker-cache: ${{ steps.define-variables.outputs.KEY_SERVER_DOCKER_CACHE }}
       server-docker-cache: ${{ steps.define-variables.outputs.SERVER_DOCKER_CACHE }}
       server-container: ${{ steps.define-variables.outputs.SERVER_CONTAINER }}
-      path-client-docker-cache: ${{ steps.define-variables.outputs.PATH_CLIENT_DOCKER_CACHE }}
-      key-client-docker-cache: ${{ steps.define-variables.outputs.KEY_CLIENT_DOCKER_CACHE }}
-      client-docker-cache: ${{ steps.define-variables.outputs.CLIENT_DOCKER_CACHE }}
-      client-container: ${{ steps.define-variables.outputs.CLIENT_CONTAINER }}
       path-vendor-cache: ${{ steps.define-variables.outputs.PATH_VENDOR_CACHE }}
       key-composer-cache: ${{ steps.define-variables.outputs.KEY_COMPOSER_CACHE }}
       vendor-cache: ${{ steps.define-variables.outputs.VENDOR_CACHE }}
-      path-npm-cache: ${{ steps.define-variables.outputs.PATH_NPM_CACHE }}
-      key-npm-cache: ${{ steps.define-variables.outputs.KEY_NPM_CACHE }}
-      npm-cache: ${{ steps.define-variables.outputs.NPM_CACHE }}
       path-database-cache: ${{ steps.define-variables.outputs.PATH_DATABASE_CACHE }}
       key-database-cache: ${{ steps.define-variables.outputs.KEY_DATABASE_CACHE }}
       database-cache: ${{ steps.define-variables.outputs.DATABASE_CACHE }}
@@ -84,16 +63,6 @@ jobs:
           echo "KEY_SERVER_DOCKER_CACHE=${KEY_SERVER_DOCKER_CACHE}" >> $GITHUB_OUTPUT
           echo "SERVER_DOCKER_CACHE=${SERVER_DOCKER_CACHE}" >> $GITHUB_OUTPUT
           echo "SERVER_CONTAINER=${SERVER_CONTAINER}" >> $GITHUB_OUTPUT
-          # Docker 関連(Client)
-          PATH_CLIENT_DOCKER_CACHE="${ROOT_CACHE}/docker/client"
-          HASH_CLIENT_DOCKERFILE="${{ hashFiles('./docker/node/Dockerfile', './docker/node/Dockerfile.ci') }}"
-          KEY_CLIENT_DOCKER_CACHE="docker-client-${HASH_CLIENT_DOCKERFILE}"
-          CLIENT_DOCKER_CACHE="${PATH_CLIENT_DOCKER_CACHE}/${HASH_CLIENT_DOCKERFILE}.tar.gz"
-          CLIENT_CONTAINER="isekai-journey-admin-node"
-          echo "PATH_CLIENT_DOCKER_CACHE=${PATH_CLIENT_DOCKER_CACHE}" >> $GITHUB_OUTPUT
-          echo "KEY_CLIENT_DOCKER_CACHE=${KEY_CLIENT_DOCKER_CACHE}" >> $GITHUB_OUTPUT
-          echo "CLIENT_DOCKER_CACHE=${CLIENT_DOCKER_CACHE}" >> $GITHUB_OUTPUT
-          echo "CLIENT_CONTAINER=${CLIENT_CONTAINER}" >> $GITHUB_OUTPUT
           # Composer 関連
           PATH_VENDOR_CACHE="${ROOT_CACHE}/vendor"
           HASH_COMPOSER_LOCK="${{ hashFiles('./src/server/composer.lock') }}"
@@ -102,14 +71,6 @@ jobs:
           echo "PATH_VENDOR_CACHE=${PATH_VENDOR_CACHE}" >> $GITHUB_OUTPUT
           echo "KEY_COMPOSER_CACHE=${KEY_COMPOSER_CACHE}" >> $GITHUB_OUTPUT
           echo "VENDOR_CACHE=${VENDOR_CACHE}" >> $GITHUB_OUTPUT
-          # npm 関連
-          PATH_NPM_CACHE="${ROOT_CACHE}/npm"
-          HASH_NPM_LOCK="${{ hashFiles('./src/client/package-lock.json') }}"
-          KEY_NPM_CACHE="npm-${HASH_NPM_LOCK}"
-          NPM_CACHE="${PATH_NPM_CACHE}/${KEY_NPM_CACHE}.tar.gz"
-          echo "PATH_NPM_CACHE=${PATH_NPM_CACHE}" >> $GITHUB_OUTPUT
-          echo "KEY_NPM_CACHE=${KEY_NPM_CACHE}" >> $GITHUB_OUTPUT
-          echo "NPM_CACHE=${NPM_CACHE}" >> $GITHUB_OUTPUT
           # テスト用 DB 関連
           PATH_DATABASE_CACHE="${ROOT_CACHE}/db"
           HASH_DATABASE="${{ hashFiles('./src/server/database/migrations/*.php') }}"
@@ -126,15 +87,8 @@ jobs:
           path: ${{ steps.define-variables.outputs.PATH_SERVER_DOCKER_CACHE }}
           key: ${{ steps.define-variables.outputs.KEY_SERVER_DOCKER_CACHE }}
 
-      - name: Cache client docker image
-        id: cache-client-docker-image
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.define-variables.outputs.PATH_CLIENT_DOCKER_CACHE }}
-          key: ${{ steps.define-variables.outputs.KEY_CLIENT_DOCKER_CACHE }}
-
       - name: Login to Docker Hub
-        if: steps.cache-server-docker-image.outputs.cache-hit != 'true' || steps.cache-client-docker-image.outputs.cache-hit != 'true'
+        if: steps.cache-server-docker-image.outputs.cache-hit != 'true'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -156,24 +110,13 @@ jobs:
         if: steps.cache-server-docker-image.outputs.cache-hit == 'true'
         run: gunzip -c ${{ steps.define-variables.outputs.SERVER_DOCKER_CACHE }} | docker load
 
-      - name: Build client image
-        if: steps.cache-client-docker-image.outputs.cache-hit != 'true'
-        run: |
-          docker build -t isekai-journey-admin-node:22 -f ./docker/node/Dockerfile.ci ./docker/node
-          mkdir -p ${{ steps.define-variables.outputs.PATH_CLIENT_DOCKER_CACHE }}
-          docker save isekai-journey-admin-node:22 | gzip > ${{ steps.define-variables.outputs.CLIENT_DOCKER_CACHE }}
-
-      - name: Load client image
-        if: steps.cache-client-docker-image.outputs.cache-hit == 'true'
-        run: gunzip -c ${{ steps.define-variables.outputs.CLIENT_DOCKER_CACHE }} | docker load
-
       - name: Copy .env
         run: |
           cp src/server/.env.example src/server/.env
           cp src/server/.env.testing.example src/server/.env.testing
 
       - name: Run Container
-        run: docker compose up -d php node
+        run: docker compose up -d php
 
       - name: Cache composer
         id: cache-composer
@@ -192,20 +135,6 @@ jobs:
       - name: Move vendor
         if: steps.cache-composer.outputs.cache-hit == 'true'
         run: tar -xzf ${{ steps.define-variables.outputs.VENDOR_CACHE }}
-
-      - name: Cache npm
-        id: cache-npm
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.define-variables.outputs.PATH_NPM_CACHE }}
-          key: ${{ steps.define-variables.outputs.KEY_NPM_CACHE }}
-
-      - name: Npm install
-        if: steps.cache-npm.outputs.cache-hit != 'true'
-        run: |
-          docker exec ${{ steps.define-variables.outputs.CLIENT_CONTAINER }} npm i
-          mkdir -p ${{ steps.define-variables.outputs.PATH_NPM_CACHE }}
-          tar -czf ${{ steps.define-variables.outputs.NPM_CACHE }} src/client/node_modules
 
       - name: Check Generate code has diff
         run: |


### PR DESCRIPTION
## 概要

サーバーとクライアントが分かれたので CI の setup 処理もサーバーとクライアントで分けた

## やったこと

- 既存 setup.yaml からクライアントとサーバーの処理を分割
- 必要な setup だけを使うように修正
- サーバーで Dockerfile.ci が更新されたときにイメージのビルドが走らないようになっていたのを修正

## やってないこと

🍐 

## 関連

resolve #233 
