### PR TITLE
楽曲タグ作成機能を作成

### DIFF
--- a/docs/exec-plans/completed/20260429-song-tag-registration.md
+++ b/docs/exec-plans/completed/20260429-song-tag-registration.md
@@ -1,0 +1,67 @@
+# Title
+
+楽曲タグ登録機能の実装
+
+## Status
+
+completed
+
+## Background
+
+`src/contracts/src/admin/song-tags/service.tsp` には `createSongTag` 契約が既にあり、`src/admin/src/generated` も `song-tags` のクライアントを持っている。一方で、`src/server/app/Http/Controllers/Api/SongTag` や `src/server/app/Http/Presenters/Api/SongTag` は未実装で、`src/admin/src/server/routes` と `src/admin/src/pages` にも登録導線がない。`src/server/packages/Song` 側には `SongTag` の domain 基盤はあるが、作成に必要な `orderNo` / 保存処理 / create 用 use case はまだ揃っていないため、管理画面から新規登録できない状態になっている。
+
+## Goal
+
+管理画面から楽曲タグを新規作成できるようにし、既存の `createSongTag` 契約に沿ってサーバ API と admin BFF / 画面をつなぐ。
+
+## Scope
+
+- `src/server/packages/Song/Domain/Models/Tag/SongTag.php` を作成用に拡張し、`orderNo` を含むレスポンス前提の形に揃える
+- `src/server/packages/Song/Domain/Models/Tag/SongTagFactoryInterface.php`、`SongTagRepositoryInterface.php`、`src/server/packages/Song/Infrastructures/Tag/SongTagFactory.php`、`SongTagRepository.php` に create/save 用の最小実装を追加する
+- `src/server/packages/Song/Application/Interactors/Tag` と `src/server/packages/Song/Application/UseCase/Tag/Create` に、楽曲タグ作成用の use case 一式を追加する
+- `src/server/app/Http/Controllers/Api/SongTag/CreateSongTagController.php`、`src/server/app/Http/Presenters/Api/SongTag/CreatePresenter.php`、`src/server/app/Http/Presenters/Api/SongTag/Converter.php` を追加する
+- `src/server/routes/admin.php` に `song-tags` の create ルートを追加する
+- `src/admin/src/server/routes/song-tags.ts` を追加し、作成 API を呼び出せるようにする
+- `src/admin/src/pages/song-tags/create/index.astro` と `src/admin/src/components/song-tag/CreateForm.tsx` を追加し、成功メッセージを見える形で返す
+
+## Non-Scope
+
+- `src/contracts/src/admin/song-tags` の契約変更
+- `song-tags` の一覧・検索・詳細・更新・削除機能
+- `song-tags` 用の DB スキーマ変更やマイグレーション追加
+- `src/server/app/Models/Song/SongTag.php` の再設計
+- `src/server/app/Providers/Domain/SongServiceProvider.php` 以外の DI 構成の再編成
+
+## Acceptance Criteria
+
+- 管理者が `POST /admin/v1/song-tags` を送ると、`createSongTag` 契約に沿った成功レスポンスまたは入力エラーが返る
+- `src/admin/src/pages/song-tags/create/index.astro` から楽曲タグを新規登録でき、成功時に画面上で完了が分かる
+- 追加した server 側の controller / presenter / use case と admin 側の BFF / 画面が、既存の `createSongTag` 契約を前提に接続されている
+- 今回の変更に `src/contracts/src/admin/song-tags` の契約修正は含まれていない
+
+## Steps
+
+1. ✅ `SongTag` の domain 基盤を作成用に揃える。`src/server/packages/Song/Domain/Models/Tag/SongTag.php` に `orderNo` を追加し、`SongTagFactoryInterface` / `SongTagRepositoryInterface` を create 用の最小契約に拡張する。あわせて `src/server/packages/Song/Infrastructures/Tag/SongTagFactory.php` / `SongTagRepository.php` を実装し、`getMaxOrderNo()` と `save()`、必要なら `findByName()` を提供できるようにする。
+2. ✅ 作成時の整合性チェックをまとめる `SongTag` 用の domain service を追加する。`SongTagName` の入力検証、重複名チェック、`orderNo = max + 10` の採番をこの層に寄せ、後続の use case からは「作成に必要な検証済みの `SongTag` を受け取る」形にする。
+3. ✅ `src/server/packages/Song/Application/UseCase/Tag/Create` と `src/server/packages/Song/Application/Interactors/Tag/CreateInteractor.php` を追加する。`AuthContext` と権限チェック、transaction、domain service 呼び出し、repository 保存、`Result<...>` への error mapping までを Creator / Song の既存パターンに合わせて実装する。
+4. ✅ `src/server/app/Http/Controllers/Api/SongTag/CreateSongTagController.php`、`src/server/app/Http/Presenters/Api/SongTag/CreatePresenter.php`、`src/server/app/Http/Presenters/Api/SongTag/Converter.php` を追加する。`SongTagCreateResponse` に `SongTag` を詰めて返し、validation / business error は既存の `ResolvesUseCaseError` に乗せる。
+5. ✅ `src/server/routes/admin.php` に `POST /admin/v1/song-tags` を追加し、`SongTagRouteMap::Create` に結びつける。`OpenApiValidator` と `Authenticate` の適用位置は既存の `creators` / `songs` と同じ構造に揃える。
+6. ✅ `src/admin/src/server/routes/song-tags.ts` を追加し、`songTagServiceCreateSongTag` を呼ぶ BFF を用意する。入力は `name` のみとし、`resolveApiResponse` と `authGuard` は既存ルートと同じ流れを再利用する。
+7. ✅ `src/admin/src/pages/song-tags/create/index.astro` と `src/admin/src/components/song-tag/CreateForm.tsx` を追加する。成功後は `setFlash` で結果を保持し、`FlashMessage` を create page 側に載せて `/song-tags/create` へ戻したときに完了が見えるようにする。
+8. ✅ `mise run phpstan` と `bunx tsc --noEmit` 相当の検証を前提に、server 側は controller / presenter / use case / domain、admin 側は BFF / page / component の結合点だけを重点確認する。
+
+## Decision Log
+
+- 2026-04-29: `song-tags` は既存の `Song` package に集約し、専用 package や追加の service provider は作らない。既存の `Song` / `Creator` の分離方針に合わせて HTTP 層だけ `SongTag` 名前空間で切る。
+- 2026-04-29: `createSongTag` 契約と生成済み admin client は既にあるため、契約変更と再生成は行わない。今回の作業は実装接続に限定する。
+- 2026-04-29: `SongTag` のレスポンスには `orderNo` が必要なので、domain model と presenter でこの値を返す前提に揃える。DB 側の既存カラムをそのまま利用する。
+- 2026-04-29: 作成後の成功表示は list 画面への遷移ではなく、`/song-tags/create` へ戻して `FlashMessage` を出す。`song-tags` の一覧ページはこのタスクの範囲に含めない。
+- 2026-04-29: 永続化は Creator と同じく repository / factory 経由に統一し、controller から Eloquent model を直接触らない。
+- 2026-04-29: `SongTag` domain model 自体は実装前から `orderNo` と `toArray()` を持っていたため、Step 1 は create 向け interface / repository / factory の追加に絞って進めた。
+
+## Validation
+
+- `mise run phpstan` で `src/server/packages/Song`、`src/server/app/Http/Controllers/Api/SongTag`、`src/server/app/Http/Presenters/Api/SongTag`、`src/server/routes/admin.php` の静的解析が通ることを確認する。
+- `bunx tsc --noEmit` で `src/admin/src/server/routes/song-tags.ts`、`src/admin/src/components/song-tag/CreateForm.tsx`、`src/admin/src/pages/song-tags/create/index.astro` の型エラーがないことを確認する。
+- ブラウザまたは API で `POST /admin/v1/song-tags` を送信し、成功時に `/song-tags/create` 上で完了メッセージが表示されること、失敗時に入力エラーが `name` に紐づくことを確認する。
+- 変更差分を確認し、今回の編集が `src/server/packages/Song`、`src/server/app/Http/Controllers/Api/SongTag`、`src/server/app/Http/Presenters/Api/SongTag`、`src/server/routes/admin.php`、`src/admin/src/server/routes/song-tags.ts`、`src/admin/src/pages/song-tags/create/index.astro`、`src/admin/src/components/song-tag/CreateForm.tsx`、および計画書に閉じていることを確認する。

