### PR TITLE
Improve Integration tests for server interactors

### DIFF
--- a/src/server/tests/Integration/AdminUser/Application/Interactors/ListInteractorTest.php
+++ b/src/server/tests/Integration/AdminUser/Application/Interactors/ListInteractorTest.php
@@ -42,7 +42,7 @@ class ListInteractorTest extends TestCase
 
         $this->assertTrue($result->isOk());
 
-        $users = $result->unwrap()->users;
+        $users = $result->unwrap()->adminUsers;
         $this->assertCount(1, $users);
         $this->assertSame($uuid, $users[0]->adminUserId->value);
     }
@@ -58,7 +58,7 @@ class ListInteractorTest extends TestCase
 
         $this->assertTrue($result->isOk());
 
-        $users = $result->unwrap()->users;
+        $users = $result->unwrap()->adminUsers;
         $this->assertCount(0, $users);
     }
 

--- a/src/server/tests/Integration/AdminUser/Application/Interactors/ListInteractorTest.php
+++ b/src/server/tests/Integration/AdminUser/Application/Interactors/ListInteractorTest.php
@@ -2,63 +2,70 @@
 
 declare(strict_types=1);
 
-namespace Tests\Integration\Creator\Application\Interactors;
+namespace Tests\Integration\AdminUser\Application\Interactors;
 
+use AdminUser\Application\Interactors\ListInteractor;
+use AdminUser\Application\UseCase\List\ListInputData;
+use AdminUser\DebugInfrastructures\FileAdminUserRepository;
 use AdminUser\Domain\Models\AdminUser;
 use AdminUser\Domain\Models\Role;
 use Auth\Domain\Models\AuthContext;
-use Creator\Application\Interactors\ListInteractor;
-use Creator\DebugInfrastructures\FileCreatorRepository;
 use DateTimeImmutable;
 use PHPUnit\Framework\Attributes\Test;
 use Support\UseCase\Error\AuthenticationError;
 use Support\UseCase\Error\AuthorizationError;
-use Tests\Support\Domain\EntityFactory;
 use Tests\Support\FileRepositoryTransaction;
 use Tests\TestCase;
 
 class ListInteractorTest extends TestCase
 {
-    use EntityFactory;
     use FileRepositoryTransaction;
 
     #[Test]
-    public function nonEmptyCreators(): void
+    public function canList(): void
     {
         $this->privilegedContext();
 
         $uuid = $this->generateUuid();
+        $user = AdminUser::reconstruct(
+            $uuid,
+            'テストユーザー',
+            'test@example.com',
+            new DateTimeImmutable(),
+            Role::General->value,
+            [],
+        );
 
-        $this->factory(FileCreatorRepository::class, $this->createCreator($uuid, 'ヰ世界情緒')->toArray());
+        $this->factory(FileAdminUserRepository::class, $user->toArray());
 
-        $result = $this->getInstance()->handle();
+        $result = $this->getInstance()->handle(new ListInputData());
+
         $this->assertTrue($result->isOk());
 
-        $response = $result->unwrap();
-
-        $this->assertCount(1, $response->creators);
-
-        $this->assertSame($uuid, $response->creators[0]->creatorId->value);
-        $this->assertSame('ヰ世界情緒', $response->creators[0]->name->value);
+        $users = $result->unwrap()->users;
+        $this->assertCount(1, $users);
+        $this->assertSame($uuid, $users[0]->adminUserId->value);
     }
 
     #[Test]
-    public function emptyCreators(): void
+    public function emptyAdminUsers(): void
     {
         $this->privilegedContext();
 
-        $result = $this->getInstance()->handle();
+        // No users created
+
+        $result = $this->getInstance()->handle(new ListInputData());
+
         $this->assertTrue($result->isOk());
 
-        $response = $result->unwrap();
-
-        $this->assertCount(0, $response->creators);
+        $users = $result->unwrap()->users;
+        $this->assertCount(0, $users);
     }
 
     #[Test]
     public function cannotListWhenUnauthenticated(): void
     {
-        $result = $this->getInstance()->handle();
+        $result = $this->getInstance()->handle(new ListInputData());
 
         $this->assertTrue($result->isErr());
         $this->assertInstanceOf(AuthenticationError::class, $result->unwrapErr());
@@ -77,7 +84,7 @@ class ListInteractorTest extends TestCase
             [], // No permissions
         ));
 
-        $result = $this->getInstance()->handle();
+        $result = $this->getInstance()->handle(new ListInputData());
 
         $this->assertTrue($result->isErr());
         $this->assertInstanceOf(AuthorizationError::class, $result->unwrapErr());

