### PR TITLE
データの保存を `Repository::save()` に置き換え

### DIFF
--- a/src/server/packages/Creator/Application/Interactors/CreateInteractor.php
+++ b/src/server/packages/Creator/Application/Interactors/CreateInteractor.php
@@ -34,7 +34,7 @@ readonly class CreateInteractor implements CreateUseCaseInterface
                 return new Err("Creator name already exists: {$inputData->creatorName}");
             }
 
-            $this->repository->insert($creator);
+            $this->repository->save($creator);
 
             return new Ok(new CreateOutputData($creator));
         });

--- a/src/server/packages/Creator/Application/Interactors/UpdateInteractor.php
+++ b/src/server/packages/Creator/Application/Interactors/UpdateInteractor.php
@@ -34,7 +34,7 @@ readonly class UpdateInteractor implements UpdateUseCaseInterface
                 return new Err("Creator name already exists: {$inputData->creatorName}");
             }
 
-            $this->repository->update($creator);
+            $this->repository->save($creator);
 
             return new Ok(new UpdateOutputData($creator));
         });

--- a/src/server/packages/Creator/DebugInfrastructures/FileCreatorRepository.php
+++ b/src/server/packages/Creator/DebugInfrastructures/FileCreatorRepository.php
@@ -51,16 +51,11 @@ readonly class FileCreatorRepository implements CreatorRepositoryInterface
         return null;
     }
 
-    public function insert(Creator $creator): void
-    {
-        $this->store->put($this->filePath, $creator->creatorId->value, $creator);
-    }
-
-    public function update(Creator $creator): CreatorId
+    public function save(Creator $creator): Creator
     {
         $this->store->put($this->filePath, $creator->creatorId->value, $creator);
 
-        return $creator->creatorId;
+        return $creator;
     }
 
     public function delete(CreatorId $creatorId): void

--- a/src/server/packages/Creator/Domain/Models/CreatorRepositoryInterface.php
+++ b/src/server/packages/Creator/Domain/Models/CreatorRepositoryInterface.php
@@ -15,9 +15,7 @@ interface CreatorRepositoryInterface
 
     public function findByName(CreatorName $creatorName): ?Creator;
 
-    public function insert(Creator $creator): void;
-
-    public function update(Creator $creator): CreatorId;
+    public function save(Creator $creator): Creator;
 
     public function delete(CreatorId $creatorId): void;
 }

--- a/src/server/packages/JourneyLog/Application/Interactors/CreateInteractor.php
+++ b/src/server/packages/JourneyLog/Application/Interactors/CreateInteractor.php
@@ -27,6 +27,6 @@ readonly class CreateInteractor implements CreateUseCaseInterface
             $inputData->journeyLogLinks
         );
 
-        $this->repository->insert($journeyLog);
+        $this->repository->save($journeyLog);
     }
 }

--- a/src/server/packages/JourneyLog/Application/Interactors/EditInteractor.php
+++ b/src/server/packages/JourneyLog/Application/Interactors/EditInteractor.php
@@ -28,6 +28,6 @@ readonly class EditInteractor implements EditUseCaseInterface
             $inputData->journeyLogLinks,
         );
 
-        $this->repository->update($journeyLog);
+        $this->repository->save($journeyLog);
     }
 }

--- a/src/server/packages/JourneyLog/DebugInfrastructures/FileJourneyLogRepository.php
+++ b/src/server/packages/JourneyLog/DebugInfrastructures/FileJourneyLogRepository.php
@@ -39,16 +39,11 @@ readonly class FileJourneyLogRepository implements JourneyLogRepositoryInterface
         return $this->store->get($this->filePath, $journeyLogId->value);
     }
 
-    public function insert(JourneyLog $journeyLog): void
-    {
-        $this->store->put($this->filePath, $journeyLog->journeyLogId->value, $journeyLog);
-    }
-
-    public function update(JourneyLog $journeyLog): JourneyLogId
+    public function save(JourneyLog $journeyLog): JourneyLog
     {
         $this->store->put($this->filePath, $journeyLog->journeyLogId->value, $journeyLog);
 
-        return $journeyLog->journeyLogId;
+        return $journeyLog;
     }
 
     public function delete(JourneyLogId $journeyLogId): void

--- a/src/server/packages/JourneyLog/Domain/Models/JourneyLogRepositoryInterface.php
+++ b/src/server/packages/JourneyLog/Domain/Models/JourneyLogRepositoryInterface.php
@@ -13,9 +13,7 @@ interface JourneyLogRepositoryInterface
 
     public function find(JourneyLogId $journeyLogId): ?JourneyLog;
 