--- a/src/admin/src/components/song-tag/CreateForm.tsx
+++ b/src/admin/src/components/song-tag/CreateForm.tsx
@@ -1,0 +1,54 @@
+import { Show } from 'solid-js';
+import { client } from '../../utils/client';
+import { createFormErrors } from '../../utils/form-error';
+import { createSubmitting } from '../../utils/use-submitting';
+import { setFlash } from '../Flash';
+import { FormError } from '../FormError';
+
+export const CreateForm = () => {
+  const { formError, getFieldError, clearErrors, handleError } = createFormErrors();
+  const { isSubmitting, withSubmitting } = createSubmitting();
+
+  const handleSubmit = withSubmitting(async (e: Event) => {
+    e.preventDefault();
+    clearErrors();
+
+    const form = e.target as HTMLFormElement;
+    const formData = new FormData(form);
+
+    const { data, error, status } = await client.api['song-tags'].post({
+      name: formData.get('name')?.toString() ?? '',
+    });
+
+    if (data) {
+      setFlash('作成しました');
+      window.location.href = '/song-tags/create';
+      return;
+    }
+
+    handleError(status, error);
+  });
+
+  return (
+    <form onsubmit={handleSubmit}>
+      <FormError message={formError()} onClose={clearErrors} />
+      <fieldset class="fieldset bg-base-200 border-base-300 rounded-box max-w-lg border p-6">
+        <label class="label">楽曲タグ名</label>
+        <input
+          type="text"
+          class="input w-full"
+          name="name"
+          required
+          classList={{ 'input-error': !!getFieldError('name') }}
+        />
+        <Show when={getFieldError('name')}>{message => <p class="mt-1 text-xs text-error">{message()}</p>}</Show>
+
+        <div class="mt-6 flex justify-end">
+          <button class="btn btn-primary" disabled={isSubmitting()}>
+            {isSubmitting() ? '作成中...' : '作成'}
+          </button>
+        </div>
+      </fieldset>
+    </form>
+  );
+};

--- a/src/admin/src/pages/song-tags/create/index.astro
+++ b/src/admin/src/pages/song-tags/create/index.astro
@@ -1,0 +1,12 @@
+---
+import { FlashMessage } from '../../../components/Flash';
+import { CreateForm } from '../../../components/song-tag/CreateForm';
+import Layout from '../../../layouts/Layout.astro';
+
+export const prerender = false;
+---
+
+<Layout pageTitle="楽曲タグ作成">
+  <FlashMessage client:only="solid-js" />
+  <CreateForm client:load />
+</Layout>

