### PR TITLE
GitHub App を利用するように変更

### DIFF
--- a/.github/workflows/update-actions-version.yml
+++ b/.github/workflows/update-actions-version.yml
@@ -10,25 +10,31 @@ jobs:
   pinact:
     runs-on: ubuntu-latest
 
-    permissions:
-      contents: write
-      pull-requests: write
-
     steps:
+      - name: Generate token
+        id: generate-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ secrets.CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout the code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Setup mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
 
       - name: Update action versions
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: pinact run --min-age 7 --update
 
       - name: Create pull request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
+          token: ${{ steps.generate-token.outputs.token }}
           branch: auto/update-actions-version
           commit-message: 'ci: update pinned actions versions'
           title: 'ci: update pinned actions versions'


### PR DESCRIPTION
## 概要

GitHub App 経由で PR 作成できるようにした
将来的にこれらは Terraform や Secret Manager などで管理する予定