### PR TITLE
Implement missing Feature tests for server

### DIFF
--- a/src/server/tests/Feature/Api/Creator/CreateCreatorTest.php
+++ b/src/server/tests/Feature/Api/Creator/CreateCreatorTest.php
@@ -37,12 +37,20 @@ class CreateCreatorTest extends TestCase
     #[Test]
     public function createFails(): void
     {
-        $this->markTestSkipped('実装する');
+        $this->withAuth()
+            ->postJson(route(CreatorRouteMap::Create), [
+                'name' => '', // Empty string
+            ])->assertStatus(422)
+            ->assertJson([
+                'field' => 'name',
+            ]);
     }
 
     #[Test]
     public function emptyParameters(): void
     {
-        $this->markTestSkipped('実装する');
+        $this->withAuth()
+            ->postJson(route(CreatorRouteMap::Create), [])
+            ->assertStatus(422);
     }
 }

--- a/src/server/tests/Feature/Api/Creator/DeleteCreatorTest.php
+++ b/src/server/tests/Feature/Api/Creator/DeleteCreatorTest.php
@@ -59,8 +59,12 @@ class DeleteCreatorTest extends TestCase
     }
 
     #[Test]
-    public function emptyParameters(): void
+    public function notFound(): void
     {
-        $this->markTestSkipped('TODO 実装する');
+        $uuid = $this->generateUuid();
+
+        $this->withAuth()
+            ->delete(route(CreatorRouteMap::Delete, $uuid))
+            ->assertStatus(204);
     }
 }

--- a/src/server/tests/Feature/Api/Creator/UpdateCreatorTest.php
+++ b/src/server/tests/Feature/Api/Creator/UpdateCreatorTest.php
@@ -40,12 +40,26 @@ class UpdateCreatorTest extends TestCase
     #[Test]
     public function updateFails(): void
     {
-        $this->markTestSkipped('TODO 実装する');
+        $uuid = $this->generateUuid();
+        $this->factory(FileCreatorRepository::class, $this->createCreator($uuid, 'クリエイター')->toArray());
+
+        $this->withAuth()
+            ->putJson(route(CreatorRouteMap::Update, $uuid), [
+                'name' => '',
+            ])->assertStatus(422)
+            ->assertJson([
+                'field' => 'name',
+            ]);
     }
 
     #[Test]
     public function emptyParameters(): void
     {
-        $this->markTestSkipped('TODO 実装する');
+        $uuid = $this->generateUuid();
+        $this->factory(FileCreatorRepository::class, $this->createCreator($uuid, 'クリエイター')->toArray());
+
+        $this->withAuth()
+            ->putJson(route(CreatorRouteMap::Update, $uuid), [])
+            ->assertStatus(422);
     }
 }

--- a/src/server/tests/Feature/Api/Performer/CreatePerformerTest.php
+++ b/src/server/tests/Feature/Api/Performer/CreatePerformerTest.php
@@ -38,12 +38,20 @@ class CreatePerformerTest extends TestCase
     #[Test]
     public function createFails(): void
     {
-        $this->markTestSkipped('実装する');
+        $this->withAuth()
+            ->postJson(route(PerformerRouteMap::Create), [
+                'name' => '',
+            ])->assertStatus(422)
+            ->assertJson([
+                'field' => 'name',
+            ]);
     }
 
     #[Test]
     public function emptyParameters(): void
     {
-        $this->markTestSkipped('実装する');
+        $this->withAuth()
+            ->postJson(route(PerformerRouteMap::Create), [])
+            ->assertStatus(422);
     }
 }

--- a/src/server/tests/Feature/Api/Performer/DeletePerformerTest.php
+++ b/src/server/tests/Feature/Api/Performer/DeletePerformerTest.php
@@ -31,8 +31,12 @@ class DeletePerformerTest extends TestCase
     }
 
     #[Test]
-    public function emptyParameters(): void
+    public function notFound(): void
     {
-        $this->markTestSkipped('TODO 実装する');
+        $uuid = $this->generateUuid();
+
+        $this->withAuth()
+            ->delete(route(PerformerRouteMap::Delete, $uuid))
+            ->assertStatus(204);
     }
 }