--- a/src/admin/src/server/index.ts
+++ b/src/admin/src/server/index.ts
@@ -23,6 +23,7 @@ export const app = new Elysia({ prefix: '/api' })
   .use(songTags)
   .use(songTypes)
   .use(songAttributes)
+  .use(songTags)
   .use(songs);
 
 export type App = typeof app;

--- a/src/admin/src/server/routes/song-tags.ts
+++ b/src/admin/src/server/routes/song-tags.ts
@@ -1,5 +1,5 @@
 import { Elysia, t } from 'elysia';
-import { songTagServiceSearchSongTags,songTagServiceCreateSongTag } from '../../generated';
+import { songTagServiceSearchSongTags, songTagServiceCreateSongTag } from '../../generated';
 import type { PerPage, SongTagSearchSortBy, SortOrder } from '../../generated';
 import { createAuthClient } from '../client';
 import { resolveApiResponse } from '../errors';
@@ -30,8 +30,9 @@ export const songTags = new Elysia({ prefix: '/song-tags' })
         order: t.Optional(t.Union([t.Literal('asc'), t.Literal('desc')])),
         page: t.Optional(t.Number()),
         per_page: t.Optional(t.Number()),
-      })
-    })
+      }),
+    },
+  )
   .post(
     '/',
     async ({ body: { name }, credential }) => {

--- a/src/admin/src/server/routes/song-tags.ts
+++ b/src/admin/src/server/routes/song-tags.ts
@@ -1,5 +1,5 @@
 import { Elysia, t } from 'elysia';
-import { songTagServiceSearchSongTags } from '../../generated';
+import { songTagServiceSearchSongTags,songTagServiceCreateSongTag } from '../../generated';
 import type { PerPage, SongTagSearchSortBy, SortOrder } from '../../generated';
 import { createAuthClient } from '../client';
 import { resolveApiResponse } from '../errors';
@@ -30,6 +30,16 @@ export const songTags = new Elysia({ prefix: '/song-tags' })
         order: t.Optional(t.Union([t.Literal('asc'), t.Literal('desc')])),
         page: t.Optional(t.Number()),
         per_page: t.Optional(t.Number()),
+      })
+    })
+  .post(
+    '/',
+    async ({ body: { name }, credential }) => {
+      return resolveApiResponse(await songTagServiceCreateSongTag({ client: createAuthClient(credential), body: { name } }));
+    },
+    {
+      body: t.Object({
+        name: t.String(),
       }),
     },
   );

--- a/src/server/app/Http/Controllers/Api/SongTag/CreateSongTagController.php
+++ b/src/server/app/Http/Controllers/Api/SongTag/CreateSongTagController.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\SongTag;
+
+use App\Http\Controllers\Controller;
+use App\Http\Presenters\Api\SongTag\CreatePresenter;
+use Illuminate\Http\JsonResponse;
+use Song\Application\UseCase\Tag\Create\CreateInputData;
+use Song\Application\UseCase\Tag\Create\CreateUseCaseInterface;
+
+class CreateSongTagController extends Controller
+{
+    public function __construct(
+        private readonly CreateUseCaseInterface $interactor,
+        private readonly CreatePresenter $presenter,
+    ) {
+    }
+
+    public function handle(CreateInputData $inputData): JsonResponse
+    {
+        return $this->presenter->present($this->interactor->handle($inputData));
+    }
+}

--- a/src/server/app/Http/Presenters/Api/SongTag/Converter.php
+++ b/src/server/app/Http/Presenters/Api/SongTag/Converter.php
@@ -9,11 +9,11 @@ use Song\Domain\Models\Tag\SongTag;
 
 class Converter
 {
-    public function toOpenApiSongTag(SongTag $songTag): OpenApiSongTag
+    public function toOpenApiSongTag(SongTag $tag): OpenApiSongTag
     {
         return new OpenApiSongTag()
-            ->setSongTagId($songTag->songTagId->value)
-            ->setName($songTag->name->value)
-            ->setOrderNo($songTag->orderNo->value);
+            ->setSongTagId($tag->songTagId->value)
+            ->setName($tag->name->value)
+            ->setOrderNo($tag->orderNo->value);
     }
 }

--- a/src/server/app/Http/Presenters/Api/SongTag/CreatePresenter.php
+++ b/src/server/app/Http/Presenters/Api/SongTag/CreatePresenter.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Presenters\Api\SongTag;
+
+use App\Http\Presenters\Api\Support\ResolvesUseCaseError;
+use Illuminate\Http\JsonResponse;
+use OpenAPI\Client\Model\SongTagCreateResponse;
+use ResultType\Result;
+use Song\Application\UseCase\Tag\Create\CreateOutputData;
+use Support\UseCase\Error\UseCaseError;
+
+class CreatePresenter
+{
+    use ResolvesUseCaseError;
+
+    public function __construct(private readonly Converter $converter)
+    {
+    }
+
+    /**
+     * @param Result<CreateOutputData, UseCaseError> $result
+     */
+    public function present(Result $result): JsonResponse
+    {
+        [$data, $status] = $result->match(
+            function (CreateOutputData $outputData) {
+                return [
+                    new SongTagCreateResponse()->setTag($this->converter->toOpenApiSongTag($outputData->tag)),
+                    200,
+                ];
+            },
+            fn (UseCaseError $error) => $this->resolveError($error),
+        );
+
+        return response()->json($data, $status);
+    }
+}