-    public function insert(JourneyLog $journeyLog): void;
-
-    public function update(JourneyLog $journeyLog): JourneyLogId;
+    public function save(JourneyLog $journeyLog): JourneyLog;
 
     public function delete(JourneyLogId $journeyLogId): void;
 }

--- a/src/server/packages/JourneyLogLinkType/Application/Interactors/CreateInteractor.php
+++ b/src/server/packages/JourneyLogLinkType/Application/Interactors/CreateInteractor.php
@@ -21,6 +21,6 @@ readonly class CreateInteractor implements CreateUseCaseInterface
     {
         $journeyLogLinkType = $this->factory->create($inputData->journeyLogLinkTypeName, $inputData->orderNo);
 
-        $this->repository->insert($journeyLogLinkType);
+        $this->repository->save($journeyLogLinkType);
     }
 }

--- a/src/server/packages/JourneyLogLinkType/Application/Interactors/EditInteractor.php
+++ b/src/server/packages/JourneyLogLinkType/Application/Interactors/EditInteractor.php
@@ -25,6 +25,6 @@ readonly class EditInteractor implements EditUseCaseInterface
             $inputData->orderNo,
         );
 
-        $this->repository->update($journeyLogLinkType);
+        $this->repository->save($journeyLogLinkType);
     }
 }

--- a/src/server/packages/JourneyLogLinkType/DebugInfrastructures/FileJourneyLogLinkTypeRepository.php
+++ b/src/server/packages/JourneyLogLinkType/DebugInfrastructures/FileJourneyLogLinkTypeRepository.php
@@ -39,14 +39,11 @@ readonly class FileJourneyLogLinkTypeRepository implements JourneyLogLinkTypeRep
         return $this->store->get($this->filePath, $journeyLogLinkTypeId->value);
     }
 
-    public function insert(JourneyLogLinkType $journeyLogLinkType): void
+    public function save(JourneyLogLinkType $journeyLogLinkType): JourneyLogLinkType
     {
         $this->store->put($this->filePath, $journeyLogLinkType->journeyLogLinkTypeId->value, $journeyLogLinkType);
-    }
 
-    public function update(JourneyLogLinkType $journeyLogLinkType): void
-    {
-        $this->store->put($this->filePath, $journeyLogLinkType->journeyLogLinkTypeId->value, $journeyLogLinkType);
+        return $journeyLogLinkType;
     }
 
     public function delete(JourneyLogLinkTypeId $journeyLogLinkTypeId): void

--- a/src/server/packages/JourneyLogLinkType/Domain/Models/JourneyLogLinkTypeRepositoryInterface.php
+++ b/src/server/packages/JourneyLogLinkType/Domain/Models/JourneyLogLinkTypeRepositoryInterface.php
@@ -13,9 +13,7 @@ interface JourneyLogLinkTypeRepositoryInterface
 
     public function find(JourneyLogLinkTypeId $journeyLogLinkTypeId): ?JourneyLogLinkType;
 
-    public function insert(JourneyLogLinkType $journeyLogLinkType): void;
-
-    public function update(JourneyLogLinkType $journeyLogLinkType): void;
+    public function save(JourneyLogLinkType $journeyLogLinkType): JourneyLogLinkType;
 
     public function delete(JourneyLogLinkTypeId $journeyLogLinkTypeId): void;
 }

--- a/src/server/packages/Performer/Application/Interactors/CreateInteractor.php
+++ b/src/server/packages/Performer/Application/Interactors/CreateInteractor.php
@@ -34,7 +34,7 @@ readonly class CreateInteractor implements CreateUseCaseInterface
                 return new Err("Performer name already exists: {$inputData->performerName}");
             }
 
-            $this->repository->insert($performer);
+            $this->repository->save($performer);
 
             return new Ok(new CreateOutputData($performer));
         });

--- a/src/server/packages/Performer/Application/Interactors/UpdateInteractor.php
+++ b/src/server/packages/Performer/Application/Interactors/UpdateInteractor.php
@@ -34,7 +34,7 @@ readonly class UpdateInteractor implements UpdateUseCaseInterface
                 return new Err("Performer name already exists: {$inputData->performerName}");
             }
 
-            $this->repository->update($performer);
+            $this->repository->save($performer);
 
             return new Ok(new UpdateOutputData($performer));
         });

