### PR TITLE
host.docker.internal を使えるように修正

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -12,6 +12,8 @@ services:
     ports:
       - 80:80
       - 443:443
+    extra_hosts:
+      - host.docker.internal:host-gateway
 
   php:
     image: isekai-terrarium-admin-php:8.4


### PR DESCRIPTION
## 概要

Docker Desktop をやめたので `host.docker.internal` が直接使えなくなっていた
host-gateway で設定すると使えるようになるので対応

<!-- この PR の概要を記載する -->

## やったこと

<!-- この PR でやったことを箇条書きで記載する -->

## やってないこと

<!-- この PR でやってないことを箇条書きで記載する -->

## 関連

<!-- 関連する ISSUE や PR へのリンクがあれば記載する -->