--- a/src/server/app/Http/Presenters/Api/SongTag/CreatePresenter.php
+++ b/src/server/app/Http/Presenters/Api/SongTag/CreatePresenter.php
@@ -25,12 +25,10 @@ class CreatePresenter
     public function present(Result $result): JsonResponse
     {
         [$data, $status] = $result->match(
-            function (CreateOutputData $outputData) {
-                return [
-                    new SongTagCreateResponse()->setTag($this->converter->toOpenApiSongTag($outputData->tag)),
-                    200,
-                ];
-            },
+            fn (CreateOutputData $outputData) => [
+                new SongTagCreateResponse()->setTag($this->converter->toOpenApiSongTag($outputData->tag)),
+                200,
+            ],
             fn (UseCaseError $error) => $this->resolveError($error),
         );
 

--- a/src/server/app/Providers/Domain/SongServiceProvider.php
+++ b/src/server/app/Providers/Domain/SongServiceProvider.php
@@ -14,6 +14,7 @@ use Song\Application\Interactors\ListAttributeInteractor;
 use Song\Application\Interactors\ListTypeInteractor;
 use Song\Application\Interactors\SearchInteractor;
 use Song\Application\Interactors\SearchTagInteractor;
+use Song\Application\Interactors\Tag\CreateInteractor as CreateTagInteractor;
 use Song\Application\Interactors\UpdateInteractor;
 use Song\Application\Query\SongQueryServiceInterface;
 use Song\Application\UseCase\Create\CreateInputData;
@@ -26,6 +27,8 @@ use Song\Application\UseCase\Search\SearchInputData;
 use Song\Application\UseCase\Search\SearchUseCaseInterface;
 use Song\Application\UseCase\SearchTag\SearchInputData as SearchTagInputData;
 use Song\Application\UseCase\SearchTag\SearchUseCaseInterface as SearchTagUseCaseInterface;
+use Song\Application\UseCase\Tag\Create\CreateInputData as CreateSongTagInputData;
+use Song\Application\UseCase\Tag\Create\CreateUseCaseInterface as CreateSongTagUseCaseInterface;
 use Song\Application\UseCase\Update\UpdateInputData;
 use Song\Application\UseCase\Update\UpdateUseCaseInterface;
 use Song\Domain\Models\SongFactoryInterface;
@@ -81,8 +84,8 @@ class SongServiceProvider extends EnvServiceProvider
             );
         });
 
+        $this->registerSongTag();
         $this->registerSongAttribute();
-
         $this->registerSongType();
 
         $this->registerSongTag();
@@ -106,6 +109,14 @@ class SongServiceProvider extends EnvServiceProvider
             $request = $this->app->make(Request::class);
 
             return $this->getMapper()->map(SearchTagInputData::class, $request->query());
+        });
+
+        $this->app->bind(CreateSongTagUseCaseInterface::class, CreateTagInteractor::class);
+
+        $this->app->bind(CreateSongTagInputData::class, function (): CreateSongTagInputData {
+            $request = $this->app->make(Request::class);
+
+            return $this->getMapper()->map(CreateSongTagInputData::class, $request->all());
         });
     }
 }

--- a/src/server/app/Providers/Domain/SongServiceProvider.php
+++ b/src/server/app/Providers/Domain/SongServiceProvider.php
@@ -84,8 +84,8 @@ class SongServiceProvider extends EnvServiceProvider
             );
         });
 
-        $this->registerSongTag();
         $this->registerSongAttribute();
+
         $this->registerSongType();
 
         $this->registerSongTag();

--- a/src/server/packages/Song/Application/Interactors/Tag/CreateInteractor.php
+++ b/src/server/packages/Song/Application/Interactors/Tag/CreateInteractor.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Song\Application\Interactors\Tag;
+
+use AdminUser\Domain\Models\Permission;
+use Auth\Domain\Models\AuthContext;
+use LogicException;
+use Override;
+use ResultType\Err;
+use ResultType\Ok;
+use ResultType\Result;
+use Song\Application\UseCase\Tag\Create\CreateInputData;
+use Song\Application\UseCase\Tag\Create\CreateOutputData;
+use Song\Application\UseCase\Tag\Create\CreateUseCaseInterface;
+use Song\Domain\Models\Tag\SongTagRepositoryInterface;
+use Song\Domain\Services\SongTagIntegrityService;
+use Support\Contracts\TransactionInterface;
+use Support\Domain\Error\BusinessRuleViolationError;
+use Support\Domain\Error\DomainError;
+use Support\Domain\Error\DomainValidationError;
+use Support\Domain\Error\EntityRuleViolationError;
+use Support\UseCase\Error\AuthenticationError;
+use Support\UseCase\Error\AuthorizationError;
+use Support\UseCase\Error\BusinessLogicError;
+use Support\UseCase\Error\InvalidInputError;
+use Support\UseCase\Error\UseCaseError;
+
+readonly class CreateInteractor implements CreateUseCaseInterface
+{
+    public function __construct(
+        private AuthContext $context,
+        private TransactionInterface $transaction,
+        private SongTagRepositoryInterface $repository,
+        private SongTagIntegrityService $service,
+    ) {
+    }
+
+    #[Override]
+    public function handle(CreateInputData $inputData): Result
+    {
+        $user = $this->context->get();
+
+        if (is_null($user)) {
+            return new Err(new AuthenticationError());
+        }
+
+        if (! $user->can(Permission::WriteSong)) {
+            return new Err(new AuthorizationError());
+        }
+
+        return $this->transaction->scope(function () use ($inputData): Result {
+            $result = $this->service->prepareForCreate($inputData->name);
+
+            if ($result->isErr()) {
+                return new Err($this->handleError($result->unwrapErr()));
+            }
+
+            $tag = $result->unwrap();
+
+            $this->repository->save($tag);
+
+            return new Ok(new CreateOutputData($tag));
+        });
+    }
+
+    private function handleError(DomainError $error): UseCaseError
+    {
+        return match (true) {
+            $error instanceof DomainValidationError => new InvalidInputError($error->errors),
+            $error instanceof EntityRuleViolationError => new InvalidInputError([$error->field => [$error->message]]),
+            $error instanceof BusinessRuleViolationError => new BusinessLogicError($error->message),
+            default => throw new LogicException('予期しないドメインエラーが発生しました: ' . $error::class),
+        };
+    }
+}