--- a/src/server/packages/Performer/DebugInfrastructures/FilePerformerRepository.php
+++ b/src/server/packages/Performer/DebugInfrastructures/FilePerformerRepository.php
@@ -48,16 +48,11 @@ readonly class FilePerformerRepository implements PerformerRepositoryInterface
         return null;
     }
 
-    public function insert(Performer $performer): void
-    {
-        $this->store->put($this->filePath, $performer->performerId->value, $performer);
-    }
-
-    public function update(Performer $performer): PerformerId
+    public function save(Performer $performer): Performer
     {
         $this->store->put($this->filePath, $performer->performerId->value, $performer);
 
-        return $performer->performerId;
+        return $performer;
     }
 
     public function delete(PerformerId $performerId): void

--- a/src/server/packages/Performer/Domain/Models/PerformerRepositoryInterface.php
+++ b/src/server/packages/Performer/Domain/Models/PerformerRepositoryInterface.php
@@ -15,9 +15,7 @@ interface PerformerRepositoryInterface
 
     public function findByName(PerformerName $performerName): ?Performer;
 
-    public function insert(Performer $performer): void;
-
-    public function update(Performer $performer): PerformerId;
+    public function save(Performer $performer): Performer;
 
     public function delete(PerformerId $performerId): void;
 }

--- a/src/server/packages/Song/Application/Interactors/CreateInteractor.php
+++ b/src/server/packages/Song/Application/Interactors/CreateInteractor.php
@@ -30,6 +30,6 @@ readonly class CreateInteractor implements CreateUseCaseInterface
             $inputData->arrangers,
         );
 
-        $this->repository->insert($song);
+        $this->repository->save($song);
     }
 }

--- a/src/server/packages/Song/DebugInfrastructures/FileSongRepository.php
+++ b/src/server/packages/Song/DebugInfrastructures/FileSongRepository.php
@@ -33,8 +33,10 @@ readonly class FileSongRepository implements SongRepositoryInterface
         return array_values($this->store->getAll($this->filePath));
     }
 
-    public function insert(Song $song): void
+    public function save(Song $song): Song
     {
         $this->store->put($this->filePath, $song->songId->value, $song);
+
+        return $song;
     }
 }

--- a/src/server/packages/Song/Domain/Models/SongRepositoryInterface.php
+++ b/src/server/packages/Song/Domain/Models/SongRepositoryInterface.php
@@ -11,5 +11,5 @@ interface SongRepositoryInterface
      */
     public function all(): array;
 
-    public function insert(Song $song): void;
+    public function save(Song $song): Song;
 }

--- a/src/server/packages/SongType/Application/Interactors/CreateInteractor.php
+++ b/src/server/packages/SongType/Application/Interactors/CreateInteractor.php
@@ -34,7 +34,7 @@ readonly class CreateInteractor implements CreateUseCaseInterface
                 return new Err("Song type already exists: {$inputData->songTypeName}");
             }
 
-            $this->repository->insert($songType);
+            $this->repository->save($songType);
 
             return new Ok(new CreateOutputData($songType));
         });

--- a/src/server/packages/SongType/Application/Interactors/UpdateInteractor.php
+++ b/src/server/packages/SongType/Application/Interactors/UpdateInteractor.php
@@ -34,7 +34,7 @@ readonly class UpdateInteractor implements UpdateUseCaseInterface
                 return new Err("Song type already exists: {$inputData->songTypeId}");
             }
 
-            $this->repository->update($songType);
+            $this->repository->save($songType);
 
             return new Ok(new UpdateOutputData($songType));
         });

--- a/src/server/packages/SongType/DebugInfrastructures/FileSongTypeRepository.php
+++ b/src/server/packages/SongType/DebugInfrastructures/FileSongTypeRepository.php
@@ -51,16 +51,11 @@ readonly class FileSongTypeRepository implements SongTypeRepositoryInterface
         return null;
     }
 
-    public function insert(SongType $songType): void
-    {
-        $this->store->put($this->filePath, $songType->songTypeId->value, $songType);
-    }
-
-    public function update(SongType $songType): SongTypeId
+    public function save(SongType $songType): SongType
     {
         $this->store->put($this->filePath, $songType->songTypeId->value, $songType);
 
-        return $songType->songTypeId;
+        return $songType;
     }
 
     public function delete(SongTypeId $songTypeId): void

