### PR TITLE
Migrate GitHub Actions to use mise

### DIFF
--- a/.github/workflows/client-ci.yaml
+++ b/.github/workflows/client-ci.yaml
@@ -38,6 +38,9 @@ jobs:
       - name: Setup mise
         uses: jdx/mise-action@v2
 
+      - name: Setup mise config
+        run: cp mise.ci.toml mise.local.toml
+
       - name: Cache node modules
         id: cache-node-modules
         uses: actions/cache@v4

--- a/.github/workflows/client-ci.yaml
+++ b/.github/workflows/client-ci.yaml
@@ -9,7 +9,7 @@ on:
       - dev
 
 env:
-  WORKING_DIR: ./src/client
+  # WORKING_DIR: ./src/client (Managed by mise)
   MISE_ENV: ci
 
 jobs:

--- a/.github/workflows/client-ci.yaml
+++ b/.github/workflows/client-ci.yaml
@@ -9,7 +9,7 @@ on:
       - dev
 
 env:
-  # WORKING_DIR: ./src/client (Managed by mise)
+  WORKING_DIR: ./src/client
   MISE_ENV: ci
 
 jobs:

--- a/.github/workflows/client-ci.yaml
+++ b/.github/workflows/client-ci.yaml
@@ -10,6 +10,7 @@ on:
 
 env:
   WORKING_DIR: ./src/client
+  MISE_ENV: ci
 
 jobs:
   check:
@@ -34,6 +35,9 @@ jobs:
         with:
           node-version: ${{ matrix.node-versions }}
 
+      - name: Setup mise
+        uses: jdx/mise-action@v2
+
       - name: Cache node modules
         id: cache-node-modules
         uses: actions/cache@v4
@@ -43,13 +47,11 @@ jobs:
 
       - name: Install packages
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
-        working-directory: ${{ env.WORKING_DIR }}
-        run: npm i
+        run: mise run ci:npm:install
 
       - name: Check generate code has diff
-        working-directory: ${{ env.WORKING_DIR }}
         run: |
-          npm run generate:api
+          mise run ci:generate:client
           if [ -n "$(git status --porcelain)" ]; then
             echo "自動生成コードに差分があります"
             git status
@@ -57,12 +59,10 @@ jobs:
           fi
 
       - name: Run ESLint
-        working-directory: ${{ env.WORKING_DIR }}
-        run: npm run lint
+        run: mise run ci:lint
 
       - name: Run Stylelint
-        working-directory: ${{ env.WORKING_DIR }}
-        run: npm run style
+        run: mise run ci:style
 
       # - name: Run Build
       #   working-directory: ${{ env.WORKING_DIR }}

--- a/.github/workflows/server-ci.yaml
+++ b/.github/workflows/server-ci.yaml
@@ -25,6 +25,8 @@ env:
   OPENAPI_GENERATOR_CLI_DOCKER_KEY_PREFIX: docker-openapi-generator-cli-
   OPENAPI_GENERATOR_CLI_IMAGE: openapi-generator:7.18.0
 
+  MISE_ENV: ci
+
 jobs:
   setup:
     name: Setup server
@@ -40,6 +42,9 @@ jobs:
         with:
           ref: ${{ github.ref }}
           submodules: true
+
+      - name: Setup mise
+        uses: jdx/mise-action@v2
 
       - name: Define variables
         id: define-variables
@@ -108,15 +113,11 @@ jobs:
 
       - name: Composer install
         if: steps.cache-composer.outputs.cache-hit != 'true'
-        run: docker exec ${{ env.SERVER_CONTAINER }} composer install -n --prefer-dist
+        run: mise run ci:composer:install
 
       - name: Check generate code has diff
         run: |
-          docker run --rm -u ${UID}:${GID} -v ".:/local" ghcr.io/sayuprc/${{ env.OPENAPI_GENERATOR_CLI_IMAGE }} generate \
-            -i /local/src/contracts/generated/oas/openapi.yaml \
-            -g php \
-            -t /local/src/server/tools/openapi-generator/templates \
-            -o /local/src/server/Generated
+          mise run ci:generate:server
           if [ -n "$(git status --porcelain)" ]; then
             echo "自動生成コードに差分があります"
             git status
@@ -136,6 +137,9 @@ jobs:
         with:
           ref: ${{ github.ref }}
 
+      - name: Setup mise
+        uses: jdx/mise-action@v2
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -154,7 +158,7 @@ jobs:
           key: ${{ needs.setup.outputs.vendor-key }}
 
       - name: Check Layer
-        run: docker exec ${{ env.SERVER_CONTAINER }} composer arkitect
+        run: mise run arkitect
 
   ecs:
     needs: setup
@@ -168,6 +172,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
+
+      - name: Setup mise
+        uses: jdx/mise-action@v2
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -187,7 +194,7 @@ jobs:
           key: ${{ needs.setup.outputs.vendor-key }}
 
       - name: Run ecs
