### PR TITLE
不要な org を削除

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yaml
@@ -7,7 +7,7 @@ labels:
   - "bug"
 
 projects:
-  - "sayuprc/isekai-journey"
+  - "isekai-journey"
 
 assignees:
   - "sayuprc"

--- a/.github/ISSUE_TEMPLATE/02-feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/02-feature-request.yaml
@@ -7,7 +7,7 @@ labels:
   - "feature-request"
 
 projects:
-  - "sayuprc/isekai-journey"
+  - "isekai-journey"
 
 assignees:
   - "sayuprc"

--- a/.github/ISSUE_TEMPLATE/99-others.yaml
+++ b/.github/ISSUE_TEMPLATE/99-others.yaml
@@ -4,7 +4,7 @@ description: 上記に当てはまらない場合
 title: "[Other]: "
 
 projects:
-  - "sayuprc/isekai-journey"
+  - "isekai-journey"
 
 assignees:
   - "sayuprc"


### PR DESCRIPTION
## 概要

issue テンプレートのプロジェクトに不要な org があったので削除した

## やったこと

- `sayuprc/isekai-journey` を `isekai-journey` に変更

## やってないこと

<!-- この PR でやってないことを箇条書きで記載する -->

## 関連

<!-- 関連する ISSUE や PR へのリンクがあれば記載する -->