--- a/src/server/packages/SongType/Domain/Models/SongTypeRepositoryInterface.php
+++ b/src/server/packages/SongType/Domain/Models/SongTypeRepositoryInterface.php
@@ -15,9 +15,7 @@ interface SongTypeRepositoryInterface
 
     public function findByName(SongTypeName $songTypeName): ?SongType;
 
-    public function insert(SongType $songType): void;
-
-    public function update(SongType $songType): SongTypeId;
+    public function save(SongType $songType): SongType;
 
     public function delete(SongTypeId $songTypeId): void;
 }

--- a/src/server/packages/User/Application/Interactors/CreateInteractor.php
+++ b/src/server/packages/User/Application/Interactors/CreateInteractor.php
@@ -33,7 +33,7 @@ readonly class CreateInteractor implements CreateUseCaseInterface
 
             $user = $this->factory->create($inputData->email, $inputData->plainPassword);
 
-            $this->repository->insert($user);
+            $this->repository->save($user);
 
             return new Ok(new CreateOutputData($user));
         });

--- a/src/server/packages/User/Application/Interactors/LoginInteractor.php
+++ b/src/server/packages/User/Application/Interactors/LoginInteractor.php
@@ -30,7 +30,7 @@ readonly class LoginInteractor implements LoginUseCaseInterface
             $refreshToken = $this->refreshTokenFactory->create($inputData->userId);
             $accessToken = $this->accessTokenFactory->create($refreshToken->refreshTokenId->value);
 
-            $this->refreshTokenRepository->insert($refreshToken);
+            $this->refreshTokenRepository->save($refreshToken);
 
             return new Ok(new LoginOutputData($accessToken, $refreshToken));
         });

--- a/src/server/packages/User/DebugInfrastructures/FileRefreshTokenRepository.php
+++ b/src/server/packages/User/DebugInfrastructures/FileRefreshTokenRepository.php
@@ -37,8 +37,10 @@ readonly class FileRefreshTokenRepository implements RefreshTokenRepositoryInter
             : $found;
     }
 
-    public function insert(RefreshToken $refreshToken): void
+    public function save(RefreshToken $refreshToken): RefreshToken
     {
         $this->store->put($this->filePath, $refreshToken->refreshTokenId->value, $refreshToken);
+
+        return $refreshToken;
     }
 }

--- a/src/server/packages/User/DebugInfrastructures/FileUserRepository.php
+++ b/src/server/packages/User/DebugInfrastructures/FileUserRepository.php
@@ -49,8 +49,10 @@ readonly class FileUserRepository implements UserRepositoryInterface
         return null;
     }
 
-    public function insert(User $user): void
+    public function save(User $user): User
     {
         $this->store->put($this->filePath, $user->userId->value, $user);
+
+        return $user;
     }
 }

--- a/src/server/packages/User/Domain/Models/Credential/RefreshToken/RefreshTokenRepositoryInterface.php
+++ b/src/server/packages/User/Domain/Models/Credential/RefreshToken/RefreshTokenRepositoryInterface.php
@@ -8,5 +8,5 @@ interface RefreshTokenRepositoryInterface
 {
     public function findActive(RefreshTokenId $refreshTokenId): ?RefreshToken;
 
-    public function insert(RefreshToken $refreshToken): void;
+    public function save(RefreshToken $refreshToken): RefreshToken;
 }

--- a/src/server/packages/User/Domain/Models/UserRepositoryInterface.php
+++ b/src/server/packages/User/Domain/Models/UserRepositoryInterface.php
@@ -10,5 +10,5 @@ interface UserRepositoryInterface
 
     public function findByEmail(Email $email): ?User;
 
-    public function insert(User $user): void;
+    public function save(User $user): User;
 }

--- a/src/server/tests/Unit/Creator/Application/Interactors/CreateInteractorTest.php
+++ b/src/server/tests/Unit/Creator/Application/Interactors/CreateInteractorTest.php
@@ -60,7 +60,7 @@ class CreateInteractorTest extends TestCase
 
         $this->factory->shouldReceive('create')
             ->with('クリエイター')
