### PR TITLE
Unit テスト拡充

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,15 @@
 - [API](https://github.com/sayuprc/isekai-terrarium-api)
 - [Contract](https://github.com/sayuprc/isekai-terrarium-contracts)
 - [Client](https://github.com/sayuprc/isekai-terrarium)
+
+## 開発
+
+### テストの実行
+
+```bash
+# 全てのテストを実行
+mise run test:all
+
+# Unitテストのみ実行
+mise run test:unit
+```

--- a/src/server/tests/Feature/Api/AdminUser/ListAdminUserTest.php
+++ b/src/server/tests/Feature/Api/AdminUser/ListAdminUserTest.php
@@ -37,30 +37,39 @@ class ListAdminUserTest extends TestCase
             )->toArray(),
         );
 
-        $this->withAuth()
-            ->get(route(AdminUserRouteMap::List))
-            ->assertStatus(200)
-            ->assertJson([
-                'adminUsers' => [
-                    [
-                        'adminUserId' => $uuid,
-                        'name' => 'コンソールユーザー',
-                        'email' => 'admin@example.com',
-                        'createdAt' => '2019-12-09T10:20:30+09:00',
-                        'role' => [
-                            'name' => Role::Console->getName(),
-                            'value' => Role::Console->value,
-                        ],
-                        'permissions' => [],
+        $response = $this->withAuth()
+            ->get(route(AdminUserRouteMap::List));
+
+        $response->assertStatus(200);
+
+        $json = $response->json();
+        $authUser = collect($json['adminUsers'])->firstWhere('email', 'root@example.com');
+
+        $response->assertExactJson([
+            'adminUsers' => [
+                [
+                    'adminUserId' => $uuid,
+                    'name' => 'コンソールユーザー',
+                    'email' => 'admin@example.com',
+                    'createdAt' => '2019-12-09T10:20:30+09:00',
+                    'role' => [
+                        'name' => Role::Console->getName(),
+                        'value' => Role::Console->value,
                     ],
-                    [
-                        'name' => 'テストユーザー',
-                        'role' => [
-                            'name' => Role::Privilege->getName(),
-                            'value' => Role::Privilege->value,
-                        ],
-                    ],
+                    'permissions' => [],
                 ],
-            ]);
+                [
+                    'adminUserId' => $authUser['adminUserId'],
+                    'name' => 'テストユーザー',
+                    'email' => 'root@example.com',
+                    'createdAt' => $authUser['createdAt'],
+                    'role' => [
+                        'name' => Role::Privilege->getName(),
+                        'value' => Role::Privilege->value,
+                    ],
+                    'permissions' => [],
+                ],
+            ],
+        ]);
     }
 }

--- a/src/server/tests/Feature/Api/Creator/CreateCreatorTest.php
+++ b/src/server/tests/Feature/Api/Creator/CreateCreatorTest.php
@@ -23,11 +23,14 @@ class CreateCreatorTest extends TestCase
             ->postJson(route(CreatorRouteMap::Create), [
                 'name' => 'ヰ世界情緒',
             ])->assertStatus(200)
-            ->assertJson(fn (AssertableJson $json) => $json
-                ->has('creator', fn (AssertableJson $json) => $json
-                    ->whereType('creatorId', 'string')
-                    ->where('name', 'ヰ世界情緒')
-                )
+            ->assertJson(
+                fn (AssertableJson $json) => $json
+                    ->has(
+                        'creator',
+                        fn (AssertableJson $json) => $json
+                            ->whereType('creatorId', 'string')
+                            ->where('name', 'ヰ世界情緒'),
+                    ),
             );
     }
 

--- a/src/server/tests/Feature/Api/Creator/CreateCreatorTest.php
+++ b/src/server/tests/Feature/Api/Creator/CreateCreatorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Feature\Api\Creator;
 
 use Creator\Route\CreatorRouteMap;
+use Illuminate\Testing\Fluent\AssertableJson;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\Feature\Api\WithAuth;
 use Tests\Support\FileRepositoryTransaction;
@@ -18,20 +19,16 @@ class CreateCreatorTest extends TestCase
     #[Test]
     public function canCreate(): void
     {
-        $response = $this->withAuth()
+        $this->withAuth()
             ->postJson(route(CreatorRouteMap::Create), [
                 'name' => 'ヰ世界情緒',
-            ]);
-
-        $response->assertStatus(200);
-        $creatorId = $response->json('creator.creatorId');
-
-        $response->assertExactJson([
-            'creator' => [
-                'creatorId' => $creatorId,
-                'name' => 'ヰ世界情緒',
-            ],
-        ]);
+            ])->assertStatus(200)
+            ->assertJson(fn (AssertableJson $json) => $json
+                ->has('creator', fn (AssertableJson $json) => $json
+                    ->whereType('creatorId', 'string')
+                    ->where('name', 'ヰ世界情緒')
+                )
+            );
     }
 
     #[Test]