--- a/src/server/packages/Song/Application/UseCase/Tag/Create/CreateInputData.php
+++ b/src/server/packages/Song/Application/UseCase/Tag/Create/CreateInputData.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Song\Application\UseCase\Tag\Create;
+
+readonly class CreateInputData
+{
+    public function __construct(public string $name)
+    {
+    }
+}

--- a/src/server/packages/Song/Application/UseCase/Tag/Create/CreateOutputData.php
+++ b/src/server/packages/Song/Application/UseCase/Tag/Create/CreateOutputData.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Song\Application\UseCase\Tag\Create;
+
+use Song\Domain\Models\Tag\SongTag;
+
+readonly class CreateOutputData
+{
+    public function __construct(public SongTag $tag)
+    {
+    }
+}

--- a/src/server/packages/Song/Application/UseCase/Tag/Create/CreateUseCaseInterface.php
+++ b/src/server/packages/Song/Application/UseCase/Tag/Create/CreateUseCaseInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Song\Application\UseCase\Tag\Create;
+
+use ResultType\Result;
+use Support\UseCase\Error\UseCaseError;
+
+interface CreateUseCaseInterface
+{
+    /**
+     * @return Result<CreateOutputData, UseCaseError>
+     */
+    public function handle(CreateInputData $inputData): Result;
+}

--- a/src/server/packages/Song/Domain/Models/Tag/SongTagFactoryInterface.php
+++ b/src/server/packages/Song/Domain/Models/Tag/SongTagFactoryInterface.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Song\Domain\Models\Tag;
 
+use Support\Domain\ValueObjects\OrderNo;
+
 interface SongTagFactoryInterface
 {
+    public function create(SongTagId $songTagId, SongTagName $name, OrderNo $orderNo): SongTag;
 }

--- a/src/server/packages/Song/Domain/Models/Tag/SongTagRepositoryInterface.php
+++ b/src/server/packages/Song/Domain/Models/Tag/SongTagRepositoryInterface.php
@@ -20,5 +20,9 @@ interface SongTagRepositoryInterface
 
     public function maxPage(SongTagSearchCriteria $criteria): int;
 
-    public function save(SongTag $songTag): SongTag;
+    public function findByName(SongTagName $name): ?SongTag;
+
+    public function save(SongTag $tag): SongTag;
+
+    public function getMaxOrderNo(): int;
 }

--- a/src/server/packages/Song/Domain/Services/SongTagIntegrityService.php
+++ b/src/server/packages/Song/Domain/Services/SongTagIntegrityService.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Song\Domain\Services;
+
+use ResultType\Err;
+use ResultType\Ok;
+use ResultType\Result;
+use Song\Domain\Models\Tag\SongTag;
+use Song\Domain\Models\Tag\SongTagFactoryInterface;
+use Song\Domain\Models\Tag\SongTagId;
+use Song\Domain\Models\Tag\SongTagName;
+use Song\Domain\Models\Tag\SongTagRepositoryInterface;
+use Support\Contracts\Uuid\UuidGeneratorInterface;
+use Support\Domain\Error\BusinessRuleViolationError;
+use Support\Domain\Error\DomainError;
+use Support\Domain\Error\DomainValidationError;
+use Support\Domain\Error\EntityRuleViolationError;
+use Support\Domain\ValueObjects\OrderNo;
+
+class SongTagIntegrityService
+{
+    public function __construct(
+        private readonly UuidGeneratorInterface $generator,
+        private readonly SongTagFactoryInterface $factory,
+        private readonly SongTagRepositoryInterface $repository,
+    ) {
+    }
+
+    /**
+     * @return Result<SongTag, DomainError>
+     */
+    public function prepareForCreate(string $name): Result
+    {
+        $result = $this->build(
+            $this->generator->generate(),
+            $name,
+            // 更新時に同じ値になることを防ぐために +10 で採番
+            $this->repository->getMaxOrderNo() + 10,
+        );
+
+        if ($result->isErr()) {
+            return new Err($result->unwrapErr());
+        }
+
+        $tag = $result->unwrap();
+
+        if (! is_null($this->repository->findByName($tag->name))) {
+            return new Err(new BusinessRuleViolationError(sprintf('すでに使われている名前です "%s"', $name)));
+        }
+
+        return new Ok($tag);
+    }
+
+    /**
+     * @return Result<SongTag, DomainError>
+     */
+    private function build(string $songTagId, string $name, int $orderNo): Result
+    {
+        return Result::collect3(
+            SongTagId::create($songTagId),
+            SongTagName::create($name),
+            OrderNo::create($orderNo),
+        )
+            ->mapErr(function (array $errors): DomainValidationError {
+                $messages = [];
+                foreach ($errors as $error) {
+                    if ($error instanceof EntityRuleViolationError) {
+                        $messages[$error->field] ??= [];
+                        $messages[$error->field][] = $error->message;
+                    }
+                }
+
+                return new DomainValidationError($messages);
+            })
+            ->map(fn (array $values): SongTag => $this->factory->create(...$values));
+    }
+}