-            ->andReturn(new Creator(
+            ->andReturn($creator = new Creator(
                 new CreatorId('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'),
                 new CreatorName('クリエイター')
             ))
@@ -71,11 +71,12 @@ class CreateInteractorTest extends TestCase
             ->andreturn(false)
             ->once();
 
-        $this->repository->shouldReceive('insert')
+        $this->repository->shouldReceive('save')
             ->with(Mockery::on(
                 fn (Creator $arg): bool => $arg->creatorId->value === 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'
                     && $arg->creatorName->value === 'クリエイター'
             ))
+            ->andReturn($creator)
             ->once();
 
         $result = $this->interactor->handle(new CreateInputData('クリエイター'));

--- a/src/server/tests/Unit/Creator/Application/Interactors/UpdateInteractorTest.php
+++ b/src/server/tests/Unit/Creator/Application/Interactors/UpdateInteractorTest.php
@@ -60,7 +60,7 @@ class UpdateInteractorTest extends TestCase
 
         $this->factory->shouldReceive('reconstitute')
             ->with('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA', 'クリエイター')
-            ->andReturn(new Creator(
+            ->andReturn($creator = new Creator(
                 new CreatorId('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'),
                 new CreatorName('クリエイター')
             ))
@@ -71,12 +71,12 @@ class UpdateInteractorTest extends TestCase
             ->andReturn(false)
             ->once();
 
-        $this->repository->shouldReceive('update')
+        $this->repository->shouldReceive('save')
             ->with(Mockery::on(
                 fn (Creator $arg): bool => $arg->creatorId->value === 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'
                     && $arg->creatorName->value === 'クリエイター'
             ))
-            ->andReturn(new CreatorId('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'))
+            ->andReturn($creator)
             ->once();
 
         $result = $this->interactor->handle(new UpdateInputData('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA', 'クリエイター'));

--- a/src/server/tests/Unit/JourneyLog/Application/Interactors/CreateInteractorTest.php
+++ b/src/server/tests/Unit/JourneyLog/Application/Interactors/CreateInteractorTest.php
@@ -63,7 +63,7 @@ class CreateInteractorTest extends TestCase
                 1,
                 [],
             )
-            ->andReturn(new JourneyLog(
+            ->andReturn($journeyLog = new JourneyLog(
                 new JourneyLogId('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'),
                 new Story('story'),
                 new Period(new FromOn(new ImmutableDate('2019-12-08')), new ToOn(new ImmutableDate('2019-12-09'))),
@@ -72,7 +72,7 @@ class CreateInteractorTest extends TestCase
             ))
             ->once();
 
-        $this->repository->shouldReceive('insert')
+        $this->repository->shouldReceive('save')
             ->with(Mockery::on(
                 fn (JourneyLog $arg): bool => $arg->journeyLogId->value === 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'
                     && $arg->story->value === 'story'
@@ -81,6 +81,7 @@ class CreateInteractorTest extends TestCase
                     && $arg->orderNo->value === 1
                     && count($arg->journeyLogLinks) === 0
             ))
+            ->andReturn($journeyLog)
             ->once();
 
         $this->interactor->handle(new CreateInputData(
@@ -115,7 +116,7 @@ class CreateInteractorTest extends TestCase
                         && $args[1]->journeyLogLinkTypeId === 'CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC'
                 ),
             )
-            ->andReturn(new JourneyLog(
+            ->andReturn($journeyLog = new JourneyLog(
                 new JourneyLogId('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'),
                 new Story('story'),
                 new Period(new FromOn(new ImmutableDate('2019-12-08')), new ToOn(new ImmutableDate('2019-12-09'))),
@@ -139,7 +140,7 @@ class CreateInteractorTest extends TestCase
             ))
             ->once();
 
-        $this->repository->shouldReceive('insert')
+        $this->repository->shouldReceive('save')
             ->with(Mockery::on(
                 fn (JourneyLog $arg): bool => $arg->journeyLogId->value === 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'
                     && $arg->story->value === 'story'
@@ -158,6 +159,7 @@ class CreateInteractorTest extends TestCase
                     && $arg->journeyLogLinks[1]->orderNo->value === 2
                     && $arg->journeyLogLinks[1]->journeyLogLinkTypeId->value === 'CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC'
             ))
+            ->andReturn($journeyLog)
             ->once();
 
         $this->interactor->handle(new CreateInputData(

--- a/src/server/tests/Unit/JourneyLog/Application/Interactors/EditInteractorTest.php
+++ b/src/server/tests/Unit/JourneyLog/Application/Interactors/EditInteractorTest.php
@@ -64,7 +64,7 @@ class EditInteractorTest extends TestCase
                 1,
                 [],
             )
-            ->andReturn(new JourneyLog(
+            ->andReturn($journeyLog = new JourneyLog(
                 new JourneyLogId('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'),
                 new Story('story'),
                 new Period(new FromOn(new ImmutableDate('2019-12-08')), new ToOn(new ImmutableDate('2019-12-09'))),
@@ -73,7 +73,7 @@ class EditInteractorTest extends TestCase
             ))
             ->once();
 
-        $this->repository->shouldReceive('update')
+        $this->repository->shouldReceive('save')
             ->with(Mockery::on(
                 fn (JourneyLog $arg): bool => $arg->journeyLogId->value === 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'
                     && $arg->story->value === 'story'
@@ -82,7 +82,7 @@ class EditInteractorTest extends TestCase
                     && $arg->orderNo->value === 1
                     && count($arg->journeyLogLinks) === 0
             ))
-            ->andReturn(new JourneyLogId('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'))
+            ->andReturn($journeyLog)
             ->once();
 
         $this->interactor->handle(new EditInputData(
@@ -119,7 +119,7 @@ class EditInteractorTest extends TestCase
                         && $args[1]->journeyLogLinkTypeId === 'CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC'
                 ),
             )
-            ->andReturn(new JourneyLog(
+            ->andReturn($journeyLog = new JourneyLog(
                 new JourneyLogId('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'),
                 new Story('story'),
                 new Period(new FromOn(new ImmutableDate('2019-12-08')), new ToOn(new ImmutableDate('2019-12-09'))),
@@ -143,7 +143,7 @@ class EditInteractorTest extends TestCase
             ))
             ->once();
 
-        $this->repository->shouldReceive('update')
+        $this->repository->shouldReceive('save')
             ->with(Mockery::on(
                 fn (JourneyLog $arg): bool => $arg->journeyLogId->value === 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'
                     && $arg->story->value === 'story'
@@ -162,7 +162,7 @@ class EditInteractorTest extends TestCase
                     && $arg->journeyLogLinks[1]->orderNo->value === 2
                     && $arg->journeyLogLinks[1]->journeyLogLinkTypeId->value === 'CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC'
             ))
-            ->andReturn(new JourneyLogId('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'))
+            ->andReturn($journeyLog)
             ->once();
 
         $this->interactor->handle(new EditInputData(

--- a/src/server/tests/Unit/JourneyLogLinkType/Application/Interactors/CreateInteractorTest.php
+++ b/src/server/tests/Unit/JourneyLogLinkType/Application/Interactors/CreateInteractorTest.php
@@ -47,19 +47,20 @@ class CreateInteractorTest extends TestCase
     {
         $this->factory->shouldReceive('create')
             ->with('リンク', 1)
-            ->andReturn(new JourneyLogLinkType(
+            ->andReturn($journeyLogLinkType = new JourneyLogLinkType(
                 new JourneyLogLinkTypeId('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'),
                 new JourneyLogLinkTypeName('リンク'),
                 new OrderNo(1),
             ))
             ->once();
 
-        $this->repository->shouldReceive('insert')
+        $this->repository->shouldReceive('save')
             ->with(Mockery::on(
                 fn (JourneyLogLinkType $arg): bool => $arg->journeyLogLinkTypeId->value === 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'
                     && $arg->journeyLogLinkTypeName->value === 'リンク'
                     && $arg->orderNo->value === 1
             ))
+            ->andReturn($journeyLogLinkType)
             ->once();
 
         $this->interactor->handle(new CreateInputData(

--- a/src/server/tests/Unit/JourneyLogLinkType/Application/Interactors/EditInteractorTest.php
+++ b/src/server/tests/Unit/JourneyLogLinkType/Application/Interactors/EditInteractorTest.php
@@ -47,19 +47,20 @@ class EditInteractorTest extends TestCase
     {
         $this->factory->shouldReceive('reconstitute')
             ->with('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA', 'リンク', 1)
-            ->andReturn(new JourneyLogLinkType(
+            ->andReturn($journeyLogLinkType = new JourneyLogLinkType(
                 new JourneyLogLinkTypeId('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'),
                 new JourneyLogLinkTypeName('リンク'),
                 new OrderNo(1),
             ))
             ->once();
 
-        $this->repository->shouldReceive('update')
+        $this->repository->shouldReceive('save')
             ->with(Mockery::on(
                 fn (JourneyLogLinkType $arg): bool => $arg->journeyLogLinkTypeId->value === 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'
                     && $arg->journeyLogLinkTypeName->value === 'リンク'
                     && $arg->orderNo->value === 1
             ))
+            ->andReturn($journeyLogLinkType)
             ->once();
 
         $this->interactor->handle(new EditInputData(

--- a/src/server/tests/Unit/Performer/Application/Interactors/CreateInteractorTest.php
+++ b/src/server/tests/Unit/Performer/Application/Interactors/CreateInteractorTest.php
@@ -61,7 +61,7 @@ class CreateInteractorTest extends TestCase
 
         $this->factory->shouldReceive('create')
             ->with('共演者', 1)
-            ->andReturn(new Performer(
+            ->andReturn($performer = new Performer(
                 new PerformerId('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'),
                 new PerformerName('共演者'),
                 new OrderNo(1),
@@ -73,11 +73,12 @@ class CreateInteractorTest extends TestCase
             ->andreturn(false)
             ->once();
 
-        $this->repository->shouldReceive('insert')
+        $this->repository->shouldReceive('save')
             ->with(Mockery::on(
                 fn (Performer $arg): bool => $arg->performerId->value === 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'
                     && $arg->performerName->value === '共演者'
             ))
+            ->andReturn($performer)
             ->once();
 
         $result = $this->interactor->handle(new CreateInputData('共演者', 1));

--- a/src/server/tests/Unit/Performer/Application/Interactors/UpdateInteractorTest.php
+++ b/src/server/tests/Unit/Performer/Application/Interactors/UpdateInteractorTest.php
@@ -61,7 +61,7 @@ class UpdateInteractorTest extends TestCase
 
         $this->factory->shouldReceive('reconstitute')
             ->with('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA', '共演者2', 2)
-            ->andReturn(new Performer(
+            ->andReturn($performer = new Performer(
                 new PerformerId('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'),
                 new PerformerName('共演者2'),
                 new OrderNo(2)
@@ -76,13 +76,13 @@ class UpdateInteractorTest extends TestCase
             ->andReturn(false)
             ->once();
 
-        $this->repository->shouldReceive('update')
+        $this->repository->shouldReceive('save')
             ->with(Mockery::on(
                 fn (Performer $arg): bool => $arg->performerId->value === 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'
                     && $arg->performerName->value === '共演者2'
                     && $arg->orderNo->value === 2
             ))
-            ->andReturn(new PerformerId('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'))
+            ->andReturn($performer)
             ->once();
 
         $result = $this->interactor->handle(new UpdateInputData('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA', '共演者2', 2));

--- a/src/server/tests/Unit/Song/Application/Interactors/CreateInteractorTest.php
+++ b/src/server/tests/Unit/Song/Application/Interactors/CreateInteractorTest.php
@@ -81,7 +81,7 @@ class CreateInteractorTest extends TestCase
                 ),
             )
             ->andReturn(
-                new Song(
+                $song = new Song(
                     new SongId('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'),
                     new Title('title'),
                     new Description('description'),
@@ -110,7 +110,7 @@ class CreateInteractorTest extends TestCase
             )
             ->once();
 
-        $this->repository->shouldReceive('insert')
+        $this->repository->shouldReceive('save')
             ->with(Mockery::on(
                 fn (Song $arg): bool => $arg->songId->value === 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'
                     && $arg->title->value === 'title'
@@ -128,6 +128,7 @@ class CreateInteractorTest extends TestCase
                     && $arg->arrangers[0]->creatorId->value === 'EEEEEEEE-EEEE-EEEE-EEEE-EEEEEEEEEEEE'
                     && $arg->arrangers[0]->orderNo->value === 1
             ))
+            ->andReturn($song)
             ->once();
 
         $this->interactor->handle(new CreateInputData(

--- a/src/server/tests/Unit/SongType/Application/Interactors/CreateInteractorTest.php
+++ b/src/server/tests/Unit/SongType/Application/Interactors/CreateInteractorTest.php
@@ -61,7 +61,7 @@ class CreateInteractorTest extends TestCase
 
         $this->factory->shouldReceive('create')
             ->with('楽曲種別', 1)
-            ->andReturn(new SongType(
+            ->andReturn($songType = new SongType(
                 new SongTypeId('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'),
                 new SongTypeName('楽曲種別'),
                 new OrderNo(1),
@@ -73,12 +73,13 @@ class CreateInteractorTest extends TestCase
             ->andReturnFalse()
             ->once();
 
-        $this->repository->shouldReceive('insert')
+        $this->repository->shouldReceive('save')
             ->with(Mockery::on(
                 fn (SongType $arg): bool => $arg->songTypeId->value === 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'
                     && $arg->songTypeName->value === '楽曲種別'
                     && $arg->orderNo->value === 1
             ))
+            ->andReturn($songType)
             ->once();
 
         $result = $this->interactor->handle(new CreateInputData('楽曲種別', 1));

--- a/src/server/tests/Unit/SongType/Application/Interactors/UpdateInteractorTest.php
+++ b/src/server/tests/Unit/SongType/Application/Interactors/UpdateInteractorTest.php
@@ -61,7 +61,7 @@ class UpdateInteractorTest extends TestCase
 
         $this->factory->shouldReceive('reconstitute')
             ->with('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA', '楽曲種別', 1)
-            ->andReturn(new SongType(
+            ->andReturn($songType = new SongType(
                 new SongTypeId('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'),
                 new SongTypeName('楽曲種別'),
                 new OrderNo(1),
@@ -76,13 +76,13 @@ class UpdateInteractorTest extends TestCase
             ->andReturnFalse()
             ->once();
 
-        $this->repository->shouldReceive('update')
+        $this->repository->shouldReceive('save')
             ->with(Mockery::on(
                 fn (SongType $arg): bool => $arg->songTypeId->value === 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'
                     && $arg->songTypeName->value === '楽曲種別'
                     && $arg->orderNo->value === 1
             ))
-            ->andReturn(new SongTypeId('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'))
+            ->andReturn($songType)
             ->once();
 
         $result = $this->interactor->handle(new UpdateInputData('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA', '楽曲種別', 1));

--- a/src/server/tests/Unit/User/Application/Interactors/CreateInteractorTest.php
+++ b/src/server/tests/Unit/User/Application/Interactors/CreateInteractorTest.php
@@ -61,7 +61,7 @@ class CreateInteractorTest extends TestCase
         $this->factory->shouldReceive('create')
             ->with('example@example.com', 'plainpassword')
             ->andReturn(
-                new User(
+                $user = new User(
                     new UserId($uuid),
                     new Email('example@example.com'),
                     new HashedPassword('hashedpassword')
@@ -69,7 +69,7 @@ class CreateInteractorTest extends TestCase
             )
             ->once();
 
-        $this->repository->shouldReceive('insert')
+        $this->repository->shouldReceive('save')
             ->with(
                 Mockery::on(
                     fn (User $arg) => $arg->userId->value === $uuid
@@ -77,6 +77,7 @@ class CreateInteractorTest extends TestCase
                         && $arg->hashedPassword->value !== 'plainpassword'
                 )
             )
+            ->andReturn($user)
             ->once();
 
         $result = $this->getInstance()->handle(new CreateInputData('example@example.com', 'plainpassword'));

--- a/src/server/tests/Unit/User/Application/Interactors/LoginInteractorTest.php
+++ b/src/server/tests/Unit/User/Application/Interactors/LoginInteractorTest.php
@@ -59,7 +59,7 @@ class LoginInteractorTest extends TestCase
 
         $this->refreshTokenFactory->shouldReceive('create')
             ->with($userId)
-            ->andReturnUsing(fn () => new RefreshToken(
+            ->andReturn($refreshToken = new RefreshToken(
                 new RefreshTokenId('BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB'),
                 new UserId($userId),
                 new TokenValue('token'),
@@ -73,7 +73,7 @@ class LoginInteractorTest extends TestCase
             ->andReturn(new AccessToken(new Jwt('jwt')))
             ->once();
 
-        $this->refreshTokenRepository->shouldReceive('insert')
+        $this->refreshTokenRepository->shouldReceive('save')
             ->with(
                 Mockery::on(
                     fn (RefreshToken $arg) => $arg->refreshTokenId->value === 'BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB'
@@ -82,6 +82,7 @@ class LoginInteractorTest extends TestCase
                         && $arg->isEnabled($now)
                 )
             )
+            ->andReturn($refreshToken)
             ->once();
 
         $this->getInstance()->handle(new LoginInputData($userId));


### PR DESCRIPTION
## 概要

- `Repository::insert()`
- `Repository::update()`

を `Repository::save()` に置き換えた

<!-- この PR の概要を記載する -->

## やったこと

- `Repository::save()` に置き換え
- 利用個所とテストを修正

<!-- この PR でやったことを箇条書きで記載する -->

## やってないこと

<!-- この PR でやってないことを箇条書きで記載する -->

## 関連

resolve #337 

<!-- 関連する ISSUE や PR へのリンクがあれば記載する -->
