### PR TITLE
ConfigInterface をリファクタリング

### DIFF
--- a/src/server/app/Providers/AppServiceProvider.php
+++ b/src/server/app/Providers/AppServiceProvider.php
@@ -6,7 +6,7 @@ namespace App\Providers;
 
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\ServiceProvider;
-use Support\Infrastructures\Config;
+use Support\Infrastructures\Config\Config;
 
 class AppServiceProvider extends ServiceProvider
 {

--- a/src/server/app/Providers/Domain/SupportServiceProvider.php
+++ b/src/server/app/Providers/Domain/SupportServiceProvider.php
@@ -11,7 +11,7 @@ use Support\Contracts\TransactionInterface;
 use Support\Contracts\UuidGeneratorInterface;
 use Support\DebugInfrastructures\NopTransaction;
 use Support\Infrastructures\Clock;
-use Support\Infrastructures\Config;
+use Support\Infrastructures\Config\Config;
 use Support\Infrastructures\Mapper;
 use Support\Infrastructures\UuidGenerator;
 

--- a/src/server/packages/Support/Contracts/ConfigInterface.php
+++ b/src/server/packages/Support/Contracts/ConfigInterface.php
@@ -10,7 +10,7 @@ interface ConfigInterface
 
     public function getNullableString(string $key, ?string $default = null): ?string;
 
-    public function getNullableInt(string $key, ?int $default = null): ?int;
+    public function getNullableInteger(string $key, ?int $default = null): ?int;
 
-    public function getNullableBool(string $key, ?bool $default = null): ?bool;
+    public function getNullableBoolean(string $key, ?bool $default = null): ?bool;
 }

--- a/src/server/packages/Support/Contracts/ConfigInterface.php
+++ b/src/server/packages/Support/Contracts/ConfigInterface.php
@@ -7,4 +7,10 @@ namespace Support\Contracts;
 interface ConfigInterface
 {
     public function getString(string $key): string;
+
+    public function getNullableString(string $key, ?string $default = null): ?string;
+
+    public function getNullableInt(string $key, ?int $default = null): ?int;
+
+    public function getNullableBool(string $key, ?bool $default = null): ?bool;
 }

--- a/src/server/packages/Support/Contracts/ConfigInterface.php
+++ b/src/server/packages/Support/Contracts/ConfigInterface.php
@@ -6,5 +6,5 @@ namespace Support\Contracts;
 
 interface ConfigInterface
 {
-    public function getString(string $key, ?string $default = null): string;
+    public function getString(string $key): string;
 }

--- a/src/server/packages/Support/Infrastructures/Config.php
+++ b/src/server/packages/Support/Infrastructures/Config.php
@@ -23,6 +23,48 @@ class Config implements ConfigInterface
         return $value;
     }
 
