### PR TITLE
Add missing unit tests for Song and AdminUser domains

### DIFF
--- a/src/server/tests/Unit/AdminUser/Domain/Models/AdminUserTest.php
+++ b/src/server/tests/Unit/AdminUser/Domain/Models/AdminUserTest.php
@@ -62,7 +62,7 @@ class AdminUserTest extends TestCase
                     'admin@example.com',
                     new DateTimeImmutable(),
                     Role::Privilege->value,
-                    [] // No explicit permissions
+                    [], // No explicit permissions
                 ),
                 Permission::ReadSong,
                 true,
@@ -74,7 +74,7 @@ class AdminUserTest extends TestCase
                     'user@example.com',
                     new DateTimeImmutable(),
                     Role::General->value,
-                    [Permission::ReadSong->value]
+                    [Permission::ReadSong->value],
                 ),
                 Permission::ReadSong,
                 true,
@@ -86,7 +86,7 @@ class AdminUserTest extends TestCase
                     'user@example.com',
                     new DateTimeImmutable(),
                     Role::General->value,
-                    [Permission::ReadSong->value]
+                    [Permission::ReadSong->value],
                 ),
                 Permission::WriteSong,
                 false,

--- a/src/server/tests/Unit/AdminUser/Domain/Models/AdminUserTest.php
+++ b/src/server/tests/Unit/AdminUser/Domain/Models/AdminUserTest.php
@@ -21,6 +21,79 @@ class AdminUserTest extends TestCase
         $this->assertSame($expected, $object->equals($other));
     }
 