--- a/src/server/tests/Integration/Performer/Application/Interactors/ListInteractorTest.php
+++ b/src/server/tests/Integration/Performer/Application/Interactors/ListInteractorTest.php
@@ -4,9 +4,15 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Performer\Application\Interactors;
 
+use AdminUser\Domain\Models\AdminUser;
+use AdminUser\Domain\Models\Role;
+use Auth\Domain\Models\AuthContext;
+use DateTimeImmutable;
 use Performer\Application\Interactors\ListInteractor;
 use Performer\DebugInfrastructures\FilePerformerRepository;
 use PHPUnit\Framework\Attributes\Test;
+use Support\UseCase\Error\AuthenticationError;
+use Support\UseCase\Error\AuthorizationError;
 use Tests\Support\Domain\EntityFactory;
 use Tests\Support\FileRepositoryTransaction;
 use Tests\TestCase;
@@ -19,6 +25,8 @@ class ListInteractorTest extends TestCase
     #[Test]
     public function nonEmptyPerformers(): void
     {
+        $this->privilegedContext();
+
         $uuid = $this->generateUuid();
 
         $this->factory(FilePerformerRepository::class, $this->createPerformer($uuid, 'ヰ世界情緒', 1)->toArray());
@@ -35,10 +43,49 @@ class ListInteractorTest extends TestCase
         $this->assertSame(1, $response->performers[0]->orderNo->value);
     }
 
-    private function getInstance(): ListInteractor
+    #[Test]
+    public function emptyPerformers(): void
     {
         $this->privilegedContext();
 
+        $result = $this->getInstance()->handle();
+        $this->assertTrue($result->isOk());
+
+        $response = $result->unwrap();
+
+        $this->assertCount(0, $response->performers);
+    }
+
+    #[Test]
+    public function cannotListWhenUnauthenticated(): void
+    {
+        $result = $this->getInstance()->handle();
+
+        $this->assertTrue($result->isErr());
+        $this->assertInstanceOf(AuthenticationError::class, $result->unwrapErr());
+    }
+
+    #[Test]
+    public function cannotListWhenUnauthorized(): void
+    {
+        $context = $this->app->make(AuthContext::class);
+        $context->set(AdminUser::reconstruct(
+            $this->generateUuid(),
+            'Unprivileged User',
+            'unprivileged@example.com',
+            new DateTimeImmutable(),
+            Role::General->value,
+            [], // No permissions
+        ));
+
+        $result = $this->getInstance()->handle();
+
+        $this->assertTrue($result->isErr());
+        $this->assertInstanceOf(AuthorizationError::class, $result->unwrapErr());
+    }
+
+    private function getInstance(): ListInteractor
+    {
         return $this->app->make(ListInteractor::class);
     }
 }

--- a/src/server/tests/Integration/Song/Application/Interactors/ListInteractorTest.php
+++ b/src/server/tests/Integration/Song/Application/Interactors/ListInteractorTest.php
@@ -4,9 +4,15 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Song\Application\Interactors;
 
+use AdminUser\Domain\Models\AdminUser;
+use AdminUser\Domain\Models\Role;
+use Auth\Domain\Models\AuthContext;
+use DateTimeImmutable;
 use PHPUnit\Framework\Attributes\Test;
 use Song\Application\Interactors\ListInteractor;
 use SongType\Domain\Models\SongType;
+use Support\UseCase\Error\AuthenticationError;
+use Support\UseCase\Error\AuthorizationError;
 use Tests\Support\Domain\EntityFactory;
 use Tests\Support\FileRepositoryTransaction;
 use Tests\TestCase;
@@ -19,6 +25,8 @@ class ListInteractorTest extends TestCase
     #[Test]
     public function nonEmptySongs(): void
     {
+        $this->privilegedContext();
+
         $arranger = $this->createCreator($arrangerId = $this->generateUuid(), '編曲者A');
         $composer = $this->createCreator($composerId = $this->generateUuid(), '作曲者A');
         $lyricist = $this->createCreator($lyricistId = $this->generateUuid(), '作詞者A');
@@ -82,10 +90,49 @@ class ListInteractorTest extends TestCase
         $this->assertCount(0, $response->songs[1]->lyricists);
     }
 