--- a/src/server/packages/Song/Infrastructures/Tag/SongTagFactory.php
+++ b/src/server/packages/Song/Infrastructures/Tag/SongTagFactory.php
@@ -4,8 +4,18 @@ declare(strict_types=1);
 
 namespace Song\Infrastructures\Tag;
 
+use Override;
+use Song\Domain\Models\Tag\SongTag;
 use Song\Domain\Models\Tag\SongTagFactoryInterface;
+use Song\Domain\Models\Tag\SongTagId;
+use Song\Domain\Models\Tag\SongTagName;
+use Support\Domain\ValueObjects\OrderNo;
 
-class SongTagFactory implements SongTagFactoryInterface
+readonly class SongTagFactory implements SongTagFactoryInterface
 {
+    #[Override]
+    public function create(SongTagId $songTagId, SongTagName $name, OrderNo $orderNo): SongTag
+    {
+        return new SongTag($songTagId, $name, $orderNo);
+    }
 }

--- a/src/server/packages/Song/Infrastructures/Tag/SongTagRepository.php
+++ b/src/server/packages/Song/Infrastructures/Tag/SongTagRepository.php
@@ -8,11 +8,8 @@ use App\Models\Song\SongTag as ModelsSongTag;
 use Override;
 use Song\Domain\Criteria\Tag\SongTagSearchCriteria;
 use Song\Domain\Models\Tag\SongTag;
-use Song\Domain\Models\Tag\SongTag;
 use Song\Domain\Models\Tag\SongTagName;
 use Song\Domain\Models\Tag\SongTagRepositoryInterface;
-use Song\Domain\Models\Tag\SongTagRepositoryInterface;
-use Support\Contracts\Uuid\UuidConverterInterface;
 use Support\Contracts\Uuid\UuidConverterInterface;
 use Support\Infrastructures\Database\SqlHelper;
 

--- a/src/server/packages/Song/Infrastructures/Tag/SongTagRepository.php
+++ b/src/server/packages/Song/Infrastructures/Tag/SongTagRepository.php
@@ -8,7 +8,11 @@ use App\Models\Song\SongTag as ModelsSongTag;
 use Override;
 use Song\Domain\Criteria\Tag\SongTagSearchCriteria;
 use Song\Domain\Models\Tag\SongTag;
+use Song\Domain\Models\Tag\SongTag;
+use Song\Domain\Models\Tag\SongTagName;
 use Song\Domain\Models\Tag\SongTagRepositoryInterface;
+use Song\Domain\Models\Tag\SongTagRepositoryInterface;
+use Support\Contracts\Uuid\UuidConverterInterface;
 use Support\Contracts\Uuid\UuidConverterInterface;
 use Support\Infrastructures\Database\SqlHelper;
 
@@ -62,12 +66,26 @@ readonly class SongTagRepository implements SongTagRepositoryInterface
     }
 
     #[Override]
-    public function save(SongTag $songTag): SongTag
+    public function findByName(SongTagName $name): ?SongTag
+    {
+        $found = ModelsSongTag::query()
+            ->where('name', $name->value)
+            ->first();
+
+        if (is_null($found)) {
+            return null;
+        }
+
+        return $this->hydrate($found);
+    }
+
+    #[Override]
+    public function save(SongTag $tag): SongTag
     {
         ModelsSongTag::query()->upsert(
             [
-                ...$songTag->toArray(),
-                'song_tag_id' => $this->converter->toBin($songTag->songTagId->value),
+                ...$tag->toArray(),
+                'song_tag_id' => $this->converter->toBin($tag->songTagId->value),
                 'created_at' => now(),
                 'updated_at' => now(),
             ],
@@ -79,15 +97,22 @@ readonly class SongTagRepository implements SongTagRepositoryInterface
             ],
         );
 
-        return $songTag;
+        return $tag;
     }
 
-    private function hydrate(ModelsSongTag $row): SongTag
+    #[Override]
+    public function getMaxOrderNo(): int
+    {
+        /** @var int */
+        return ModelsSongTag::query()->max('order_no') ?? 0;
+    }
+
+    private function hydrate(ModelsSongTag $model): SongTag
     {
         return SongTag::reconstruct(
-            $this->converter->toUuid($row->song_tag_id),
-            $row->name,
-            $row->order_no,
+            $this->converter->toUuid($model->song_tag_id),
+            $model->name,
+            $model->order_no,
         );
     }
 }

--- a/src/server/routes/admin.php
+++ b/src/server/routes/admin.php
@@ -23,6 +23,7 @@ use App\Http\Controllers\Api\Song\GetSongController;
 use App\Http\Controllers\Api\Song\SearchSongController;
 use App\Http\Controllers\Api\Song\UpdateSongController;
 use App\Http\Controllers\Api\SongAttribute\ListSongAttributeController;
+use App\Http\Controllers\Api\SongTag\CreateSongTagController;
 use App\Http\Controllers\Api\SongTag\SearchSongTagController;
 use App\Http\Controllers\Api\SongType\ListSongTypeController;
 use App\Http\Middleware\Authenticate;
