### PR TITLE
クライアントの共通部分を整備

### DIFF
--- a/src/client/src/components/Welcome.astro
+++ b/src/client/src/components/Welcome.astro
@@ -125,7 +125,6 @@ import background from '../assets/background.svg';
 		font-weight: normal;
 		background: linear-gradient(14deg, #d83333 0%, #f041ff 100%);
 		background-clip: text;
-		background-clip: text;
 		-webkit-text-fill-color: transparent;
 	}
 

--- a/src/client/src/layouts/Layout.astro
+++ b/src/client/src/layouts/Layout.astro
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="ja">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width" />

--- a/src/client/src/layouts/Layout.astro
+++ b/src/client/src/layouts/Layout.astro
@@ -1,3 +1,7 @@
+---
+import '../styles/reset.css';
+---
+
 <!doctype html>
 <html lang="ja">
   <head>

--- a/src/client/src/layouts/Layout.astro
+++ b/src/client/src/layouts/Layout.astro
@@ -1,5 +1,19 @@
 ---
 import '../styles/reset.css';
+
+interface Props {
+  pageTitle: string;
+}
+
+const { pageTitle } = Astro.props;
+
+const siteTitle = '管理画面';
+
+const generateTitle = (title: string): string => {
+  return title ? `${title} | ${siteTitle}` : siteTitle;
+};
+
+const title = generateTitle(pageTitle);
 ---
 
 <!doctype html>
@@ -9,7 +23,7 @@ import '../styles/reset.css';
     <meta name="viewport" content="width=device-width" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="generator" content={Astro.generator} />
-    <title>Astro Basics</title>
+    <title>{title}</title>
   </head>
   <body>
     <slot />

--- a/src/client/src/styles/reset.css
+++ b/src/client/src/styles/reset.css
@@ -1,0 +1,13 @@
+* {
+  padding: 0;
+  margin: 0;
+}
+
+a {
+  text-decoration: none;
+}
+
+ul,
+ol {
+  list-style: none;
+}

--- a/src/client/stylelint.config.mjs
+++ b/src/client/stylelint.config.mjs
@@ -27,8 +27,5 @@ export default {
     'selector-class-pattern': [
       '^[a-z][a-zA-Z0-9-]+$',
     ],
-    'max-line-length': [
-      120,
-    ],
   },
 };


### PR DESCRIPTION
## 概要

言語設定やサイトタイトルの動的生成を行った

## やったこと

- reset.css の導入
  - 簡易的なので後ほど必要に応じて修正予定
- HTML の言語設定(`ja` にした)
- `<title>` に渡す値を動的に設定できるように
- stylelint で不明なエラーがあったので削除

## やってないこと

- eslint/stylelint のエラー対応

## その他

コンポーネントスクリプトでマルチバイト文字を 6 文字以上含むコメントを書くと stylistic が parse エラーになるためコメントを消している
これは別途どうするか検討して対応する予定