-    private function getInstance(): ListInteractor
+    #[Test]
+    public function emptySongs(): void
     {
         $this->privilegedContext();
 
+        $result = $this->getInstance()->handle();
+        $this->assertTrue($result->isOk());
+
+        $response = $result->unwrap();
+
+        $this->assertCount(0, $response->songs);
+    }
+
+    #[Test]
+    public function cannotListWhenUnauthenticated(): void
+    {
+        $result = $this->getInstance()->handle();
+
+        $this->assertTrue($result->isErr());
+        $this->assertInstanceOf(AuthenticationError::class, $result->unwrapErr());
+    }
+
+    #[Test]
+    public function cannotListWhenUnauthorized(): void
+    {
+        $context = $this->app->make(AuthContext::class);
+        $context->set(AdminUser::reconstruct(
+            $this->generateUuid(),
+            'Unprivileged User',
+            'unprivileged@example.com',
+            new DateTimeImmutable(),
+            Role::General->value,
+            [], // No permissions
+        ));
+
+        $result = $this->getInstance()->handle();
+
+        $this->assertTrue($result->isErr());
+        $this->assertInstanceOf(AuthorizationError::class, $result->unwrapErr());
+    }
+
+    private function getInstance(): ListInteractor
+    {
         return $this->app->make(ListInteractor::class);
     }
 }

--- a/src/server/tests/Integration/SongType/Application/Interactors/ListInteractorTest.php
+++ b/src/server/tests/Integration/SongType/Application/Interactors/ListInteractorTest.php
@@ -2,57 +2,32 @@
 
 declare(strict_types=1);
 
-namespace Tests\Integration\Creator\Application\Interactors;
+namespace Tests\Integration\SongType\Application\Interactors;
 
 use AdminUser\Domain\Models\AdminUser;
 use AdminUser\Domain\Models\Role;
 use Auth\Domain\Models\AuthContext;
-use Creator\Application\Interactors\ListInteractor;
-use Creator\DebugInfrastructures\FileCreatorRepository;
 use DateTimeImmutable;
 use PHPUnit\Framework\Attributes\Test;
+use SongType\Application\Interactors\ListInteractor;
+use SongType\Domain\Models\SongType;
 use Support\UseCase\Error\AuthenticationError;
 use Support\UseCase\Error\AuthorizationError;
-use Tests\Support\Domain\EntityFactory;
-use Tests\Support\FileRepositoryTransaction;
 use Tests\TestCase;
 
 class ListInteractorTest extends TestCase
 {
-    use EntityFactory;
-    use FileRepositoryTransaction;
-
     #[Test]
-    public function nonEmptyCreators(): void
-    {
-        $this->privilegedContext();
-
-        $uuid = $this->generateUuid();
-
-        $this->factory(FileCreatorRepository::class, $this->createCreator($uuid, 'ヰ世界情緒')->toArray());
-
-        $result = $this->getInstance()->handle();
-        $this->assertTrue($result->isOk());
-
-        $response = $result->unwrap();
-
-        $this->assertCount(1, $response->creators);
-
-        $this->assertSame($uuid, $response->creators[0]->creatorId->value);
-        $this->assertSame('ヰ世界情緒', $response->creators[0]->name->value);
-    }
-
-    #[Test]
-    public function emptyCreators(): void
+    public function canList(): void
     {
         $this->privilegedContext();
 
         $result = $this->getInstance()->handle();
+
         $this->assertTrue($result->isOk());
 
-        $response = $result->unwrap();
-
-        $this->assertCount(0, $response->creators);
+        $types = $result->unwrap()->songTypes;
+        $this->assertCount(count(SongType::cases()), $types);
     }
 
     #[Test]


### PR DESCRIPTION
This PR improves the integration test coverage for the server interactors.

Changes include:
- Created `src/server/tests/Integration/AdminUser/Application/Interactors/ListInteractorTest.php` to test listing admin users.
- Created `src/server/tests/Integration/SongType/Application/Interactors/ListInteractorTest.php` to test listing song types.
- Updated `src/server/tests/Integration/Creator/Application/Interactors/ListInteractorTest.php` to include empty state and authorization checks.
- Updated `src/server/tests/Integration/Performer/Application/Interactors/ListInteractorTest.php` to include empty state and authorization checks.
- Updated `src/server/tests/Integration/Song/Application/Interactors/ListInteractorTest.php` to include empty state and authorization checks.

Verification:
- Manually reviewed the code to ensure it follows the existing testing patterns and properly uses `FileRepositoryTransaction` and `EntityFactory`.
- Tests could not be run locally due to PHP version mismatch (environment has 8.3.6, project requires 8.5+), but the logic is consistent with the codebase structure.

---
*PR created automatically by Jules for task [7162737391630210452](https://jules.google.com/task/7162737391630210452) started by @sayuprc*