@@ -77,6 +78,10 @@ Route::middleware(OpenApiValidator::class)->group(function () {
                     Route::delete('/{songId}', [DeleteSongController::class, 'handle'])->name(SongRouteMap::Delete);
                     Route::get('/search', [SearchSongController::class, 'handle'])->name(SongRouteMap::Search);
                     Route::get('/{songId}', [GetSongController::class, 'handle'])->name(SongRouteMap::Get);
+                });
+
+                Route::prefix('song-tags')->group(function () {
+                    Route::post('/', [CreateSongTagController::class, 'handle'])->name(SongTagRouteMap::Create);
                 });
 
                 Route::prefix('song-types')->group(function () {

--- a/src/server/routes/admin.php
+++ b/src/server/routes/admin.php
@@ -80,10 +80,6 @@ Route::middleware(OpenApiValidator::class)->group(function () {
                     Route::get('/{songId}', [GetSongController::class, 'handle'])->name(SongRouteMap::Get);
                 });
 
-                Route::prefix('song-tags')->group(function () {
-                    Route::post('/', [CreateSongTagController::class, 'handle'])->name(SongTagRouteMap::Create);
-                });
-
                 Route::prefix('song-types')->group(function () {
                     Route::get('/', [ListSongTypeController::class, 'handle'])->name(SongTypeRouteMap::List);
                 });
@@ -93,6 +89,7 @@ Route::middleware(OpenApiValidator::class)->group(function () {
                 });
 
                 Route::prefix('song-tags')->group(function () {
+                    Route::post('/', [CreateSongTagController::class, 'handle'])->name(SongTagRouteMap::Create);
                     Route::get('/search', [SearchSongTagController::class, 'handle'])->name(SongTagRouteMap::Search);
                 });
             });

--- a/src/server/tests/Feature/Api/SongTag/CreateSongTagTest.php
+++ b/src/server/tests/Feature/Api/SongTag/CreateSongTagTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\SongTag;
+
+use Illuminate\Testing\Fluent\AssertableJson;
+use PHPUnit\Framework\Attributes\Test;
+use Song\Infrastructures\Tag\SongTagRepository;
+use Song\Route\Tag\SongTagRouteMap;
+use Tests\Feature\Api\WithAuth;
+use Tests\Support\DatabaseTestCase;
+use Tests\Support\Domain\EntityFactory;
+
+class CreateSongTagTest extends DatabaseTestCase
+{
+    use EntityFactory;
+    use WithAuth;
+
+    #[Test]
+    public function canCreate(): void
+    {
+        $this->withAuth()
+            ->postJson(route(SongTagRouteMap::Create), [
+                'name' => '派生曲',
+            ])->assertStatus(200)
+            ->assertJson(
+                fn (AssertableJson $json) => $json
+                    ->has(
+                        'tag',
+                        fn (AssertableJson $json) => $json
+                            ->whereType('songTagId', 'string')
+                            ->where('name', '派生曲')
+                            ->where('orderNo', 10),
+                    ),
+            );
+    }
+
+    #[Test]
+    public function createFailsWhenNameAlreadyExists(): void
+    {
+        $this->app->make(SongTagRepository::class)->save(
+            $this->createSongTag($this->generateUuid(), '派生曲', 10),
+        );
+
+        $this->withAuth()
+            ->postJson(route(SongTagRouteMap::Create), [
+                'name' => '派生曲',
+            ])->assertStatus(400)
+            ->assertExactJson([
+                'message' => 'すでに使われている名前です "派生曲"',
+            ]);
+    }
+
+    #[Test]
+    public function emptyParameters(): void
+    {
+        $this->withAuth()
+            ->postJson(route(SongTagRouteMap::Create), [
+                'name' => '',
+            ])->assertStatus(422)
+            ->assertJson(
+                fn (AssertableJson $json) => $json
+                    ->has(
+                        'errors',
+                        1,
+                        fn (AssertableJson $json) => $json
+                            ->where('field', 'name')
+                            ->whereType('message', 'string'),
+                    ),
+            );
+    }
+}

--- a/src/server/tests/Integration/Song/Application/Interactors/Tag/CreateInteractorTest.php
+++ b/src/server/tests/Integration/Song/Application/Interactors/Tag/CreateInteractorTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Song\Application\Interactors\Tag;
+
+use App\Models\Song\SongTag as ModelsSongTag;
+use PHPUnit\Framework\Attributes\Test;
+use Song\Application\Interactors\Tag\CreateInteractor;
+use Song\Application\UseCase\Tag\Create\CreateInputData;
+use Song\Infrastructures\Tag\SongTagRepository;
+use Tests\Support\DatabaseTestCase;
+use Tests\Support\Domain\EntityFactory;
+
+class CreateInteractorTest extends DatabaseTestCase
+{
+    use EntityFactory;
+
+    #[Test]
+    public function create(): void
+    {
+        $result = $this->getInstance()->handle(new CreateInputData('派生曲'));
+
+        $this->assertTrue($result->isOk());
+
+        $tags = ModelsSongTag::query()->orderBy('order_no')->get();
+        $this->assertCount(1, $tags);
+        $this->assertSame('派生曲', $tags->first()->name);
+        $this->assertSame(10, $tags->first()->order_no);
+    }
+
+    #[Test]
+    public function createAppendsOrderNoFromCurrentMax(): void
+    {
+        $this->app->make(SongTagRepository::class)->save(
+            $this->createSongTag($this->generateUuid(), '既存タグ', 40),
+        );
+
+        $result = $this->getInstance()->handle(new CreateInputData('派生曲'));
+
+        $this->assertTrue($result->isOk());
+
+        $tags = ModelsSongTag::query()->orderBy('order_no')->get();
+        $this->assertCount(2, $tags);
+        $this->assertSame('派生曲', $tags->last()->name);
+        $this->assertSame(50, $tags->last()->order_no);
+    }
+
+    private function getInstance(): CreateInteractor
+    {
+        $this->privilegedContext();
+
+        return $this->app->make(CreateInteractor::class);
+    }
+}