--- a/src/server/tests/Feature/Api/Creator/CreateCreatorTest.php
+++ b/src/server/tests/Feature/Api/Creator/CreateCreatorTest.php
@@ -18,15 +18,20 @@ class CreateCreatorTest extends TestCase
     #[Test]
     public function canCreate(): void
     {
-        $this->withAuth()
+        $response = $this->withAuth()
             ->postJson(route(CreatorRouteMap::Create), [
                 'name' => 'ヰ世界情緒',
-            ])->assertStatus(200)
-            ->assertJson([
-                'creator' => [
-                    'name' => 'ヰ世界情緒',
-                ],
             ]);
+
+        $response->assertStatus(200);
+        $creatorId = $response->json('creator.creatorId');
+
+        $response->assertExactJson([
+            'creator' => [
+                'creatorId' => $creatorId,
+                'name' => 'ヰ世界情緒',
+            ],
+        ]);
     }
 
     #[Test]

--- a/src/server/tests/Feature/Api/Creator/DeleteCreatorTest.php
+++ b/src/server/tests/Feature/Api/Creator/DeleteCreatorTest.php
@@ -53,7 +53,7 @@ class DeleteCreatorTest extends TestCase
         $this->withAuth()
             ->delete(route(CreatorRouteMap::Delete, $creatorId))
             ->assertStatus(400)