--- a/src/server/tests/Feature/Api/Performer/UpdatePerformerTest.php
+++ b/src/server/tests/Feature/Api/Performer/UpdatePerformerTest.php
@@ -42,12 +42,27 @@ class UpdatePerformerTest extends TestCase
     #[Test]
     public function updateFails(): void
     {
-        $this->markTestSkipped('TODO 実装する');
+        $uuid = $this->generateUuid();
+        $this->factory(FilePerformerRepository::class, $this->createPerformer($uuid, '共演者', 1)->toArray());
+
+        $this->withAuth()
+            ->putJson(route(PerformerRouteMap::Update, $uuid), [
+                'name' => 'ヰ世界情緒',
+                'orderNo' => 0,
+            ])->assertStatus(422)
+            ->assertJson([
+                'field' => 'orderNo',
+            ]);
     }
 
     #[Test]
     public function emptyParameters(): void
     {
-        $this->markTestSkipped('TODO 実装する');
+        $uuid = $this->generateUuid();
+        $this->factory(FilePerformerRepository::class, $this->createPerformer($uuid, '共演者', 1)->toArray());
+
+        $this->withAuth()
+            ->putJson(route(PerformerRouteMap::Update, $uuid), [])
+            ->assertStatus(422);
     }
 }

--- a/src/server/tests/Feature/Api/Song/CreateSongTest.php
+++ b/src/server/tests/Feature/Api/Song/CreateSongTest.php
@@ -72,12 +72,38 @@ class CreateSongTest extends TestCase
     #[Test]
     public function createFails(): void
     {
-        $this->markTestSkipped('実装する');
+        $this->storeCreators(
+            $creator1 = $this->createCreator($this->generateUuid(), '編曲者'),
+            $creator2 = $this->createCreator($this->generateUuid(), '作曲者'),
+            $creator3 = $this->createCreator($this->generateUuid(), '作詞者'),
+        );
+
+        $this->withAuth()
+            ->postJson(route(SongRouteMap::Create), [
+                'title' => '描き続けた君へ',
+                'description' => 'オリジナル楽曲',
+                'songTypeValue' => 99, // Invalid value
+                'arrangers' => [['creatorId' => $creator1->creatorId->value]],
+                'composers' => [['creatorId' => $creator2->creatorId->value]],
+                'lyricists' => [['creatorId' => $creator3->creatorId->value]],
+            ])->assertStatus(422)
+            ->assertJson(
+                fn (AssertableJson $json) => $json
+                    ->where('field', 'songTypeValue')
+                    ->where('message', 'The value does not match the expected format: 99.'),
+            );
     }
 
     #[Test]
     public function emptyParameters(): void
     {
-        $this->markTestSkipped('実装する');
+        $this->withAuth()
+            ->postJson(route(SongRouteMap::Create), [])
+            ->assertStatus(422)
+            ->assertJson(
+                fn (AssertableJson $json) => $json
+                    ->where('field', '')
+                    ->where('message', 'Keyword validation failed: Required property \'title\' must be present in the object'),
+            );
     }
 }

--- a/src/server/tests/Feature/Api/Song/CreateSongTest.php
+++ b/src/server/tests/Feature/Api/Song/CreateSongTest.php
@@ -90,7 +90,7 @@ class CreateSongTest extends TestCase
             ->assertJson(
                 fn (AssertableJson $json) => $json
                     ->where('field', 'songTypeValue')
-                    ->where('message', 'The value does not match the expected format: 99.'),
+                    ->where('message', 'Keyword validation failed: Value must be present in the enum'),
             );
     }
 
@@ -102,7 +102,7 @@ class CreateSongTest extends TestCase
             ->assertStatus(422)
             ->assertJson(
                 fn (AssertableJson $json) => $json
-                    ->where('field', '')
+                    ->where('field', 'title')
                     ->where('message', 'Keyword validation failed: Required property \'title\' must be present in the object'),
             );
     }

--- a/src/server/tests/Feature/Api/Song/DeleteSongTest.php
+++ b/src/server/tests/Feature/Api/Song/DeleteSongTest.php
@@ -35,8 +35,12 @@ class DeleteSongTest extends TestCase
     }
 
     #[Test]