--- a/src/server/tests/Unit/Song/Domain/Services/SongTagIntegrityServiceTest.php
+++ b/src/server/tests/Unit/Song/Domain/Services/SongTagIntegrityServiceTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Song\Domain\Services;
+
+use Mockery;
+use Mockery\MockInterface;
+use Override;
+use PHPUnit\Framework\Attributes\Test;
+use Song\Domain\Models\Tag\SongTagFactoryInterface;
+use Song\Domain\Models\Tag\SongTagId;
+use Song\Domain\Models\Tag\SongTagName;
+use Song\Domain\Models\Tag\SongTagRepositoryInterface;
+use Song\Domain\Services\SongTagIntegrityService;
+use Support\Contracts\Uuid\UuidGeneratorInterface;
+use Support\Domain\Error\BusinessRuleViolationError;
+use Support\Domain\ValueObjects\OrderNo;
+use Tests\Support\Domain\EntityFactory;
+use Tests\TestCase;
+
+class SongTagIntegrityServiceTest extends TestCase
+{
+    use EntityFactory;
+
+    private MockInterface&UuidGeneratorInterface $generator;
+
+    private MockInterface&SongTagFactoryInterface $factory;
+
+    private MockInterface&SongTagRepositoryInterface $repository;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->generator = Mockery::mock(UuidGeneratorInterface::class);
+        $this->factory = Mockery::mock(SongTagFactoryInterface::class);
+        $this->repository = Mockery::mock(SongTagRepositoryInterface::class);
+    }
+
+    #[Test]
+    public function prepareForCreate(): void
+    {
+        $name = '派生曲';
+        $uuid = 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA';
+        $maxOrderNo = 20;
+
+        $this->generator->shouldReceive('generate')
+            ->with()
+            ->andReturn($uuid)
+            ->once();
+
+        $this->repository->shouldReceive('getMaxOrderNo')
+            ->with()
+            ->andReturn($maxOrderNo)
+            ->once();
+
+        $expectedTag = $this->createSongTag($uuid, $name, $maxOrderNo + 10);
+
+        $this->factory->shouldReceive('create')
+            ->withArgs(
+                fn (SongTagId $songTagIdArg, SongTagName $nameArg, OrderNo $orderNoArg): bool => $songTagIdArg->value === $uuid
+                    && $nameArg->value === $name
+                    && $orderNoArg->value === $maxOrderNo + 10,
+            )
+            ->andReturn($expectedTag)
+            ->once();
+
+        $this->repository->shouldReceive('findByName')
+            ->withArgs(fn (SongTagName $arg): bool => $arg->value === $name)
+            ->andReturnNull()
+            ->once();
+
+        $result = $this->getInstance()->prepareForCreate($name);
+
+        $this->assertTrue($result->isOk());
+        $this->assertSame($expectedTag, $result->unwrap());
+    }
+
+    #[Test]
+    public function prepareForCreateDuplicateName(): void
+    {
+        $name = '派生曲';
+        $uuid = 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA';
+        $maxOrderNo = 20;
+
+        $this->generator->shouldReceive('generate')
+            ->with()
+            ->andReturn($uuid)
+            ->once();
+
+        $this->repository->shouldReceive('getMaxOrderNo')
+            ->with()
+            ->andReturn($maxOrderNo)
+            ->once();
+
+        $expectedTag = $this->createSongTag($uuid, $name, $maxOrderNo + 10);
+
+        $this->factory->shouldReceive('create')
+            ->withArgs(
+                fn (SongTagId $songTagIdArg, SongTagName $nameArg, OrderNo $orderNoArg): bool => $songTagIdArg->value === $uuid
+                    && $nameArg->value === $name
+                    && $orderNoArg->value === $maxOrderNo + 10,
+            )
+            ->andReturn($expectedTag)
+            ->once();
+
+        $this->repository->shouldReceive('findByName')
+            ->withArgs(fn (SongTagName $arg): bool => $arg->value === $name)
+            ->andReturn($this->createSongTag('BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB', $name, 10))
+            ->once();
+
+        $result = $this->getInstance()->prepareForCreate($name);
+
+        $this->assertTrue($result->isErr());
+        $error = $result->unwrapErr();
+        $this->assertInstanceOf(BusinessRuleViolationError::class, $error);
+        $this->assertSame('すでに使われている名前です "派生曲"', $error->message);
+    }
+
+    private function getInstance(): SongTagIntegrityService
+    {
+        return new SongTagIntegrityService(
+            $this->generator,
+            $this->factory,
+            $this->repository,
+        );
+    }
+}


### PR DESCRIPTION
## Summary

resolve #564 


- add server-side create flow for song tags, including use case, presenter, repository, and route wiring
- add admin BFF route and create page/form for 
- record the implementation plan in the completed exec plan

## Validation
- 
 [OK] No errors                                                                 
- error TS5058: The specified path does not exist: 'admin/tsconfig.json'. *(existing unrelated type errors remain in creator/performer/song search files; no new errors from song-tag files)*