-            ->assertJson([
+            ->assertExactJson([
                 'message' => 'このクリエイターは楽曲に使用されているため削除できません',
             ]);
     }

--- a/src/server/tests/Feature/Api/Creator/GetCreatorTest.php
+++ b/src/server/tests/Feature/Api/Creator/GetCreatorTest.php
@@ -28,7 +28,7 @@ class GetCreatorTest extends TestCase
         $this->withAuth()
             ->get(route(CreatorRouteMap::Get, $uuid))
             ->assertStatus(200)
-            ->assertJson([
+            ->assertExactJson([
                 'creator' => [
                     'creatorId' => $uuid,
                     'name' => 'ヰ世界情緒',

--- a/src/server/tests/Feature/Api/Creator/ListCreatorTest.php
+++ b/src/server/tests/Feature/Api/Creator/ListCreatorTest.php
@@ -28,7 +28,7 @@ class ListCreatorTest extends TestCase
         $this->withAuth()
             ->get(route(CreatorRouteMap::List))
             ->assertStatus(200)
-            ->assertJson([
+            ->assertExactJson([
                 'creators' => [
                     [
                         'creatorId' => $uuid,
@@ -44,6 +44,6 @@ class ListCreatorTest extends TestCase
         $this->withAuth()
             ->get(route(CreatorRouteMap::List))
             ->assertStatus(200)
-            ->assertJson(['creators' => []]);
+            ->assertExactJson(['creators' => []]);
     }
 }

--- a/src/server/tests/Feature/Api/Creator/UpdateCreatorTest.php
+++ b/src/server/tests/Feature/Api/Creator/UpdateCreatorTest.php
@@ -29,7 +29,7 @@ class UpdateCreatorTest extends TestCase
             ->putJson(route(CreatorRouteMap::Update, $uuid), [
                 'name' => 'ヰ世界情緒',
             ])->assertStatus(200)
-            ->assertJson([
+            ->assertExactJson([
                 'creator' => [
                     'creatorId' => $uuid,
                     'name' => 'ヰ世界情緒',

--- a/src/server/tests/Feature/Api/Performer/CreatePerformerTest.php
+++ b/src/server/tests/Feature/Api/Performer/CreatePerformerTest.php
@@ -23,12 +23,15 @@ class CreatePerformerTest extends TestCase
             ->postJson(route(PerformerRouteMap::Create), [
                 'name' => 'ヰ世界情緒',
             ])->assertStatus(200)
-            ->assertJson(fn (AssertableJson $json) => $json
-                ->has('performer', fn (AssertableJson $json) => $json
-                    ->whereType('performerId', 'string')
-                    ->where('name', 'ヰ世界情緒')
-                    ->where('orderNo', 10)
-                )
+            ->assertJson(
+                fn (AssertableJson $json) => $json
+                    ->has(
+                        'performer',
+                        fn (AssertableJson $json) => $json
+                            ->whereType('performerId', 'string')
+                            ->where('name', 'ヰ世界情緒')
+                            ->where('orderNo', 10),
+                    ),
             );
     }
 

--- a/src/server/tests/Feature/Api/Performer/CreatePerformerTest.php
+++ b/src/server/tests/Feature/Api/Performer/CreatePerformerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Api\Performer;
 
+use Illuminate\Testing\Fluent\AssertableJson;
 use Performer\Route\PerformerRouteMap;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\Feature\Api\WithAuth;
@@ -18,21 +19,17 @@ class CreatePerformerTest extends TestCase
     #[Test]
     public function canCreate(): void
     {
-        $response = $this->withAuth()
+        $this->withAuth()
             ->postJson(route(PerformerRouteMap::Create), [
                 'name' => 'ヰ世界情緒',
-            ]);
-
-        $response->assertStatus(200);
-        $performerId = $response->json('performer.performerId');
-
-        $response->assertExactJson([
-            'performer' => [
-                'performerId' => $performerId,
-                'name' => 'ヰ世界情緒',
-                'orderNo' => 10,
-            ],
-        ]);
+            ])->assertStatus(200)
+            ->assertJson(fn (AssertableJson $json) => $json
+                ->has('performer', fn (AssertableJson $json) => $json
+                    ->whereType('performerId', 'string')
+                    ->where('name', 'ヰ世界情緒')
+                    ->where('orderNo', 10)
+                )
+            );
     }
 
     #[Test]

--- a/src/server/tests/Feature/Api/Performer/CreatePerformerTest.php
+++ b/src/server/tests/Feature/Api/Performer/CreatePerformerTest.php
@@ -18,16 +18,21 @@ class CreatePerformerTest extends TestCase
     #[Test]
     public function canCreate(): void
     {
-        $this->withAuth()
+        $response = $this->withAuth()
             ->postJson(route(PerformerRouteMap::Create), [
                 'name' => 'ヰ世界情緒',
-            ])->assertStatus(200)
-            ->assertJson([
-                'performer' => [
-                    'name' => 'ヰ世界情緒',
-                    'orderNo' => 10,
-                ],
             ]);
+
+        $response->assertStatus(200);
+        $performerId = $response->json('performer.performerId');
+
+        $response->assertExactJson([
+            'performer' => [
+                'performerId' => $performerId,
+                'name' => 'ヰ世界情緒',
+                'orderNo' => 10,
+            ],
+        ]);
     }
 
     #[Test]

--- a/src/server/tests/Feature/Api/Performer/GetPerformerTest.php
+++ b/src/server/tests/Feature/Api/Performer/GetPerformerTest.php
@@ -28,7 +28,7 @@ class GetPerformerTest extends TestCase
         $this->withAuth()
             ->get(route(PerformerRouteMap::Get, $uuid))
             ->assertStatus(200)
-            ->assertJson([
+            ->assertExactJson([
                 'performer' => [
                     'performerId' => $uuid,
                     'name' => 'ヰ世界情緒',

--- a/src/server/tests/Feature/Api/Performer/ListPerformerTest.php
+++ b/src/server/tests/Feature/Api/Performer/ListPerformerTest.php
@@ -28,7 +28,7 @@ class ListPerformerTest extends TestCase
         $this->withAuth()
             ->get(route(PerformerRouteMap::List))
             ->assertStatus(200)
-            ->assertJson([
+            ->assertExactJson([
                 'performers' => [
                     [
                         'performerId' => $uuid,
@@ -45,6 +45,6 @@ class ListPerformerTest extends TestCase
         $this->withAuth()
             ->get(route(PerformerRouteMap::List))
             ->assertStatus(200)
-            ->assertJson(['performers' => []]);
+            ->assertExactJson(['performers' => []]);
     }
 }

--- a/src/server/tests/Feature/Api/Performer/UpdatePerformerTest.php
+++ b/src/server/tests/Feature/Api/Performer/UpdatePerformerTest.php
@@ -30,7 +30,7 @@ class UpdatePerformerTest extends TestCase
                 'name' => 'ヰ世界情緒',
                 'orderNo' => 2,
             ])->assertStatus(200)
-            ->assertJson([
+            ->assertExactJson([
                 'performer' => [
                     'performerId' => $uuid,
                     'name' => 'ヰ世界情緒',

--- a/src/server/tests/Feature/Api/Song/CreateSongTest.php
+++ b/src/server/tests/Feature/Api/Song/CreateSongTest.php
@@ -27,7 +27,7 @@ class CreateSongTest extends TestCase
             $creator3 = $this->createCreator($this->generateUuid(), '作詞者'),
         );
 
-        $this->withAuth()
+        $response = $this->withAuth()
             ->postJson(route(SongRouteMap::Create), [
                 'title' => '描き続けた君へ',
                 'description' => 'オリジナル楽曲',
@@ -35,40 +35,44 @@ class CreateSongTest extends TestCase
                 'arrangers' => [['creatorId' => $creator1->creatorId->value]],
                 'composers' => [['creatorId' => $creator2->creatorId->value]],
                 'lyricists' => [['creatorId' => $creator3->creatorId->value]],
-            ])->assertStatus(200)
-            ->assertJson([
-                'song' => [
-                    // ID は事前にわからないのでチェックしない
-                    'title' => '描き続けた君へ',
-                    'description' => 'オリジナル楽曲',
-                    'songType' => [
-                        'name' => SongType::Original->getName(),
-                        'value' => SongType::Original->value,
-                    ],
-                    'orderNo' => 10,
-                    'arrangers' => [
-                        [
-                            'creatorId' => $creator1->creatorId->value,
-                            'name' => $creator1->name->value,
-                            'orderNo' => 1,
-                        ],
-                    ],
-                    'composers' => [
-                        [
-                            'creatorId' => $creator2->creatorId->value,
-                            'name' => $creator2->name->value,
-                            'orderNo' => 1,
-                        ],
-                    ],
-                    'lyricists' => [
-                        [
-                            'creatorId' => $creator3->creatorId->value,
-                            'name' => $creator3->name->value,
-                            'orderNo' => 1,
-                        ],
+            ]);
+
+        $response->assertStatus(200);
+        $songId = $response->json('song.songId');
+
+        $response->assertExactJson([
+            'song' => [
+                'songId' => $songId,
+                'title' => '描き続けた君へ',
+                'description' => 'オリジナル楽曲',
+                'songType' => [
+                    'name' => SongType::Original->getName(),
+                    'value' => SongType::Original->value,
+                ],
+                'orderNo' => 10,
+                'arrangers' => [
+                    [
+                        'creatorId' => $creator1->creatorId->value,
+                        'name' => $creator1->name->value,
+                        'orderNo' => 1,
                     ],
                 ],
-            ]);
+                'composers' => [
+                    [
+                        'creatorId' => $creator2->creatorId->value,
+                        'name' => $creator2->name->value,
+                        'orderNo' => 1,
+                    ],
+                ],
+                'lyricists' => [
+                    [
+                        'creatorId' => $creator3->creatorId->value,
+                        'name' => $creator3->name->value,
+                        'orderNo' => 1,
+                    ],
+                ],
+            ],
+        ]);
     }
 
     #[Test]

--- a/src/server/tests/Feature/Api/Song/CreateSongTest.php
+++ b/src/server/tests/Feature/Api/Song/CreateSongTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Api\Song;
 
+use Illuminate\Testing\Fluent\AssertableJson;
 use PHPUnit\Framework\Attributes\Test;
 use Song\Route\SongRouteMap;
 use SongType\Domain\Models\SongType;
@@ -27,7 +28,7 @@ class CreateSongTest extends TestCase
             $creator3 = $this->createCreator($this->generateUuid(), '作詞者'),
         );
 
-        $response = $this->withAuth()
+        $this->withAuth()
             ->postJson(route(SongRouteMap::Create), [
                 'title' => '描き続けた君へ',
                 'description' => 'オリジナル楽曲',
@@ -35,44 +36,34 @@ class CreateSongTest extends TestCase
                 'arrangers' => [['creatorId' => $creator1->creatorId->value]],
                 'composers' => [['creatorId' => $creator2->creatorId->value]],
                 'lyricists' => [['creatorId' => $creator3->creatorId->value]],
-            ]);
-
-        $response->assertStatus(200);
-        $songId = $response->json('song.songId');
-
-        $response->assertExactJson([
-            'song' => [
-                'songId' => $songId,
-                'title' => '描き続けた君へ',
-                'description' => 'オリジナル楽曲',
-                'songType' => [
-                    'name' => SongType::Original->getName(),
-                    'value' => SongType::Original->value,
-                ],
-                'orderNo' => 10,
-                'arrangers' => [
-                    [
+            ])->assertStatus(200)
+            ->assertJson(fn (AssertableJson $json) => $json
+                ->has('song', fn (AssertableJson $json) => $json
+                    ->whereType('songId', 'string')
+                    ->where('title', '描き続けた君へ')
+                    ->where('description', 'オリジナル楽曲')
+                    ->where('songType', [
+                        'name' => SongType::Original->getName(),
+                        'value' => SongType::Original->value,
+                    ])
+                    ->where('orderNo', 10)
+                    ->where('arrangers', [[
                         'creatorId' => $creator1->creatorId->value,
                         'name' => $creator1->name->value,
                         'orderNo' => 1,
-                    ],
-                ],
-                'composers' => [
-                    [
+                    ]])
+                    ->where('composers', [[
                         'creatorId' => $creator2->creatorId->value,
                         'name' => $creator2->name->value,
                         'orderNo' => 1,
-                    ],
-                ],
-                'lyricists' => [
-                    [
+                    ]])
+                    ->where('lyricists', [[
                         'creatorId' => $creator3->creatorId->value,
                         'name' => $creator3->name->value,
                         'orderNo' => 1,
-                    ],
-                ],
-            ],
-        ]);
+                    ]])
+                )
+            );
     }
 
     #[Test]

--- a/src/server/tests/Feature/Api/Song/CreateSongTest.php
+++ b/src/server/tests/Feature/Api/Song/CreateSongTest.php
@@ -37,32 +37,35 @@ class CreateSongTest extends TestCase
                 'composers' => [['creatorId' => $creator2->creatorId->value]],
                 'lyricists' => [['creatorId' => $creator3->creatorId->value]],
             ])->assertStatus(200)
-            ->assertJson(fn (AssertableJson $json) => $json
-                ->has('song', fn (AssertableJson $json) => $json
-                    ->whereType('songId', 'string')
-                    ->where('title', '描き続けた君へ')
-                    ->where('description', 'オリジナル楽曲')
-                    ->where('songType', [
-                        'name' => SongType::Original->getName(),
-                        'value' => SongType::Original->value,
-                    ])
-                    ->where('orderNo', 10)
-                    ->where('arrangers', [[
-                        'creatorId' => $creator1->creatorId->value,
-                        'name' => $creator1->name->value,
-                        'orderNo' => 1,
-                    ]])
-                    ->where('composers', [[
-                        'creatorId' => $creator2->creatorId->value,
-                        'name' => $creator2->name->value,
-                        'orderNo' => 1,
-                    ]])
-                    ->where('lyricists', [[
-                        'creatorId' => $creator3->creatorId->value,
-                        'name' => $creator3->name->value,
-                        'orderNo' => 1,
-                    ]])
-                )
+            ->assertJson(
+                fn (AssertableJson $json) => $json
+                    ->has(
+                        'song',
+                        fn (AssertableJson $json) => $json
+                            ->whereType('songId', 'string')
+                            ->where('title', '描き続けた君へ')
+                            ->where('description', 'オリジナル楽曲')
+                            ->where('songType', [
+                                'name' => SongType::Original->getName(),
+                                'value' => SongType::Original->value,
+                            ])
+                            ->where('orderNo', 10)
+                            ->where('arrangers', [[
+                                'creatorId' => $creator1->creatorId->value,
+                                'name' => $creator1->name->value,
+                                'orderNo' => 1,
+                            ]])
+                            ->where('composers', [[
+                                'creatorId' => $creator2->creatorId->value,
+                                'name' => $creator2->name->value,
+                                'orderNo' => 1,
+                            ]])
+                            ->where('lyricists', [[
+                                'creatorId' => $creator3->creatorId->value,
+                                'name' => $creator3->name->value,
+                                'orderNo' => 1,
+                            ]]),
+                    ),
             );
     }
 

--- a/src/server/tests/Feature/Api/Song/GetSongTest.php
+++ b/src/server/tests/Feature/Api/Song/GetSongTest.php
@@ -45,7 +45,7 @@ class GetSongTest extends TestCase
         $this->withAuth()
             ->get(route(SongRouteMap::Get, $songId))
             ->assertStatus(200)
-            ->assertJson([
+            ->assertExactJson([
                 'song' => [
                     'songId' => $songId,
                     'title' => '描き続けた君へ',

--- a/src/server/tests/Feature/Api/Song/ListSongTest.php
+++ b/src/server/tests/Feature/Api/Song/ListSongTest.php
@@ -56,7 +56,7 @@ class ListSongTest extends TestCase
         $this->withAuth()
             ->get(route(SongRouteMap::List))
             ->assertStatus(200)
-            ->assertJson([
+            ->assertExactJson([
                 'songs' => [
                     [
                         'songId' => $song1Id,
@@ -94,6 +94,6 @@ class ListSongTest extends TestCase
         $this->withAuth()
             ->get(route(SongRouteMap::List))
             ->assertStatus(200)
-            ->assertJson(['songs' => []]);
+            ->assertExactJson(['songs' => []]);
     }
 }

--- a/src/server/tests/Feature/Api/Song/UpdateSongTest.php
+++ b/src/server/tests/Feature/Api/Song/UpdateSongTest.php
@@ -52,7 +52,7 @@ class UpdateSongTest extends TestCase
                 'composers' => [['creatorId' => $creator2->creatorId->value, 'orderNo' => 1]],
                 'lyricists' => [],
             ])->assertStatus(200)
-            ->assertJson([
+            ->assertExactJson([
                 'song' => [
                     'songId' => $songId,
                     'title' => '描き続けた君へ',

--- a/src/server/tests/Unit/Song/Domain/Models/Creators/ArrangersTest.php
+++ b/src/server/tests/Unit/Song/Domain/Models/Creators/ArrangersTest.php
@@ -42,4 +42,16 @@ class ArrangersTest extends TestCase
 
         $this->assertCount(0, $arrangers);
     }
+
+    #[Test]
+    public function fromArrayInvalidCreatorId(): void
+    {
+        $input = [
+            ['creatorId' => 'invalid-uuid'],
+        ];
+
+        $result = Arrangers::fromArray($input);
+
+        $this->assertTrue($result->isErr());
+    }
 }

--- a/src/server/tests/Unit/Song/Domain/Models/Creators/ComposersTest.php
+++ b/src/server/tests/Unit/Song/Domain/Models/Creators/ComposersTest.php
@@ -42,4 +42,16 @@ class ComposersTest extends TestCase
 
         $this->assertCount(0, $composers);
     }
+
+    #[Test]
+    public function fromArrayInvalidCreatorId(): void
+    {
+        $input = [
+            ['creatorId' => 'invalid-uuid'],
+        ];
+
+        $result = Composers::fromArray($input);
+
+        $this->assertTrue($result->isErr());
+    }
 }

--- a/src/server/tests/Unit/Song/Domain/Models/Creators/LyricistsTest.php
+++ b/src/server/tests/Unit/Song/Domain/Models/Creators/LyricistsTest.php
@@ -42,4 +42,16 @@ class LyricistsTest extends TestCase
 
         $this->assertCount(0, $lyricists);
     }
+
+    #[Test]
+    public function fromArrayInvalidCreatorId(): void
+    {
+        $input = [
+            ['creatorId' => 'invalid-uuid'],
+        ];
+
+        $result = Lyricists::fromArray($input);
+
+        $this->assertTrue($result->isErr());
+    }
 }

--- a/src/server/tests/Unit/Song/Domain/Models/SongTest.php
+++ b/src/server/tests/Unit/Song/Domain/Models/SongTest.php
@@ -124,4 +124,47 @@ class SongTest extends TestCase
     {
         return [['creatorId' => $creatorId, 'orderNo' => 1]];
     }
+
+    #[Test]
+    public function toArray(): void
+    {
+        $songId = '11111111-1111-1111-1111-111111111111';
+        $title = 'Song Title';
+        $description = 'Song Description';
+        $songType = SongType::Original->value;
+        $orderNo = 1;
+        $arrangers = self::creators('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa');
+        $composers = self::creators('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb');
+        $lyricists = self::creators('cccccccc-cccc-cccc-cccc-cccccccccccc');
+
+        $song = Song::reconstruct(
+            $songId,
+            $title,
+            $description,
+            $songType,
+            $orderNo,
+            $arrangers,
+            $composers,
+            $lyricists,
+        );
+
+        $expected = [
+            'song_id' => $songId,
+            'title' => $title,
+            'description' => $description,
+            'song_type' => $songType,
+            'order_no' => $orderNo,
+            'arrangers' => [
+                ['creator_id' => 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'order_no' => 1],
+            ],
+            'composers' => [
+                ['creator_id' => 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 'order_no' => 1],
+            ],
+            'lyricists' => [
+                ['creator_id' => 'cccccccc-cccc-cccc-cccc-cccccccccccc', 'order_no' => 1],
+            ],
+        ];
+
+        $this->assertSame($expected, $song->toArray());
+    }
 }

--- a/src/server/tests/Unit/Song/Domain/Services/SongIntegrityServiceTest.php
+++ b/src/server/tests/Unit/Song/Domain/Services/SongIntegrityServiceTest.php
@@ -315,11 +315,21 @@ class SongIntegrityServiceTest extends TestCase
         $uuid = 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA';
 
         $this->creatorRepository->shouldReceive('findByIds')
+            ->withArgs(
+                fn (
+                    CreatorId $arg1,
+                    CreatorId $arg2,
+                    CreatorId $arg3,
+                ): bool => $arg1->value === 'BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB'
+                    && $arg2->value === 'CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC'
+                    && $arg3->value === 'DDDDDDDD-DDDD-DDDD-DDDD-DDDDDDDDDDDD',
+            )
             ->andReturn([
                 $this->createCreator('BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB', ''),
                 $this->createCreator('CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC', ''),
                 $this->createCreator('DDDDDDDD-DDDD-DDDD-DDDD-DDDDDDDDDDDD', ''),
-            ]);
+            ])
+            ->once();
 
         $this->generator->shouldReceive('generate')->andReturn($uuid);
 
@@ -344,6 +354,8 @@ class SongIntegrityServiceTest extends TestCase
         $description = '説明';
         $songType = SongType::Original->value;
 
+        $this->creatorRepository->shouldNotReceive('findByIds');
+
         $result = $this->getInstance()->prepareForCreate(
             $title,
             $description,
@@ -366,11 +378,21 @@ class SongIntegrityServiceTest extends TestCase
         $orderNo = 0; // Invalid
 
         $this->creatorRepository->shouldReceive('findByIds')
+            ->withArgs(
+                fn (
+                    CreatorId $arg1,
+                    CreatorId $arg2,
+                    CreatorId $arg3,
+                ): bool => $arg1->value === 'BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB'
+                    && $arg2->value === 'CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC'
+                    && $arg3->value === 'DDDDDDDD-DDDD-DDDD-DDDD-DDDDDDDDDDDD',
+            )
             ->andReturn([
                 $this->createCreator('BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB', ''),
                 $this->createCreator('CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC', ''),
                 $this->createCreator('DDDDDDDD-DDDD-DDDD-DDDD-DDDDDDDDDDDD', ''),
-            ]);
+            ])
+            ->once();
 
         $result = $this->getInstance()->prepareForUpdate(
             $songId,
@@ -396,11 +418,21 @@ class SongIntegrityServiceTest extends TestCase
         $orderNo = 1;
 
         $this->creatorRepository->shouldReceive('findByIds')
+            ->withArgs(
+                fn (
+                    CreatorId $arg1,
+                    CreatorId $arg2,
+                    CreatorId $arg3,
+                ): bool => $arg1->value === 'BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB'
+                    && $arg2->value === 'CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC'
+                    && $arg3->value === 'DDDDDDDD-DDDD-DDDD-DDDD-DDDDDDDDDDDD',
+            )
             ->andReturn([
                 $this->createCreator('BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB', ''),
                 $this->createCreator('CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC', ''),
                 $this->createCreator('DDDDDDDD-DDDD-DDDD-DDDD-DDDDDDDDDDDD', ''),
-            ]);
+            ])
+            ->once();
 
         $result = $this->getInstance()->prepareForUpdate(
             $songId,
@@ -424,6 +456,8 @@ class SongIntegrityServiceTest extends TestCase
         $description = '説明';
         $songType = SongType::Original->value;
         $orderNo = 1;
+
+        $this->creatorRepository->shouldNotReceive('findByIds');
 
         $result = $this->getInstance()->prepareForUpdate(
             $songId,

--- a/src/server/tests/Unit/Song/Domain/Services/SongIntegrityServiceTest.php
+++ b/src/server/tests/Unit/Song/Domain/Services/SongIntegrityServiceTest.php
@@ -331,9 +331,15 @@ class SongIntegrityServiceTest extends TestCase
             ])
             ->once();
 
-        $this->generator->shouldReceive('generate')->andReturn($uuid);
+        $this->generator->shouldReceive('generate')
+            ->with()
+            ->andReturn($uuid)
+            ->once();
 
-        $this->songRepository->shouldReceive('getMaxOrderNo')->andReturn(100);
+        $this->songRepository->shouldReceive('getMaxOrderNo')
+            ->with()
+            ->andReturn(100)
+            ->once();
 
         $result = $this->getInstance()->prepareForCreate(
             $title,

--- a/src/server/tests/Unit/Song/Domain/Services/SongIntegrityServiceTest.php
+++ b/src/server/tests/Unit/Song/Domain/Services/SongIntegrityServiceTest.php
@@ -306,6 +306,139 @@ class SongIntegrityServiceTest extends TestCase
         $this->assertTrue($result->isErr());
     }
 
+    #[Test]
+    public function prepareForCreateReturnsErrorWhenSongTypeIsInvalid(): void
+    {
+        $title = '描き続けた君へ';
+        $description = '説明';
+        $songType = 999; // Invalid
+        $uuid = 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA';
+
+        $this->creatorRepository->shouldReceive('findByIds')
+            ->andReturn([
+                $this->createCreator('BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB', ''),
+                $this->createCreator('CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC', ''),
+                $this->createCreator('DDDDDDDD-DDDD-DDDD-DDDD-DDDDDDDDDDDD', ''),
+            ]);
+
+        $this->generator->shouldReceive('generate')->andReturn($uuid);
+
+        $this->songRepository->shouldReceive('getMaxOrderNo')->andReturn(100);
+
+        $result = $this->getInstance()->prepareForCreate(
+            $title,
+            $description,
+            $songType,
+            [['creatorId' => 'BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB']],
+            [['creatorId' => 'CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC']],
+            [['creatorId' => 'DDDDDDDD-DDDD-DDDD-DDDD-DDDDDDDDDDDD']],
+        );
+
+        $this->assertTrue($result->isErr());
+    }
+
+    #[Test]
+    public function prepareForCreateReturnsErrorWhenCreatorsAreInvalid(): void
+    {
+        $title = '描き続けた君へ';
+        $description = '説明';
+        $songType = SongType::Original->value;
+
+        $result = $this->getInstance()->prepareForCreate(
+            $title,
+            $description,
+            $songType,
+            [['creatorId' => 'invalid-uuid']],
+            [['creatorId' => 'CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC']],
+            [['creatorId' => 'DDDDDDDD-DDDD-DDDD-DDDD-DDDDDDDDDDDD']],
+        );
+
+        $this->assertTrue($result->isErr());
+    }
+
+    #[Test]
+    public function prepareForUpdateReturnsErrorWhenOrderNoIsInvalid(): void
+    {
+        $songId = 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA';
+        $title = '描き続けた君へ';
+        $description = '説明';
+        $songType = SongType::Original->value;
+        $orderNo = 0; // Invalid
+
+        $this->creatorRepository->shouldReceive('findByIds')
+            ->andReturn([
+                $this->createCreator('BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB', ''),
+                $this->createCreator('CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC', ''),
+                $this->createCreator('DDDDDDDD-DDDD-DDDD-DDDD-DDDDDDDDDDDD', ''),
+            ]);
+
+        $result = $this->getInstance()->prepareForUpdate(
+            $songId,
+            $title,
+            $description,
+            $songType,
+            $orderNo,
+            [['creatorId' => 'BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB']],
+            [['creatorId' => 'CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC']],
+            [['creatorId' => 'DDDDDDDD-DDDD-DDDD-DDDD-DDDDDDDDDDDD']],
+        );
+
+        $this->assertTrue($result->isErr());
+    }
+
+    #[Test]
+    public function prepareForUpdateReturnsErrorWhenSongTypeIsInvalid(): void
+    {
+        $songId = 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA';
+        $title = '描き続けた君へ';
+        $description = '説明';
+        $songType = 999; // Invalid
+        $orderNo = 1;
+
+        $this->creatorRepository->shouldReceive('findByIds')
+            ->andReturn([
+                $this->createCreator('BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB', ''),
+                $this->createCreator('CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC', ''),
+                $this->createCreator('DDDDDDDD-DDDD-DDDD-DDDD-DDDDDDDDDDDD', ''),
+            ]);
+
+        $result = $this->getInstance()->prepareForUpdate(
+            $songId,
+            $title,
+            $description,
+            $songType,
+            $orderNo,
+            [['creatorId' => 'BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB']],
+            [['creatorId' => 'CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC']],
+            [['creatorId' => 'DDDDDDDD-DDDD-DDDD-DDDD-DDDDDDDDDDDD']],
+        );
+
+        $this->assertTrue($result->isErr());
+    }
+
+    #[Test]
+    public function prepareForUpdateReturnsErrorWhenCreatorsAreInvalid(): void
+    {
+        $songId = 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA';
+        $title = '描き続けた君へ';
+        $description = '説明';
+        $songType = SongType::Original->value;
+        $orderNo = 1;
+
+        $result = $this->getInstance()->prepareForUpdate(
+            $songId,
+            $title,
+            $description,
+            $songType,
+            $orderNo,
+            [['creatorId' => 'invalid-uuid']],
+            [['creatorId' => 'CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC']],
+            [['creatorId' => 'DDDDDDDD-DDDD-DDDD-DDDD-DDDDDDDDDDDD']],
+        );
+
+        $this->assertTrue($result->isErr());
+    }
+
     private function getInstance(): SongIntegrityService
     {
         return new SongIntegrityService(


### PR DESCRIPTION
Implemented additional unit tests for the Song domain to improve test coverage and verification strength. 
Specifically, added tests for:
- Invalid creator ID handling in `Arrangers`, `Composers`, and `Lyricists` collection classes.
- Validation logic in `SongIntegrityService` for creation and update scenarios, including invalid enum values and domain constraints.
- `toArray` method in `Song` model to ensure correct data structure for persistence or API responses.

---
*PR created automatically by Jules for task [5697335025240096174](https://jules.google.com/task/5697335025240096174) started by @sayuprc*