### PR TITLE
Add order_no to song tag contract

### DIFF
--- a/docs/exec-plans/completed/20260429-song-tag-order-no.md
+++ b/docs/exec-plans/completed/20260429-song-tag-order-no.md
@@ -1,0 +1,59 @@
+# Title
+
+楽曲タグに order_no を追加
+
+## Status
+
+completed
+
+## Background
+
+楽曲タグ定義では `order_no` が契約に存在せず、`SongTag` のレスポンスや更新入力、検索ソート条件が名前ベースに限定されている。ほかのマスタ系（`Creator`、`Performer`、`Song`）は `order_no` を持っており、管理対象の並び順を統一して扱えない。
+
+## Goal
+
+楽曲タグでも `order_no` を正式な契約とデータ定義に含め、一覧・検索・更新で表示順を扱える状態にする。
+
+## Scope
+
+- `src/contracts/src/admin/song-tags/domain.tsp` の `SongTag` に `orderNo` を追加する
+- `src/contracts/src/admin/song-tags/transport.tsp` の更新リクエスト/レスポンス定義に `orderNo` の入出力要件を反映する
+- `src/contracts/src/admin/song-tags/service.tsp` の検索ソート条件とデフォルト順を `order_no` 対応に揃える
+- `src/contracts/generated/oas/IsekaiObservatory.Admin.v1.yaml` と `src/admin/src/generated/types.gen.ts` など生成物に変更を反映する
+
+## Non-Scope
+
+- `song_taggings` の並び順仕様変更
+- 楽曲タグ以外のマスタ（クリエイター、歌唱者、楽曲）の仕様変更
+- 管理画面の見た目だけを先行して変える対応
+
+## Acceptance Criteria
+
+- `SongTag` の契約定義と生成された OpenAPI/TypeScript 型に `order_no` が含まれる
+- 楽曲タグ検索のソート条件で `order_no` を指定でき、デフォルトソートも `order_no` になる
+- 楽曲タグ更新入力で `order_no` を受け取れる定義になっている
+
+## Steps
+
+1. ✅ `src/contracts/src/admin/song-tags/domain.tsp` を更新し、`Creator` / `Performer` と同じパターンで `SongTag` に `orderNo: orderNo;` を追加する。`@example` にも `orderNo` を含め、レスポンス契約の Source of Truth を揃える。
+2. ✅ `src/contracts/src/admin/song-tags/transport.tsp` を更新し、`SongTagUpdateRequest` に `orderNo: orderNo;` を追加する。`SongTagCreateRequest` は今回の Acceptance Criteria と Non-Scope に含まれないため変更しない。
+3. ✅ `src/contracts/src/admin/song-tags/service.tsp` を更新し、`SongTagSearchSortBy` に `orderNo: "order_no"` を追加する。`searchSongTags` の `sort` デフォルト値も `SongTagSearchSortBy.orderNo` に変更し、他マスタの検索契約と整合させる。
+4. ✅ `mise run contract:compile:admin` を実行して `src/contracts/generated/oas/IsekaiObservatory.Admin.v1.yaml` を再生成し、`SongTag` スキーマ、`SongTagUpdateRequest`、`SongTagSearchSortBy`、`/song-tags/search` のデフォルトクエリに `order_no` が反映されることを確認する。
+5. ✅ `mise run generate:client:admin` を実行して `src/admin/src/generated/types.gen.ts` と `src/admin/src/generated/index.ts` を更新し、`SongTag` 型、`SongTagUpdateRequest` 型、`SongTagSearchSortBy` 型に `order_no` 対応が反映されることを確認する。
+6. ✅ `mise run generate:server` を実行して `src/server/Generated/lib/Model/SongTag.php`、`src/server/Generated/lib/Model/SongTagUpdateRequest.php`、`src/server/Generated/lib/Model/SongTagSearchSortBy.php`、必要に応じて `src/server/Generated/lib/Api/SongTagApi.php` を更新し、サーバー側生成物も契約に追従させる。
+7. ✅ 生成差分を確認し、`song-tags` 以外の手編集や `dump.sql` / スキーマ変更が含まれていないことを確認する。不要な差分が混ざる場合は再生成手順を見直し、契約定義と生成物だけに差分を閉じ込める。
+
+## Decision Log
+
+- 2026-04-29: 今回の対象は「契約定義と生成物のみ」とし、`src/server/dump.sql` と Atlas スキーマは変更しない。
+- 2026-04-29: `SongTag` の `orderNo` 追加パターンは `Creator` / `Performer` を踏襲し、同じ `orderNo` 共通 scalar を使う。
+- 2026-04-29: 更新入力は Acceptance Criteria に合わせて `SongTagUpdateRequest` のみ拡張し、作成入力への `orderNo` 追加はこの計画には含めない。
+- 2026-04-29: 検索ソートは既存マスタと同様に `order_no` を enum 値にし、デフォルトも `order_no` に寄せる。
+- 2026-04-29: 生成物は OpenAPI、Admin クライアント、Server OpenAPI クライアントまで更新対象に含める。
+
+## Validation
+
+- `mise run contract:compile:admin` を実行し、`src/contracts/generated/oas/IsekaiObservatory.Admin.v1.yaml` に `SongTag.orderNo`、`SongTagUpdateRequest.orderNo`、`SongTagSearchSortBy.order_no`、検索 API の `sort` デフォルト `order_no` が出力されることを確認する。
+- `mise run generate:client:admin` を実行し、`src/admin/src/generated/types.gen.ts` の `SongTag` / `SongTagUpdateRequest` / `SongTagSearchSortBy` が契約どおり更新されることを確認する。
+- `mise run generate:server` を実行し、`src/server/Generated/lib/Model/SongTag*.php` と `src/server/Generated/lib/Api/SongTagApi.php` に `order_no` 関連定義が反映されることを確認する。
+- `git diff -- docs/exec-plans/active/20260429-song-tag-order-no.md src/contracts/src/admin/song-tags src/contracts/generated/oas src/admin/src/generated src/server/Generated` 相当の差分確認で、変更が契約定義と生成物に限定されていることを確認する。