+    /**
+     * @throws Exception
+     */
+    public function getNullableString(string $key, ?string $default = null): ?string
+    {
+        $value = $this->get($key, $default);
+
+        if (! is_null($value) && ! is_string($value)) {
+            throw new Exception(sprintf('Config value for key "%s" is not a string or null', $key));
+        }
+
+        return $value;
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function getNullableInt(string $key, ?int $default = null): ?int
+    {
+        $value = $this->get($key, $default);
+
+        if (! is_null($value) && ! is_int($value)) {
+            throw new Exception(sprintf('Config value for key "%s" is not a int or null', $key));
+        }
+
+        return $value;
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function getNullableBool(string $key, ?bool $default = null): ?bool
+    {
+        $value = $this->get($key, $default);
+
+        if (! is_null($value) && ! is_bool($value)) {
+            throw new Exception(sprintf('Config value for key "%s" is not a bool or null', $key));
+        }
+
+        return $value;
+    }
+
     private function get(string $key, mixed $default = null): mixed
     {
         return config($key, $default);

--- a/src/server/packages/Support/Infrastructures/Config.php
+++ b/src/server/packages/Support/Infrastructures/Config.php
@@ -45,7 +45,7 @@ class Config implements ConfigInterface
         $value = $this->get($key, $default);
 
         if (! is_null($value) && ! is_int($value)) {
-            throw new Exception(sprintf('Config value for key "%s" is not a int or null', $key));
+            throw new Exception(sprintf('Config value for key "%s" is not an integer or null', $key));
         }
 
         return $value;
@@ -59,7 +59,7 @@ class Config implements ConfigInterface
         $value = $this->get($key, $default);
 
         if (! is_null($value) && ! is_bool($value)) {
-            throw new Exception(sprintf('Config value for key "%s" is not a bool or null', $key));
+            throw new Exception(sprintf('Config value for key "%s" is not a boolean or null', $key));
         }
 
         return $value;

--- a/src/server/packages/Support/Infrastructures/Config.php
+++ b/src/server/packages/Support/Infrastructures/Config.php
@@ -12,9 +12,9 @@ class Config implements ConfigInterface
     /**
      * @throws Exception
      */
-    public function getString(string $key, ?string $default = null): string
+    public function getString(string $key): string
     {
-        $value = $this->get($key, $default);
+        $value = $this->get($key);
 
         if (! is_string($value)) {
             throw new Exception(sprintf('Config value for key "%s" is not a string', $key));

--- a/src/server/packages/Support/Infrastructures/Config.php
+++ b/src/server/packages/Support/Infrastructures/Config.php
@@ -40,7 +40,7 @@ class Config implements ConfigInterface
     /**
      * @throws Exception
      */
-    public function getNullableInt(string $key, ?int $default = null): ?int
+    public function getNullableInteger(string $key, ?int $default = null): ?int
     {
         $value = $this->get($key, $default);
 
@@ -54,7 +54,7 @@ class Config implements ConfigInterface
     /**
      * @throws Exception
      */
-    public function getNullableBool(string $key, ?bool $default = null): ?bool
+    public function getNullableBoolean(string $key, ?bool $default = null): ?bool
     {
         $value = $this->get($key, $default);
 

--- a/src/server/packages/Support/Infrastructures/Config/Config.php
+++ b/src/server/packages/Support/Infrastructures/Config/Config.php
@@ -2,64 +2,63 @@
 
 declare(strict_types=1);
 
-namespace Support\Infrastructures;
+namespace Support\Infrastructures\Config;
 
-use Exception;
 use Support\Contracts\ConfigInterface;
 
 class Config implements ConfigInterface
 {
     /**
-     * @throws Exception
+     * @throws UnexpectedValueException
      */
     public function getString(string $key): string
     {
         $value = $this->get($key);
 
         if (! is_string($value)) {
-            throw new Exception(sprintf('Config value for key "%s" is not a string', $key));
+            throw new UnexpectedValueException(sprintf('Config value for key "%s" is not a string', $key));
         }
 
         return $value;
     }
 
     /**
-     * @throws Exception
+     * @throws UnexpectedValueException
      */
     public function getNullableString(string $key, ?string $default = null): ?string
     {
         $value = $this->get($key, $default);
 
         if (! is_null($value) && ! is_string($value)) {
-            throw new Exception(sprintf('Config value for key "%s" is not a string or null', $key));
+            throw new UnexpectedValueException(sprintf('Config value for key "%s" is not a string or null', $key));
         }
 
         return $value;
     }
 
     /**
-     * @throws Exception
+     * @throws UnexpectedValueException
      */
     public function getNullableInteger(string $key, ?int $default = null): ?int
     {
         $value = $this->get($key, $default);
 
         if (! is_null($value) && ! is_int($value)) {
-            throw new Exception(sprintf('Config value for key "%s" is not an integer or null', $key));
+            throw new UnexpectedValueException(sprintf('Config value for key "%s" is not an integer or null', $key));
         }
 
         return $value;
     }
 
     /**
-     * @throws Exception
+     * @throws UnexpectedValueException
      */
     public function getNullableBoolean(string $key, ?bool $default = null): ?bool
     {
         $value = $this->get($key, $default);
 
         if (! is_null($value) && ! is_bool($value)) {
-            throw new Exception(sprintf('Config value for key "%s" is not a boolean or null', $key));
+            throw new UnexpectedValueException(sprintf('Config value for key "%s" is not a boolean or null', $key));
         }
 
         return $value;

--- a/src/server/packages/Support/Infrastructures/Config/UnexpectedValueException.php
+++ b/src/server/packages/Support/Infrastructures/Config/UnexpectedValueException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Support\Infrastructures\Config;
+
+use Exception;
+
+class UnexpectedValueException extends Exception
+{
+}

--- a/src/server/tests/Support/FileRepositoryTransaction.php
+++ b/src/server/tests/Support/FileRepositoryTransaction.php
@@ -12,7 +12,7 @@ use ReflectionClass;
 use RuntimeException;
 use SplFileInfo;
 use Support\Contracts\ConfigInterface;
-use Support\Infrastructures\Config;
+use Support\Infrastructures\Config\Config;
 use Support\Repository\FileStore;
 
 trait FileRepositoryTransaction


### PR DESCRIPTION
## 概要

一貫性と利便性を向上させた

<!-- この PR の概要を記載する -->

## やったこと

- `getString()` のデフォルト値を廃止
- nullable な string/bool/int を取得するメソッドを追加

<!-- この PR でやったことを箇条書きで記載する -->

## やってないこと

<!-- この PR でやってないことを箇条書きで記載する -->

## 関連

<!-- 関連する ISSUE や PR へのリンクがあれば記載する -->
