### PR TITLE
Codex でも hook を使うようにした

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,2 @@
+[features]
+codex_hooks = true

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,36 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .github/hooks/protect-config.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .github/hooks/post-lint.sh"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .github/hooks/stop-verify.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## 概要

resolve #620 

apm で管理しようと思ったが、Copilot と Claude/Codex の相性が悪かったのでスクリプトを一元管理するだけにとどめている

※ Copilot と Claude/Codex の hooks.json の書き方が違い、apm はその差分を吸収しない