-        run: docker exec ${{ env.SERVER_CONTAINER }} composer ecs
+        run: mise run ecs
 
   phpstan:
     needs: setup
@@ -201,6 +208,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
+
+      - name: Setup mise
+        uses: jdx/mise-action@v2
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -220,7 +230,7 @@ jobs:
           key: ${{ needs.setup.outputs.vendor-key }}
 
       - name: Run PHPStan
-        run: docker exec ${{ env.SERVER_CONTAINER }} composer phpstan
+        run: mise run phpstan
 
   phpunit:
     needs: setup
@@ -235,6 +245,9 @@ jobs:
         with:
           ref: ${{ github.ref }}
           submodules: true
+
+      - name: Setup mise
+        uses: jdx/mise-action@v2
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -267,9 +280,7 @@ jobs:
 
       - name: Migrate
         if: steps.cache-database.outputs.cache-hit != 'true'
-        run: |
-          touch ${{ env.DATABASE_PATH }}
-          docker exec ${{ env.SERVER_CONTAINER }} bash -c "cd database/atlas; atlas schema apply --env "local" --var db_name=$(basename ${{ env.DATABASE_PATH }}) --auto-approve"
+        run: mise run ci:migrate
 
       - name: Run PHPUnit
-        run: docker exec ${{ env.SERVER_CONTAINER }} composer test-all
+        run: mise run test:all

--- a/.github/workflows/server-ci.yaml
+++ b/.github/workflows/server-ci.yaml
@@ -11,9 +11,9 @@ on:
 env:
   SERVER_DOCKER_PATH: /tmp/cache/docker/server
   SERVER_DOCKER_KEY_PREFIX: docker-server-
-  # SERVER_IMAGE: isekai-terrarium-admin-php:8.5 (Managed by mise)
+  SERVER_IMAGE: isekai-terrarium-admin-php:8.5
 
-  # SERVER_CONTAINER: isekai-terrarium-admin-php (Managed by mise)
+  SERVER_CONTAINER: isekai-terrarium-admin-php
 
   VENDOR_PATH: ./src/server/vendor
   VENDOR_KEY_PREFIX: composer-
@@ -23,7 +23,7 @@ env:
 
   OPENAPI_GENERATOR_CLI_DOCKER_PATH: /tmp/cache/docker/openapi-generator-cli
   OPENAPI_GENERATOR_CLI_DOCKER_KEY_PREFIX: docker-openapi-generator-cli-
-  # OPENAPI_GENERATOR_CLI_IMAGE: openapi-generator:7.18.0 (Managed by mise)
+  OPENAPI_GENERATOR_CLI_IMAGE: openapi-generator:7.18.0
 
   MISE_ENV: ci
 

--- a/.github/workflows/server-ci.yaml
+++ b/.github/workflows/server-ci.yaml
@@ -11,9 +11,9 @@ on:
 env:
   SERVER_DOCKER_PATH: /tmp/cache/docker/server
   SERVER_DOCKER_KEY_PREFIX: docker-server-
-  SERVER_IMAGE: isekai-terrarium-admin-php:8.5
+  # SERVER_IMAGE: isekai-terrarium-admin-php:8.5 (Managed by mise)
 
-  SERVER_CONTAINER: isekai-terrarium-admin-php
+  # SERVER_CONTAINER: isekai-terrarium-admin-php (Managed by mise)
 
   VENDOR_PATH: ./src/server/vendor
   VENDOR_KEY_PREFIX: composer-
@@ -23,7 +23,7 @@ env:
 
   OPENAPI_GENERATOR_CLI_DOCKER_PATH: /tmp/cache/docker/openapi-generator-cli
   OPENAPI_GENERATOR_CLI_DOCKER_KEY_PREFIX: docker-openapi-generator-cli-
-  OPENAPI_GENERATOR_CLI_IMAGE: openapi-generator:7.18.0
+  # OPENAPI_GENERATOR_CLI_IMAGE: openapi-generator:7.18.0 (Managed by mise)
 
   MISE_ENV: ci
 

--- a/.github/workflows/server-ci.yaml
+++ b/.github/workflows/server-ci.yaml
@@ -46,6 +46,9 @@ jobs:
       - name: Setup mise
         uses: jdx/mise-action@v2
 
+      - name: Setup mise config
+        run: cp mise.ci.toml mise.local.toml
+
       - name: Define variables
         id: define-variables
         run: |
@@ -140,6 +143,9 @@ jobs:
       - name: Setup mise
         uses: jdx/mise-action@v2
 
+      - name: Setup mise config
+        run: cp mise.ci.toml mise.local.toml
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -175,6 +181,9 @@ jobs:
 
       - name: Setup mise
         uses: jdx/mise-action@v2