+    #[Test]
+    public function toArray(): void
+    {
+        $adminUser = AdminUser::reconstruct(
+            '11111111-1111-1111-1111-111111111111',
+            'ユーザー1',
+            'admin@example.com',
+            new DateTimeImmutable('2026-01-01 00:00:00'),
+            Role::General->value,
+            [Permission::ReadSong->value, Permission::WriteSong->value],
+        );
+
+        $expected = [
+            'admin_user_id' => '11111111-1111-1111-1111-111111111111',
+            'name' => 'ユーザー1',
+            'email' => 'admin@example.com',
+            'created_at' => '2026-01-01 00:00:00',
+            'role' => Role::General->value,
+            'permissions' => [Permission::ReadSong->value, Permission::WriteSong->value],
+        ];
+
+        $this->assertSame($expected, $adminUser->toArray());
+    }
+
+    #[Test]
+    #[DataProvider('canDataProvider')]
+    public function can(AdminUser $adminUser, Permission $permission, bool $expected): void
+    {
+        $this->assertSame($expected, $adminUser->can($permission));
+    }
+
+    public static function canDataProvider(): array
+    {
+        return [
+            'Privilege user can do anything' => [
+                AdminUser::reconstruct(
+                    '11111111-1111-1111-1111-111111111111',
+                    'Admin',
+                    'admin@example.com',
+                    new DateTimeImmutable(),
+                    Role::Privilege->value,
+                    [] // No explicit permissions
+                ),
+                Permission::ReadSong,
+                true,
+            ],
+            'General user with permission can do it' => [
+                AdminUser::reconstruct(
+                    '11111111-1111-1111-1111-111111111111',
+                    'User',
+                    'user@example.com',
+                    new DateTimeImmutable(),
+                    Role::General->value,
+                    [Permission::ReadSong->value]
+                ),
+                Permission::ReadSong,
+                true,
+            ],
+            'General user without permission cannot do it' => [
+                AdminUser::reconstruct(
+                    '11111111-1111-1111-1111-111111111111',
+                    'User',
+                    'user@example.com',
+                    new DateTimeImmutable(),
+                    Role::General->value,
+                    [Permission::ReadSong->value]
+                ),
+                Permission::WriteSong,
+                false,
+            ],
+        ];
+    }
+
     public static function equalsDataProvider(): array
     {
         return [

--- a/src/server/tests/Unit/AdminUser/Domain/Models/PermissionTest.php
+++ b/src/server/tests/Unit/AdminUser/Domain/Models/PermissionTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\AdminUser\Domain\Models;
+
+use AdminUser\Domain\Models\Permission;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class PermissionTest extends TestCase
+{
+    #[Test]
+    #[DataProvider('getNameDataProvider')]
+    public function getName(Permission $permission, string $expected): void
+    {
+        $this->assertSame($expected, $permission->getName());
+    }
+
+    public static function getNameDataProvider(): array
+    {
+        return [
+            [Permission::ReadAdminUser, '管理ユーザー閲覧'],
+            [Permission::WriteAdminUser, '管理ユーザー編集'],
+            [Permission::ReadCreator, 'クリエイター閲覧'],
+            [Permission::WriteCreator, 'クリエイター編集'],
+            [Permission::ReadPerformer, '共演者閲覧'],
+            [Permission::WritePerformer, '共演者編集'],
+            [Permission::ReadSong, '楽曲閲覧'],
+            [Permission::WriteSong, '楽曲編集'],
+            [Permission::ReadSongType, '楽曲種別閲覧'],
+        ];
+    }
+}

--- a/src/server/tests/Unit/AdminUser/Domain/Models/PermissionsTest.php
+++ b/src/server/tests/Unit/AdminUser/Domain/Models/PermissionsTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\AdminUser\Domain\Models;
+
+use AdminUser\Domain\Models\Permission;
+use AdminUser\Domain\Models\Permissions;
+use PHPUnit\Framework\Attributes\Test;
+use Support\Domain\Error\DomainRuleViolationError;
+use Tests\TestCase;
+
+class PermissionsTest extends TestCase
+{
+    #[Test]
+    public function fromArray(): void
+    {
+        $input = [Permission::ReadSong->value, Permission::WriteSong->value];
+        $result = Permissions::fromArray($input);
+
+        $this->assertTrue($result->isOk());
+        $permissions = $result->unwrap();
+        $this->assertCount(2, $permissions);
+        $this->assertSame(Permission::ReadSong, $permissions[0]);
+        $this->assertSame(Permission::WriteSong, $permissions[1]);
+    }
+
+    #[Test]
+    public function fromArrayError(): void
+    {
+        $input = ['invalid_permission'];
+        $result = Permissions::fromArray($input);
+
+        $this->assertTrue($result->isErr());
+        $error = $result->unwrapErr();
+        $this->assertInstanceOf(DomainRuleViolationError::class, $error);
+        $this->assertSame('権限', $error->field);
+        $this->assertSame('不正な権限です', $error->message);
+    }
+
+    #[Test]
+    public function reconstruct(): void
+    {
+        $input = [Permission::ReadSong->value, Permission::WriteSong->value];
+        $permissions = Permissions::reconstruct($input);
+
+        $this->assertCount(2, $permissions);
+        $this->assertSame(Permission::ReadSong, $permissions[0]);
+        $this->assertSame(Permission::WriteSong, $permissions[1]);
+    }
+
+    #[Test]
+    public function toArray(): void
+    {
+        $input = [Permission::ReadSong->value, Permission::WriteSong->value];
+        $permissions = Permissions::reconstruct($input);
+
+        $this->assertSame($input, $permissions->toArray());
+    }
+}

--- a/src/server/tests/Unit/Song/Domain/Models/Creators/ArrangersTest.php
+++ b/src/server/tests/Unit/Song/Domain/Models/Creators/ArrangersTest.php
@@ -42,4 +42,22 @@ class ArrangersTest extends TestCase
 
         $this->assertCount(0, $arrangers);
     }
+
+    #[Test]
+    public function toArray(): void
+    {
+        $input = [
+            ['creatorId' => 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'],
+            ['creatorId' => 'BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB'],
+        ];
+
+        $arrangers = Arrangers::fromArray($input)->unwrap();
+
+        $expected = [
+            ['creator_id' => 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA', 'order_no' => 1],
+            ['creator_id' => 'BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB', 'order_no' => 2],
+        ];
+
+        $this->assertSame($expected, $arrangers->toArray());
+    }
 }

--- a/src/server/tests/Unit/Song/Domain/Models/Creators/ComposersTest.php
+++ b/src/server/tests/Unit/Song/Domain/Models/Creators/ComposersTest.php
@@ -42,4 +42,22 @@ class ComposersTest extends TestCase
 
         $this->assertCount(0, $composers);
     }
+
+    #[Test]
+    public function toArray(): void
+    {
+        $input = [
+            ['creatorId' => 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'],
+            ['creatorId' => 'BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB'],
+        ];
+
+        $composers = Composers::fromArray($input)->unwrap();
+
+        $expected = [
+            ['creator_id' => 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA', 'order_no' => 1],
+            ['creator_id' => 'BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB', 'order_no' => 2],
+        ];
+
+        $this->assertSame($expected, $composers->toArray());
+    }
 }

--- a/src/server/tests/Unit/Song/Domain/Models/Creators/LyricistsTest.php
+++ b/src/server/tests/Unit/Song/Domain/Models/Creators/LyricistsTest.php
@@ -42,4 +42,22 @@ class LyricistsTest extends TestCase
 
         $this->assertCount(0, $lyricists);
     }
+
+    #[Test]
+    public function toArray(): void
+    {
+        $input = [
+            ['creatorId' => 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'],
+            ['creatorId' => 'BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB'],
+        ];
+
+        $lyricists = Lyricists::fromArray($input)->unwrap();
+
+        $expected = [
+            ['creator_id' => 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA', 'order_no' => 1],
+            ['creator_id' => 'BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB', 'order_no' => 2],
+        ];
+
+        $this->assertSame($expected, $lyricists->toArray());
+    }
 }

--- a/src/server/tests/Unit/Song/Domain/Models/SongTest.php
+++ b/src/server/tests/Unit/Song/Domain/Models/SongTest.php
@@ -19,6 +19,40 @@ class SongTest extends TestCase
         $this->assertSame($expected, $object->equals($other));
     }
 
+    #[Test]
+    public function toArray(): void
+    {
+        $song = Song::reconstruct(
+            '11111111-1111-1111-1111-111111111111',
+            'Song Title',
+            'Song Description',
+            SongType::Original->value,
+            1,
+            self::creators('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'),
+            self::creators('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'),
+            self::creators('cccccccc-cccc-cccc-cccc-cccccccccccc'),
+        );
+
+        $expected = [
+            'song_id' => '11111111-1111-1111-1111-111111111111',
+            'title' => 'Song Title',
+            'description' => 'Song Description',
+            'song_type' => SongType::Original->value,
+            'order_no' => 1,
+            'arrangers' => [
+                ['creator_id' => 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'order_no' => 1],
+            ],
+            'composers' => [
+                ['creator_id' => 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 'order_no' => 1],
+            ],
+            'lyricists' => [
+                ['creator_id' => 'cccccccc-cccc-cccc-cccc-cccccccccccc', 'order_no' => 1],
+            ],
+        ];
+
+        $this->assertSame($expected, $song->toArray());
+    }
+
     public static function equalsDataProvider(): array
     {
         return [


### PR DESCRIPTION
This PR adds unit tests for `Song`, `AdminUser`, and related value objects to verify `toArray` serialization and authorization logic (`can`). It also adds tests for `Permissions` collection and `Permission` enum to ensure correct behavior. No changes to production code were made, only test files were added or modified. The changes were verified by running tests locally (with adjusted dependencies for PHP 8.3 environment).

---
*PR created automatically by Jules for task [4295787882291131683](https://jules.google.com/task/4295787882291131683) started by @sayuprc*