-    public function emptyParameters(): void
+    public function notFound(): void
     {
-        $this->markTestSkipped('TODO 実装する');
+        $uuid = $this->generateUuid();
+
+        $this->withAuth()
+            ->delete(route(SongRouteMap::Delete, $uuid))
+            ->assertStatus(204);
     }
 }

--- a/src/server/tests/Feature/Api/Song/UpdateSongTest.php
+++ b/src/server/tests/Feature/Api/Song/UpdateSongTest.php
@@ -119,7 +119,7 @@ class UpdateSongTest extends TestCase
             ->assertJson(
                 fn (AssertableJson $json) => $json
                     ->where('field', 'orderNo')
-                    ->where('message', 'The value does not match the expected format: 0.'),
+                    ->where('message', 'Keyword validation failed: Value 0 must be greater or equal to 1'),
             );
     }
 

--- a/src/server/tests/Feature/Api/Song/UpdateSongTest.php
+++ b/src/server/tests/Feature/Api/Song/UpdateSongTest.php
@@ -118,7 +118,8 @@ class UpdateSongTest extends TestCase
             ])->assertStatus(422)
             ->assertJson(
                 fn (AssertableJson $json) => $json
-                    ->where('field', 'orderNo'),
+                    ->where('field', 'orderNo')
+                    ->where('message', 'The value does not match the expected format: 0.'),
             );
     }
 

--- a/src/server/tests/Feature/Api/Song/UpdateSongTest.php
+++ b/src/server/tests/Feature/Api/Song/UpdateSongTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Api\Song;
 
+use Illuminate\Testing\Fluent\AssertableJson;
 use PHPUnit\Framework\Attributes\Test;
 use Song\Route\SongRouteMap;
 use SongType\Domain\Models\SongType;
@@ -84,12 +85,63 @@ class UpdateSongTest extends TestCase
     #[Test]
     public function updateFails(): void
     {
-        $this->markTestSkipped('TODO 実装する');
+        $creator1 = $this->createCreator($this->generateUuid(), '編曲者');
+        $creator2 = $this->createCreator($this->generateUuid(), '作曲者');
+        $creator3 = $this->createCreator($this->generateUuid(), '作詞者');
+
+        $this->storeCreators($creator1, $creator2, $creator3);
+
+        $songId = $this->generateUuid();
+
+        $this->storeSongs(
+            $this->createSong(
+                $songId,
+                '曲名',
+                '説明',
+                SongType::Original,
+                1,
+                [['creatorId' => $creator1->creatorId->value, 'orderNo' => 1]],
+                [['creatorId' => $creator2->creatorId->value, 'orderNo' => 1]],
+                [['creatorId' => $creator3->creatorId->value, 'orderNo' => 1]],
+            ),
+        );
+
+        $this->withAuth()
+            ->putJson(route(SongRouteMap::Update, $songId), [
+                'title' => '描き続けた君へ',
+                'description' => 'オリジナル楽曲',
+                'songTypeValue' => SongType::Cover->value,
+                'orderNo' => 0, // Invalid value
+                'arrangers' => [['creatorId' => $creator1->creatorId->value, 'orderNo' => 1]],
+                'composers' => [['creatorId' => $creator2->creatorId->value, 'orderNo' => 1]],
+                'lyricists' => [],
+            ])->assertStatus(422)
+            ->assertJson(
+                fn (AssertableJson $json) => $json
+                    ->where('field', 'orderNo'),
+            );
     }
 
     #[Test]
     public function emptyParameters(): void
     {
-        $this->markTestSkipped('TODO 実装する');
+        $songId = $this->generateUuid();
+
+        $this->storeSongs(
+            $this->createSong(
+                $songId,
+                '曲名',
+                '説明',
+                SongType::Original,
+                1,
+                [],
+                [],
+                [],
+            ),
+        );
+
+        $this->withAuth()
+            ->putJson(route(SongRouteMap::Update, $songId), [])
+            ->assertStatus(422);
     }
 }


### PR DESCRIPTION
Implemented missing Feature tests for server. Addressed skipped tests in Song, Creator, and Performer feature tests by implementing validation and not-found scenarios. verified logic against codebase and OpenAPI spec.

---
*PR created automatically by Jules for task [8813462269811562155](https://jules.google.com/task/8813462269811562155) started by @sayuprc*