+
+      - name: Setup mise config
+        run: cp mise.ci.toml mise.local.toml
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -212,6 +221,9 @@ jobs:
       - name: Setup mise
         uses: jdx/mise-action@v2
 
+      - name: Setup mise config
+        run: cp mise.ci.toml mise.local.toml
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -248,6 +260,9 @@ jobs:
 
       - name: Setup mise
         uses: jdx/mise-action@v2
+
+      - name: Setup mise config
+        run: cp mise.ci.toml mise.local.toml
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3

--- a/mise.ci.toml
+++ b/mise.ci.toml
@@ -1,6 +1,25 @@
+[env]
+SERVER_DOCKER_PATH = "/tmp/cache/docker/server"
+SERVER_DOCKER_KEY_PREFIX = "docker-server-"
+SERVER_IMAGE = "isekai-terrarium-admin-php:8.5"
+
+SERVER_CONTAINER = "isekai-terrarium-admin-php"
+
+VENDOR_PATH = "./src/server/vendor"
+VENDOR_KEY_PREFIX = "composer-"
+
+DATABASE_PATH = "./src/server/database/isekai_terrarium.sqlite"
+DATABASE_KEY_PREFIX = "database-"
+
+OPENAPI_GENERATOR_CLI_DOCKER_PATH = "/tmp/cache/docker/openapi-generator-cli"
+OPENAPI_GENERATOR_CLI_DOCKER_KEY_PREFIX = "docker-openapi-generator-cli-"
+OPENAPI_GENERATOR_CLI_IMAGE = "openapi-generator:7.18.0"
+
+WORKING_DIR = "./src/client"
+
 [tasks."ci:composer:install"]
 description = "CI環境でcomposerパッケージをインストールする"
-run = "docker exec {{vars.server_container}} composer install -n --prefer-dist"
+run = "docker exec ${SERVER_CONTAINER} composer install -n --prefer-dist"
 
 [tasks."ci:generate:server"]
 description = "CI環境でOASからサーバーのコードを生成する"
@@ -36,5 +55,5 @@ dir = "src/client"
 description = "CI環境でマイグレーションを実行する"
 run = '''
 touch ${DATABASE_PATH}
-docker exec {{vars.server_container}} bash -c "cd database/atlas; atlas schema apply --env local --var db_name=$(basename ${DATABASE_PATH}) --auto-approve"
+docker exec ${SERVER_CONTAINER} bash -c "cd database/atlas; atlas schema apply --env local --var db_name=$(basename ${DATABASE_PATH}) --auto-approve"
 '''

--- a/mise.ci.toml
+++ b/mise.ci.toml
@@ -1,0 +1,40 @@
+[tasks."ci:composer:install"]
+description = "CI環境でcomposerパッケージをインストールする"
+run = "docker exec {{vars.server_container}} composer install -n --prefer-dist"
+
+[tasks."ci:generate:server"]
+description = "CI環境でOASからサーバーのコードを生成する"
+run = '''
+docker run --rm -u $(id -u):$(id -g) -v ".:/local" ghcr.io/sayuprc/${OPENAPI_GENERATOR_CLI_IMAGE} generate \
+  -i /local/src/contracts/generated/oas/openapi.yaml \
+  -g php \
+  -t /local/src/server/tools/openapi-generator/templates \
+  -o /local/src/server/Generated
+'''
+
+[tasks."ci:npm:install"]
+description = "CI環境でnpmパッケージをインストールする"
+run = "npm ci"
+dir = "src/client"
+
+[tasks."ci:generate:client"]
+description = "CI環境でOASからクライアントのコードを生成する"
+run = "npm run generate:api"
+dir = "src/client"
+
+[tasks."ci:lint"]
+description = "CI環境でESLintを実行する"
+run = "npm run lint"
+dir = "src/client"
+
+[tasks."ci:style"]
+description = "CI環境でStylelintを実行する"
+run = "npm run style"
+dir = "src/client"
+
+[tasks."ci:migrate"]
+description = "CI環境でマイグレーションを実行する"
+run = '''
+touch ${DATABASE_PATH}
+docker exec {{vars.server_container}} bash -c "cd database/atlas; atlas schema apply --env local --var db_name=$(basename ${DATABASE_PATH}) --auto-approve"
+'''


### PR DESCRIPTION
This PR migrates the GitHub Actions workflows to use `mise` for executing tasks. 
It introduces a `mise.ci.toml` file to define tasks specific to the CI environment (e.g., tasks running directly on the host or with different Docker parameters).
Both `server-ci.yaml` and `client-ci.yaml` have been updated to install `mise` and use `mise run` for steps.

---
*PR created automatically by Jules for task [1506748820082807178](https://jules.google.com/task/1506748820082807178) started by @sayuprc*