--- a/src/admin/src/generated/types.gen.ts
+++ b/src/admin/src/generated/types.gen.ts
@@ -241,6 +241,7 @@ export type SongSummary = {
 export type SongTag = {
     songTagId: SongTagId;
     name: SongTagName;
+    orderNo: OrderNo;
 };
 
 export type SongTagCreateRequest = {
@@ -263,10 +264,11 @@ export type SongTagSearchResponse = {
 /**
  * 楽曲タグ検索のソート条件
  */
-export type SongTagSearchSortBy = 'name';
+export type SongTagSearchSortBy = 'name' | 'order_no';
 
 export type SongTagUpdateRequest = {
     name: SongTagName;
+    orderNo: OrderNo;
 };
 
 export type SongTagUpdateResponse = {

--- a/src/contracts/generated/oas/IsekaiObservatory.Admin.v1.yaml
+++ b/src/contracts/generated/oas/IsekaiObservatory.Admin.v1.yaml
@@ -717,7 +717,7 @@ paths:
           required: false
           schema:
             $ref: '#/components/schemas/SongTagSearchSortBy'
-            default: name
+            default: order_no
           explode: false
         - name: order
           in: query
@@ -1693,14 +1693,18 @@ components:
       required:
         - songTagId
         - name
+        - orderNo
       properties:
         songTagId:
           $ref: '#/components/schemas/songTagId'
         name:
           $ref: '#/components/schemas/songTagName'
+        orderNo:
+          $ref: '#/components/schemas/orderNo'
       examples:
         - songTagId: 3cd42c09-ff3c-4cd2-913f-a279c4ea89b4
           name: 派生曲
+          orderNo: 10
     SongTagCreateRequest:
       type: object
       required:
@@ -1741,14 +1745,18 @@ components:
       type: string
       enum:
         - name
+        - order_no
       description: 楽曲タグ検索のソート条件
     SongTagUpdateRequest:
       type: object
       required:
         - name
+        - orderNo
       properties:
         name:
           $ref: '#/components/schemas/songTagName'
+        orderNo:
+          $ref: '#/components/schemas/orderNo'
     SongTagUpdateResponse:
       type: object
       required:

--- a/src/contracts/src/admin/song-tags/domain.tsp
+++ b/src/contracts/src/admin/song-tags/domain.tsp
@@ -9,8 +9,9 @@ scalar songTagId extends uuid;
 @minLength(1)
 scalar songTagName extends string;
 
-@example(#{ songTagId: "3cd42c09-ff3c-4cd2-913f-a279c4ea89b4", name: "派生曲" })
+@example(#{ songTagId: "3cd42c09-ff3c-4cd2-913f-a279c4ea89b4", name: "派生曲", orderNo: 10 })
 model SongTag {
   songTagId: songTagId;
   name: songTagName;
+  orderNo: orderNo;
 }

--- a/src/contracts/src/admin/song-tags/service.tsp
+++ b/src/contracts/src/admin/song-tags/service.tsp
@@ -9,6 +9,7 @@ namespace IsekaiObservatory.Admin;
 @doc("楽曲タグ検索のソート条件")
 enum SongTagSearchSortBy {
   name: "name",
+  orderNo: "order_no",
 }
 
 @tag("SongTag")
@@ -22,7 +23,7 @@ interface SongTagService {
   @route("/search")
   searchSongTags(
     @query name?: string,
-    @query sort?: SongTagSearchSortBy = SongTagSearchSortBy.name,
+    @query sort?: SongTagSearchSortBy = SongTagSearchSortBy.orderNo,
     @query order?: SortOrder = SortOrder.asc,
     @query page?: page = 1,
     @query("per_page") perPage?: PerPage = PerPage.fifty,

--- a/src/contracts/src/admin/song-tags/transport.tsp
+++ b/src/contracts/src/admin/song-tags/transport.tsp
@@ -19,6 +19,7 @@ model SongTagCreateResponse {
 
 model SongTagUpdateRequest {
   name: songTagName;
+  orderNo: orderNo;
 }
 
 model SongTagUpdateResponse {

--- a/src/server/Generated/lib/Model/SongTag.php
+++ b/src/server/Generated/lib/Model/SongTag.php
@@ -58,7 +58,8 @@ class SongTag implements ModelInterface, ArrayAccess, \JsonSerializable
       */
     protected static $openAPITypes = [
         'song_tag_id' => 'string',
-        'name' => 'string'
+        'name' => 'string',
+        'order_no' => 'int'
     ];
 
     /**
@@ -70,7 +71,8 @@ class SongTag implements ModelInterface, ArrayAccess, \JsonSerializable
       */
     protected static $openAPIFormats = [
         'song_tag_id' => 'uuid',
-        'name' => null
+        'name' => null,
+        'order_no' => 'int32'
     ];
 
     /**
@@ -80,7 +82,8 @@ class SongTag implements ModelInterface, ArrayAccess, \JsonSerializable
       */
     protected static array $openAPINullables = [
         'song_tag_id' => false,
-        'name' => false
+        'name' => false,
+        'order_no' => false
     ];
 
     /**
@@ -170,7 +173,8 @@ class SongTag implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     protected static $attributeMap = [
         'song_tag_id' => 'songTagId',
-        'name' => 'name'
+        'name' => 'name',
+        'order_no' => 'orderNo'
     ];
 
     /**
@@ -180,7 +184,8 @@ class SongTag implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     protected static $setters = [
         'song_tag_id' => 'setSongTagId',
-        'name' => 'setName'
+        'name' => 'setName',
+        'order_no' => 'setOrderNo'
     ];
 
     /**
@@ -190,7 +195,8 @@ class SongTag implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     protected static $getters = [
         'song_tag_id' => 'getSongTagId',
-        'name' => 'getName'
+        'name' => 'getName',
+        'order_no' => 'getOrderNo'
     ];
 
     /**
@@ -252,6 +258,7 @@ class SongTag implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $this->setIfExists('song_tag_id', $data ?? [], null);
         $this->setIfExists('name', $data ?? [], null);
+        $this->setIfExists('order_no', $data ?? [], null);
     }
 
     /**
@@ -289,6 +296,13 @@ class SongTag implements ModelInterface, ArrayAccess, \JsonSerializable
         }
         if ((mb_strlen($this->container['name']) < 1)) {
             $invalidProperties[] = "invalid value for 'name', the character length must be bigger than or equal to 1.";
+        }
+
+        if ($this->container['order_no'] === null) {
+            $invalidProperties[] = "'order_no' can't be null";
+        }
+        if (($this->container['order_no'] < 1)) {
+            $invalidProperties[] = "invalid value for 'order_no', must be bigger than or equal to 1.";
         }
 
         return $invalidProperties;
@@ -361,6 +375,38 @@ class SongTag implements ModelInterface, ArrayAccess, \JsonSerializable
         }
 
         $this->container['name'] = $name;
+
+        return $this;
+    }
+
+    /**
+     * Gets order_no
+     *
+     * @return int
+     */
+    public function getOrderNo()
+    {
+        return $this->container['order_no'];
+    }
+
+    /**
+     * Sets order_no
+     *
+     * @param int $order_no 表示順
+     *
+     * @return self
+     */
+    public function setOrderNo($order_no)
+    {
+        if (is_null($order_no)) {
+            throw new \InvalidArgumentException('non-nullable order_no cannot be null');
+        }
+
+        if (($order_no < 1)) {
+            throw new \InvalidArgumentException('invalid value for $order_no when calling SongTag., must be bigger than or equal to 1.');
+        }
+
+        $this->container['order_no'] = $order_no;
 
         return $this;
     }

--- a/src/server/Generated/lib/Model/SongTagSearchSortBy.php
+++ b/src/server/Generated/lib/Model/SongTagSearchSortBy.php
@@ -45,6 +45,8 @@ enum SongTagSearchSortBy: string
      */
     case NAME = 'name';
 
+    case ORDER_NO = 'order_no';
+
 }
 
 

--- a/src/server/Generated/lib/Model/SongTagUpdateRequest.php
+++ b/src/server/Generated/lib/Model/SongTagUpdateRequest.php
@@ -57,7 +57,8 @@ class SongTagUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
       * @var string[]
       */
     protected static $openAPITypes = [
-        'name' => 'string'
+        'name' => 'string',
+        'order_no' => 'int'
     ];
 
     /**
@@ -68,7 +69,8 @@ class SongTagUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
       * @psalm-var array<string, string|null>
       */
     protected static $openAPIFormats = [
-        'name' => null
+        'name' => null,
+        'order_no' => 'int32'
     ];
 
     /**
@@ -77,7 +79,8 @@ class SongTagUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
       * @var boolean[]
       */
     protected static array $openAPINullables = [
-        'name' => false
+        'name' => false,
+        'order_no' => false
     ];
 
     /**
@@ -166,7 +169,8 @@ class SongTagUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      * @var string[]
      */
     protected static $attributeMap = [
-        'name' => 'name'
+        'name' => 'name',
+        'order_no' => 'orderNo'
     ];
 
     /**
@@ -175,7 +179,8 @@ class SongTagUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      * @var string[]
      */
     protected static $setters = [
-        'name' => 'setName'
+        'name' => 'setName',
+        'order_no' => 'setOrderNo'
     ];
 
     /**
@@ -184,7 +189,8 @@ class SongTagUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      * @var string[]
      */
     protected static $getters = [
-        'name' => 'getName'
+        'name' => 'getName',
+        'order_no' => 'getOrderNo'
     ];
 
     /**
@@ -245,6 +251,7 @@ class SongTagUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
     public function __construct(?array $data = null)
     {
         $this->setIfExists('name', $data ?? [], null);
+        $this->setIfExists('order_no', $data ?? [], null);
     }
 
     /**
@@ -279,6 +286,13 @@ class SongTagUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
         }
         if ((mb_strlen($this->container['name']) < 1)) {
             $invalidProperties[] = "invalid value for 'name', the character length must be bigger than or equal to 1.";
+        }
+
+        if ($this->container['order_no'] === null) {
+            $invalidProperties[] = "'order_no' can't be null";
+        }
+        if (($this->container['order_no'] < 1)) {
+            $invalidProperties[] = "invalid value for 'order_no', must be bigger than or equal to 1.";
         }
 
         return $invalidProperties;
@@ -324,6 +338,38 @@ class SongTagUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
         }
 
         $this->container['name'] = $name;
+
+        return $this;
+    }
+
+    /**
+     * Gets order_no
+     *
+     * @return int
+     */
+    public function getOrderNo()
+    {
+        return $this->container['order_no'];
+    }
+
+    /**
+     * Sets order_no
+     *
+     * @param int $order_no 表示順
+     *
+     * @return self
+     */
+    public function setOrderNo($order_no)
+    {
+        if (is_null($order_no)) {
+            throw new \InvalidArgumentException('non-nullable order_no cannot be null');
+        }
+
+        if (($order_no < 1)) {
+            throw new \InvalidArgumentException('invalid value for $order_no when calling SongTagUpdateRequest., must be bigger than or equal to 1.');
+        }
+
+        $this->container['order_no'] = $order_no;
 
         return $this;
     }


### PR DESCRIPTION
## Summary
- add orderNo to the song tag TypeSpec contract and update request/search definitions
- regenerate Admin OpenAPI, TypeScript client types, and server PHP models for song tags
- record the execution plan in completed docs

## Testing
- mise run contract:compile:admin
- mise run generate:client:admin
- mise run generate:server