### PR TITLE
Feature テストで Mock をやめてトランザクション管理するように修正

### DIFF
--- a/src/server/tests/Feature/Api/Creator/CreateCreatorTest.php
+++ b/src/server/tests/Feature/Api/Creator/CreateCreatorTest.php
@@ -4,41 +4,18 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Api\Creator;
 
-use Creator\Domain\Models\Creator;
-use Creator\Domain\Models\CreatorName;
-use Creator\Domain\Models\CreatorRepositoryInterface;
 use Creator\Route\CreatorRouteMap;
-use Mockery;
-use Mockery\MockInterface;
 use PHPUnit\Framework\Attributes\Test;
+use Tests\Support\FileRepositoryTransaction;
 use Tests\TestCase;
 
 class CreateCreatorTest extends TestCase
 {
-    // TODO モックやめる
-    private CreatorRepositoryInterface&MockInterface $repository;
-
-    public function setUp(): void
-    {
-        parent::setUp();
-
-        $this->repository = Mockery::mock(CreatorRepositoryInterface::class);
-
-        $this->app->bind(CreatorRepositoryInterface::class, fn (): CreatorRepositoryInterface => $this->repository);
-    }
+    use FileRepositoryTransaction;
 
     #[Test]
     public function canCreate(): void
     {
-        $this->repository->shouldReceive('findByName')
-            ->with(Mockery::on(fn (CreatorName $arg): bool => $arg->value === 'ヰ世界情緒'))
-            ->andReturnNull()
-            ->once();
-
-        $this->repository->shouldReceive('insert')
-            ->with(Mockery::on(fn (Creator $arg): bool => $arg->creatorName->value === 'ヰ世界情緒'))
-            ->once();
-
         $this->postJson(route(CreatorRouteMap::Create), [
             'creatorName' => 'ヰ世界情緒',
         ])->assertStatus(200)

--- a/src/server/tests/Feature/Api/Creator/DeleteCreatorTest.php
+++ b/src/server/tests/Feature/Api/Creator/DeleteCreatorTest.php
@@ -4,36 +4,29 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Api\Creator;
 
+use Creator\DebugInfrastructures\FileCreatorRepository;
+use Creator\Domain\Models\Creator;
 use Creator\Domain\Models\CreatorId;
-use Creator\Domain\Models\CreatorRepositoryInterface;
+use Creator\Domain\Models\CreatorName;
 use Creator\Route\CreatorRouteMap;
-use Mockery;
-use Mockery\MockInterface;
 use PHPUnit\Framework\Attributes\Test;
+use Tests\Support\FileRepositoryTransaction;
 use Tests\TestCase;
 
 class DeleteCreatorTest extends TestCase
 {
-    // TODO モックやめる
-    private CreatorRepositoryInterface&MockInterface $repository;
-
-    public function setUp(): void
-    {
-        parent::setUp();
-
-        $this->repository = Mockery::mock(CreatorRepositoryInterface::class);
-
-        $this->app->bind(CreatorRepositoryInterface::class, fn (): CreatorRepositoryInterface => $this->repository);
-    }
+    use FileRepositoryTransaction;
 
     #[Test]
     public function canDelete(): void
     {
         $uuid = $this->generateUuid();
 
-        $this->repository->shouldReceive('delete')
-            ->with(Mockery::on(fn (CreatorId $arg) => $arg->value === $uuid))
-            ->once();
+        $this->factory(
+            FileCreatorRepository::class,
+            $uuid,
+            new Creator(new CreatorId($uuid), new CreatorName('クリエイター'))
+        );
 
         $this->delete(route(CreatorRouteMap::Delete, $uuid))
             ->assertStatus(204);

--- a/src/server/tests/Feature/Api/Creator/GetCreatorTest.php
+++ b/src/server/tests/Feature/Api/Creator/GetCreatorTest.php
@@ -4,42 +4,29 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Api\Creator;
 
+use Creator\DebugInfrastructures\FileCreatorRepository;
 use Creator\Domain\Models\Creator;
 use Creator\Domain\Models\CreatorId;
 use Creator\Domain\Models\CreatorName;
-use Creator\Domain\Models\CreatorRepositoryInterface;
 use Creator\Route\CreatorRouteMap;
-use Mockery;
-use Mockery\MockInterface;
 use PHPUnit\Framework\Attributes\Test;
+use Tests\Support\FileRepositoryTransaction;
 use Tests\TestCase;
 
 class GetCreatorTest extends TestCase
 {
-    // TODO モックやめる
-    private CreatorRepositoryInterface&MockInterface $repository;
-
-    public function setUp(): void
-    {
-        parent::setUp();
-
-        $this->repository = Mockery::mock(CreatorRepositoryInterface::class);
-
-        $this->app->bind(CreatorRepositoryInterface::class, fn (): CreatorRepositoryInterface => $this->repository);
-    }
+    use FileRepositoryTransaction;
 
     #[Test]
     public function found(): void
     {
         $uuid = $this->generateUuid();
 
-        $this->repository->shouldReceive('find')
-            ->with(Mockery::on(fn (CreatorId $arg) => $arg->value === $uuid))
-            ->andReturn(new Creator(
-                new CreatorId($uuid),
-                new CreatorName('ヰ世界情緒'),
-            ))
-            ->once();
+        $this->factory(
+            FileCreatorRepository::class,
+            $uuid,
+            new Creator(new CreatorId($uuid), new CreatorName('ヰ世界情緒'))
+        );
 
         $this->get(route(CreatorRouteMap::Get, $uuid))
             ->assertStatus(200)
@@ -55,11 +42,6 @@ class GetCreatorTest extends TestCase
     public function notFound(): void
     {
         $uuid = $this->generateUuid();
-
-        $this->repository->shouldReceive('find')
-            ->with(Mockery::on(fn (CreatorId $arg) => $arg->value === $uuid))
-            ->andReturnNull()
-            ->once();
 
         $this->get(route(CreatorRouteMap::Get, $uuid))
             ->assertStatus(404);

--- a/src/server/tests/Feature/Api/Creator/ListCreatorTest.php
+++ b/src/server/tests/Feature/Api/Creator/ListCreatorTest.php
@@ -4,43 +4,25 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Api\Creator;
 
+use Creator\DebugInfrastructures\FileCreatorRepository;
 use Creator\Domain\Models\Creator;
 use Creator\Domain\Models\CreatorId;
 use Creator\Domain\Models\CreatorName;
-use Creator\Domain\Models\CreatorRepositoryInterface;
 use Creator\Route\CreatorRouteMap;
-use Mockery;
-use Mockery\MockInterface;
 use PHPUnit\Framework\Attributes\Test;
+use Tests\Support\FileRepositoryTransaction;
 use Tests\TestCase;
 
 class ListCreatorTest extends TestCase
 {
-    // TODO モックやめる
-    private CreatorRepositoryInterface&MockInterface $repository;
-
-    public function setUp(): void
-    {
-        parent::setUp();
-
-        $this->repository = Mockery::mock(CreatorRepositoryInterface::class);
-
-        $this->app->bind(CreatorRepositoryInterface::class, fn (): CreatorRepositoryInterface => $this->repository);
-    }
+    use FileRepositoryTransaction;
 
     #[Test]
     public function showList(): void
     {
         $uuid = $this->generateUuid();
 
-        $this->repository->shouldReceive('all')
-            ->andReturn([
-                new Creator(
-                    new CreatorId($uuid),
-                    new CreatorName('ヰ世界情緒'),
-                ),
-            ])
-            ->once();
+        $this->factory(FileCreatorRepository::class, $uuid, new Creator(new CreatorId($uuid), new CreatorName('ヰ世界情緒')));
 
         $this->get(route(CreatorRouteMap::List))
             ->assertStatus(200)
@@ -57,10 +39,6 @@ class ListCreatorTest extends TestCase
     #[Test]
     public function showEmptyList(): void
     {
-        $this->repository->shouldReceive('all')
-            ->andReturn([])
-            ->once();
-
         $this->get(route(CreatorRouteMap::List))
             ->assertStatus(200)
             ->assertJson(['creators' => []]);

--- a/src/server/tests/Feature/Api/Creator/UpdateCreatorTest.php
+++ b/src/server/tests/Feature/Api/Creator/UpdateCreatorTest.php
@@ -4,49 +4,29 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Api\Creator;
 
+use Creator\DebugInfrastructures\FileCreatorRepository;
 use Creator\Domain\Models\Creator;
 use Creator\Domain\Models\CreatorId;
 use Creator\Domain\Models\CreatorName;
-use Creator\Domain\Models\CreatorRepositoryInterface;
 use Creator\Route\CreatorRouteMap;
-use Mockery;
-use Mockery\MockInterface;
 use PHPUnit\Framework\Attributes\Test;
+use Tests\Support\FileRepositoryTransaction;
 use Tests\TestCase;
 
 class UpdateCreatorTest extends TestCase
 {
-    // TODO モックをやめる
-    private CreatorRepositoryInterface&MockInterface $repository;
-
-    public function setUp(): void
-    {
-        parent::setUp();
-
-        $this->repository = Mockery::mock(CreatorRepositoryInterface::class);
-
-        $this->app->bind(CreatorRepositoryInterface::class, fn (): CreatorRepositoryInterface => $this->repository);
-    }
+    use FileRepositoryTransaction;
 
     #[Test]
     public function canUpdate(): void
     {
         $uuid = $this->generateUuid();
 
-        $this->repository->shouldReceive('findByName')
-            ->with(Mockery::on(fn (CreatorName $arg): bool => $arg->value === 'ヰ世界情緒'))
-            ->andReturnNull()
-            ->once();
-
-        $this->repository->shouldReceive('update')
-            ->with(
-                Mockery::on(
-                    fn (Creator $arg): bool => $arg->creatorId->value === $uuid
-                        && $arg->creatorName->value === 'ヰ世界情緒'
-                )
-            )
-            ->andReturn(new CreatorId($uuid))
-            ->once();
+        $this->factory(
+            FileCreatorRepository::class,
+            $uuid,
+            new Creator(new CreatorId($uuid), new CreatorName('クリエイター'))
+        );
 
         $this->putJson(route(CreatorRouteMap::Update, $uuid), [
             'creatorName' => 'ヰ世界情緒',

--- a/src/server/tests/Feature/Api/SongType/CreateSongTypeTest.php
+++ b/src/server/tests/Feature/Api/SongType/CreateSongTypeTest.php
@@ -4,44 +4,18 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Api\SongType;
 
-use Mockery;
-use Mockery\MockInterface;
 use PHPUnit\Framework\Attributes\Test;
-use SongType\Domain\Models\SongType;
-use SongType\Domain\Models\SongTypeName;
-use SongType\Domain\Models\SongTypeRepositoryInterface;
 use SongType\Route\SongTypeRouteMap;
+use Tests\Support\FileRepositoryTransaction;
 use Tests\TestCase;
 
 class CreateSongTypeTest extends TestCase
 {
-    // TODO モックやめる
-    private MockInterface&SongTypeRepositoryInterface $repository;
-
-    public function setUp(): void
-    {
-        parent::setUp();
-
-        $this->repository = Mockery::mock(SongTypeRepositoryInterface::class);
-
-        $this->app->bind(SongTypeRepositoryInterface::class, fn (): SongTypeRepositoryInterface => $this->repository);
-    }
+    use FileRepositoryTransaction;
 
     #[Test]
     public function canCreate(): void
     {
-        $this->repository->shouldReceive('findByName')
-            ->with(Mockery::on(fn (SongTypeName $arg): bool => $arg->value === '楽曲種別'))
-            ->andReturnNull()
-            ->once();
-
-        $this->repository->shouldReceive('insert')
-            ->with(Mockery::on(
-                fn (SongType $arg): bool => $arg->songTypeName->value === '楽曲種別'
-                    && $arg->orderNo->value === 1
-            ))
-            ->once();
-
         $this->postJson(route(SongTypeRouteMap::Create), [
             'songTypeName' => '楽曲種別',
             'orderNo' => 1,

--- a/src/server/tests/Feature/Api/SongType/DeleteSongTypeTest.php
+++ b/src/server/tests/Feature/Api/SongType/DeleteSongTypeTest.php
@@ -4,36 +4,30 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Api\SongType;
 
-use Mockery;
-use Mockery\MockInterface;
 use PHPUnit\Framework\Attributes\Test;
+use SongType\DebugInfrastructures\FileSongTypeRepository;
+use SongType\Domain\Models\SongType;
 use SongType\Domain\Models\SongTypeId;
-use SongType\Domain\Models\SongTypeRepositoryInterface;
+use SongType\Domain\Models\SongTypeName;
 use SongType\Route\SongTypeRouteMap;
+use Support\Domain\ValueObjects\OrderNo;
+use Tests\Support\FileRepositoryTransaction;
 use Tests\TestCase;
 
 class DeleteSongTypeTest extends TestCase
 {
-    // TODO モックやめる
-    private MockInterface&SongTypeRepositoryInterface $repository;
-
-    public function setUp(): void
-    {
-        parent::setUp();
-
-        $this->repository = Mockery::mock(SongTypeRepositoryInterface::class);
-
-        $this->app->bind(SongTypeRepositoryInterface::class, fn (): SongTypeRepositoryInterface => $this->repository);
-    }
+    use FileRepositoryTransaction;
 
     #[Test]
     public function canDelete(): void
     {
         $uuid = $this->generateUuid();
 
-        $this->repository->shouldReceive('delete')
-            ->with(Mockery::on(fn (SongTypeId $arg) => $arg->value === $uuid))
-            ->once();
+        $this->factory(
+            FileSongTypeRepository::class,
+            $uuid,
+            new SongType(new SongTypeId($uuid), new SongTypeName('オリジナル'), new OrderNo(1))
+        );
 
         $this->delete(route(SongTypeRouteMap::Delete, $uuid))
             ->assertStatus(204);

--- a/src/server/tests/Feature/Api/SongType/GetSongTypeTest.php
+++ b/src/server/tests/Feature/Api/SongType/GetSongTypeTest.php
@@ -4,51 +4,37 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Api\SongType;
 
-use Mockery;
-use Mockery\MockInterface;
 use PHPUnit\Framework\Attributes\Test;
+use SongType\DebugInfrastructures\FileSongTypeRepository;
 use SongType\Domain\Models\SongType;
 use SongType\Domain\Models\SongTypeId;
 use SongType\Domain\Models\SongTypeName;
-use SongType\Domain\Models\SongTypeRepositoryInterface;
 use SongType\Route\SongTypeRouteMap;
 use Support\Domain\ValueObjects\OrderNo;
+use Tests\Support\FileRepositoryTransaction;
 use Tests\TestCase;
 
 class GetSongTypeTest extends TestCase
 {
-    // TODO モックやめる
-    private MockInterface&SongTypeRepositoryInterface $repository;
-
-    public function setUp(): void
-    {
-        parent::setUp();
-
-        $this->repository = Mockery::mock(SongTypeRepositoryInterface::class);
-
-        $this->app->bind(SongTypeRepositoryInterface::class, fn (): SongTypeRepositoryInterface => $this->repository);
-    }
+    use FileRepositoryTransaction;
 
     #[Test]
     public function found(): void
     {
         $uuid = $this->generateUuid();
 
-        $this->repository->shouldReceive('find')
-            ->with(Mockery::on(fn (SongTypeId $arg) => $arg->value === $uuid))
-            ->andReturn(new SongType(
-                new SongTypeId($uuid),
-                new SongTypeName('楽曲種別1'),
-                new OrderNo(1),
-            ))
-            ->once();
+        $this->factory(
+            FileSongTypeRepository::class,
+            $uuid,
+            new SongType(new SongTypeId($uuid), new SongTypeName('オリジナル'), new OrderNo(1))
+        );
 
         $this->get(route(SongTypeRouteMap::Get, $uuid))
             ->assertStatus(200)
             ->assertJson([
                 'songType' => [
                     'songTypeId' => $uuid,
-                    'songTypeName' => '楽曲種別1',
+                    'songTypeName' => 'オリジナル',
                     'orderNo' => 1,
                 ],
             ]);
@@ -58,11 +44,6 @@ class GetSongTypeTest extends TestCase
     public function notFound(): void
     {
         $uuid = $this->generateUuid();
-
-        $this->repository->shouldReceive('find')
-            ->with(Mockery::on(fn (SongTypeId $arg) => $arg->value === $uuid))
-            ->andReturnNull()
-            ->once();
 
         $this->get(route(SongTypeRouteMap::Get, $uuid))
             ->assertStatus(404);

--- a/src/server/tests/Feature/Api/SongType/ListSongTypeTest.php
+++ b/src/server/tests/Feature/Api/SongType/ListSongTypeTest.php
@@ -4,63 +4,49 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Api\SongType;
 
-use Mockery;
-use Mockery\MockInterface;
 use PHPUnit\Framework\Attributes\Test;
+use SongType\DebugInfrastructures\FileSongTypeRepository;
 use SongType\Domain\Models\SongType;
 use SongType\Domain\Models\SongTypeId;
 use SongType\Domain\Models\SongTypeName;
-use SongType\Domain\Models\SongTypeRepositoryInterface;
 use SongType\Route\SongTypeRouteMap;
 use Support\Domain\ValueObjects\OrderNo;
+use Tests\Support\FileRepositoryTransaction;
 use Tests\TestCase;
 
 class ListSongTypeTest extends TestCase
 {
-    // TODO モックやめる
-    private MockInterface&SongTypeRepositoryInterface $repository;
-
-    public function setUp(): void
-    {
-        parent::setUp();
-
-        $this->repository = Mockery::mock(SongTypeRepositoryInterface::class);
-
-        $this->app->bind(SongTypeRepositoryInterface::class, fn (): SongTypeRepositoryInterface => $this->repository);
-    }
+    use FileRepositoryTransaction;
 
     #[Test]
     public function showList(): void
     {
-        $uuid = $this->generateUuid();
+        $uuid1 = $this->generateUuid();
+        $uuid2 = $this->generateUuid();
 
-        $this->repository->shouldReceive('all')
-            ->andReturn([
-                new SongType(
-                    new SongTypeId($uuid),
-                    new SongTypeName('楽曲種別1'),
-                    new OrderNo(1),
-                ),
-                new SongType(
-                    new SongTypeId($uuid),
-                    new SongTypeName('楽曲種別2'),
-                    new OrderNo(2),
-                ),
-            ])
-            ->once();
+        $this->factory(
+            FileSongTypeRepository::class,
+            $uuid1,
+            new SongType(new SongTypeId($uuid1), new SongTypeName('オリジナル'), new OrderNo(1))
+        );
+        $this->factory(
+            FileSongTypeRepository::class,
+            $uuid2,
+            new SongType(new SongTypeId($uuid2), new SongTypeName('カバー'), new OrderNo(2))
+        );
 
         $this->get(route(SongTypeRouteMap::List))
             ->assertStatus(200)
             ->assertJson([
                 'songTypes' => [
                     [
-                        'songTypeId' => $uuid,
-                        'songTypeName' => '楽曲種別1',
+                        'songTypeId' => $uuid1,
+                        'songTypeName' => 'オリジナル',
                         'orderNo' => 1,
                     ],
                     [
-                        'songTypeId' => $uuid,
-                        'songTypeName' => '楽曲種別2',
+                        'songTypeId' => $uuid2,
+                        'songTypeName' => 'カバー',
                         'orderNo' => 2,
                     ],
                 ],
@@ -70,10 +56,6 @@ class ListSongTypeTest extends TestCase
     #[Test]
     public function showEmptyList(): void
     {
-        $this->repository->shouldReceive('all')
-            ->andReturn([])
-            ->once();
-
         $this->get(route(SongTypeRouteMap::List))
             ->assertStatus(200)
             ->assertJson(['songTypes' => []]);

--- a/src/server/tests/Feature/Api/SongType/UpdateSongTypeTest.php
+++ b/src/server/tests/Feature/Api/SongType/UpdateSongTypeTest.php
@@ -4,59 +4,39 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Api\SongType;
 
-use Mockery;
-use Mockery\MockInterface;
 use PHPUnit\Framework\Attributes\Test;
+use SongType\DebugInfrastructures\FileSongTypeRepository;
 use SongType\Domain\Models\SongType;
 use SongType\Domain\Models\SongTypeId;
 use SongType\Domain\Models\SongTypeName;
-use SongType\Domain\Models\SongTypeRepositoryInterface;
 use SongType\Route\SongTypeRouteMap;
+use Support\Domain\ValueObjects\OrderNo;
+use Tests\Support\FileRepositoryTransaction;
 use Tests\TestCase;
 
 class UpdateSongTypeTest extends TestCase
 {
-    // TODO モックをやめる
-    private MockInterface&SongTypeRepositoryInterface $repository;
-
-    public function setUp(): void
-    {
-        parent::setUp();
-
-        $this->repository = Mockery::mock(SongTypeRepositoryInterface::class);
-
-        $this->app->bind(SongTypeRepositoryInterface::class, fn (): SongTypeRepositoryInterface => $this->repository);
-    }
+    use FileRepositoryTransaction;
 
     #[Test]
     public function canUpdate(): void
     {
         $uuid = $this->generateUuid();
 
-        $this->repository->shouldReceive('findByName')
-            ->with(Mockery::on(fn (SongTypeName $arg): bool => $arg->value === '楽曲種別'))
-            ->andReturnNull()
-            ->once();
-
-        $this->repository->shouldReceive('update')
-            ->with(
-                Mockery::on(
-                    fn (SongType $arg): bool => $arg->songTypeId->value === $uuid
-                        && $arg->songTypeName->value === '楽曲種別'
-                        && $arg->orderNo->value === 1
-                )
-            )
-            ->andReturn(new SongTypeId($uuid))
-            ->once();
+        $this->factory(
+            FileSongTypeRepository::class,
+            $uuid,
+            new SongType(new SongTypeId($uuid), new SongTypeName('オリジナル'), new OrderNo(2))
+        );
 
         $this->putJson(route(SongTypeRouteMap::Update, $uuid), [
-            'songTypeName' => '楽曲種別',
+            'songTypeName' => 'カバー',
             'orderNo' => 1,
         ])->assertStatus(200)
             ->assertJson([
                 'songType' => [
                     'songTypeId' => $uuid,
-                    'songTypeName' => '楽曲種別',
+                    'songTypeName' => 'カバー',
                     'orderNo' => 1,
                 ],
             ]);

--- a/src/server/tests/Support/FileRepositoryTransaction.php
+++ b/src/server/tests/Support/FileRepositoryTransaction.php
@@ -70,7 +70,7 @@ trait FileRepositoryTransaction
 
     private function getDirectoryName(): string
     {
-        return self::FILE_DIR . '/' . new ReflectionClass($this)->getName() . '/' . $this->name();
+        return str_replace('\\', '/', self::FILE_DIR . '/' . new ReflectionClass($this)->getName() . '/' . $this->name());
     }
 
     private function factory(string $repository, int|string $key, mixed $value): void

--- a/src/server/tests/Support/FileRepositoryTransaction.php
+++ b/src/server/tests/Support/FileRepositoryTransaction.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Support;
+
+use FilesystemIterator;
+use Mockery;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use ReflectionClass;
+use RuntimeException;
+use SplFileInfo;
+use Support\Contracts\ConfigInterface;
+use Support\Repository\FileStore;
+
+trait FileRepositoryTransaction
+{
+    private const string FILE_DIR = __DIR__ . '/../../storage/app/tests';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $config = Mockery::mock(ConfigInterface::class);
+
+        $directory = $this->getDirectoryName();
+
+        $config->shouldReceive('getString')
+            ->with('debug.file.path')
+            ->andReturn($directory);
+
+        $config->shouldReceive('getString')
+            ->with('openapi.path')
+            ->andReturn(config()->string('openapi.path'));
+
+        $this->app->bind(ConfigInterface::class, fn () => $config);
+
+        if (! file_exists($directory)) {
+            mkdir($directory, 0777, true);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        $this->deleteRecursive($this->getDirectoryName());
+    }
+
+    private function deleteRecursive(string $directory): void
+    {
+        /** @var SplFileInfo $file */
+        foreach (
+            new RecursiveIteratorIterator(
+                new RecursiveDirectoryIterator(
+                    $directory,
+                    FilesystemIterator::SKIP_DOTS | FilesystemIterator::CURRENT_AS_FILEINFO
+                ),
+                RecursiveIteratorIterator::LEAVES_ONLY
+            ) as $file
+        ) {
+            unlink($file->getRealPath());
+        }
+
+        if (file_exists($directory)) {
+            rmdir($directory);
+        }
+    }
+
+    private function getDirectoryName(): string
+    {
+        return self::FILE_DIR . '/' . new ReflectionClass($this)->getName() . '/' . $this->name();
+    }
+
+    private function factory(string $repository, int|string $key, mixed $value): void
+    {
+        /** @var FileStore $store */
+        $store = $this->app->make(FileStore::class);
+
+        $store->put($this->getFileName($repository), $key, $value);
+    }
+
+    private function getAll(string $repository): array
+    {
+        /** @var FileStore $store */
+        $store = $this->app->make(FileStore::class);
+
+        return $store->getAll($this->getFileName($repository));
+    }
+
+    private function getFileName(string $repository): string
+    {
+        $fileName = new ReflectionClass($repository)->getConstant('FILE_NAME');
+
+        if ($fileName === false || $fileName === '') {
+            throw new RuntimeException('リポジトリに FILE_NAME 定数が設定されていません。');
+        }
+
+        return $this->getDirectoryName() . '/' . $fileName;
+    }
+}


### PR DESCRIPTION
## 概要

Feature で Mock を使っていたがそれをやめてトランザクション管理するようにした
<!-- この PR の概要を記載する -->

## やったこと

- Mock をやめてトランザクション管理できるように修正
- 既存テスト書き換え

<!-- この PR でやったことを箇条書きで記載する -->

## やってないこと

<!-- この PR でやってないことを箇条書きで記載する -->

## 関連

<!-- 関連する ISSUE や PR へのリンクがあれば記載する -->
