### PR TITLE
楽曲タグ削除機能を作成

### DIFF
--- a/docs/exec-plans/completed/20260430-song-tag-delete.md
+++ b/docs/exec-plans/completed/20260430-song-tag-delete.md
@@ -1,0 +1,65 @@
+# Title
+
+楽曲タグ削除機能
+
+## Status
+
+completed
+
+## Background
+
+`src/contracts/src/admin/song-tags/service.tsp` には `deleteSongTag` 契約が既にあり、`src/admin/src/generated` にも削除クライアントが生成されている。一方で、`src/server` には SongTag の delete 用 use case / controller / presenter / route の接続がなく、`src/admin` 側にも詳細画面から削除を実行する導線がない。楽曲タグは一覧・検索・詳細・編集まで揃っているため、削除だけが未接続の状態になっている。
+
+## Goal
+
+管理画面の楽曲タグ詳細ページからタグを削除できるようにし、API・BFF・UI を既存契約に沿って接続する。
+
+## Scope
+
+- `src/server/packages/Song/Application/UseCase/Tag/Delete/` と `src/server/packages/Song/Application/Interactors/Tag/DeleteInteractor.php` を追加する
+- `src/server/app/Http/Controllers/Api/SongTag/DeleteSongTagController.php` と `src/server/app/Http/Presenters/Api/SongTag/DeletePresenter.php` を追加する
+- `src/server/routes/admin.php` に `DELETE /admin/v1/song-tags/{songTagId}` を追加し、`src/server/app/Providers/Domain/SongServiceProvider.php` で delete use case を bind する
+- `src/server/tests/Unit/Song/Application/Interactors/Tag/DeleteInteractorTest.php` と `src/server/tests/Feature/Api/SongTag/DeleteSongTagTest.php` を追加する
+- `src/admin/src/server/routes/song-tags.ts` に `DELETE /:songTagId` を追加する
+- `src/admin/src/components/song-tag/EditableForm.tsx` に削除ボタンと確認ダイアログを追加する
+- `src/admin/src/pages/song-tags/[id].astro` を前提に、削除後の戻り先とフラッシュ表示を連携する
+
+## Non-Scope
+
+- `src/contracts/src/admin/song-tags/service.tsp` と生成済み OpenAPI / admin SDK の契約変更
+- 論理削除、soft delete、DB スキーマ変更
+- 楽曲タグ以外の削除機能の追加
+- 一覧・検索・作成・更新ロジックの仕様変更
+
+## Acceptance Criteria
+
+- 認証済みで `DELETE /admin/v1/song-tags/{songTagId}` を送ると、204 が返り、存在するタグは削除される。存在しない ID でも既存 delete 契約どおり 204 になる
+- `src/admin/src/pages/song-tags/[id].astro` の詳細画面から削除を実行でき、成功時は一覧へ戻って「削除しました」が表示される
+- `src/server/tests/Unit/Song/Application/Interactors/Tag/DeleteInteractorTest.php` と `src/server/tests/Feature/Api/SongTag/DeleteSongTagTest.php` が追加され、削除の成功系と主要な失敗系が検証される
+- 今回の変更に契約ファイルの修正は含まれない
+
+## Steps
+
+1. ✅ `src/server/packages/Song/Domain/Models/Tag/SongTagRepositoryInterface.php` に `delete(SongTagId $songTagId): void` を追加し、`src/server/packages/Song/Infrastructures/Tag/SongTagRepository.php` に実装を足す。
+2. ✅ `src/server/packages/Song/Application/UseCase/Tag/Delete/` に `DeleteInputData.php` と `DeleteUseCaseInterface.php` を追加し、`src/server/packages/Song/Application/Interactors/Tag/DeleteInteractor.php` を新規作成する。`Permission::WriteSong` を確認し、既存 delete 契約に合わせてそのまま `delete()` を呼ぶ流れにする。
+3. ✅ `src/server/app/Http/Controllers/Api/SongTag/DeleteSongTagController.php` と `src/server/app/Http/Presenters/Api/SongTag/DeletePresenter.php` を追加し、`DELETE /admin/v1/song-tags/{songTagId}` の 204 / 422 / 401 / 403 の返却を既存 Presenter パターンに揃える。
+4. ✅ `src/server/routes/admin.php` に `DELETE /song-tags/{songTagId}` を追加し、`src/server/app/Providers/Domain/SongServiceProvider.php` で `Song\Application\UseCase\Tag\Delete\DeleteUseCaseInterface` を `Song\Application\Interactors\Tag\DeleteInteractor` に bind する。
+5. ✅ `src/server/tests/Unit/Song/Application/Interactors/Tag/DeleteInteractorTest.php` を追加して、成功時に repository の `delete()` が 1 回呼ばれることを確認する。
+6. ✅ `src/server/tests/Feature/Api/SongTag/DeleteSongTagTest.php` を追加して、認証済み削除の 204、存在しない ID でも 204、未認証の 401 を `SongTagRouteMap::Delete` 経由で検証する。
+7. ✅ `src/admin/src/server/routes/song-tags.ts` に `DELETE /:songTagId` を追加し、生成済みの `songTagServiceDeleteSongTag` を `resolveApiResponse` 経由で返す。
+8. ✅ `src/admin/src/components/song-tag/EditableForm.tsx` に削除ボタンと確認ダイアログを追加し、削除成功時は `setFlash('削除しました')` の後に `back` 由来の一覧 URL へ戻す。既存の更新処理と同じ `listUrl` 解決を再利用する。
+9. ✅ `src/admin/src/pages/song-tags/index.astro` に既に `FlashMessage` があるため、削除後のフラッシュ表示に追加変更は不要と確認する。
+
+## Decision Log
+
+- 2026-04-30: 削除は未存在 ID でも 204 にする。`src/contracts` の delete 契約と既存の Song / Performer / Creator の削除 API が 404 を持たないため、それに合わせる。
+- 2026-04-30: 詳細画面の戻り先は `back` クエリから復元し、削除後も検索条件付き一覧へ戻す。新しい状態管理は増やさず、既存の詳細遷移パターンをそのまま使うため。
+- 2026-04-30: 契約ファイルと生成物は変更しない。`songTagServiceDeleteSongTag` は既に生成済みなので、今回はサーバ接続と UI の導線だけを追加する。
+- 2026-04-30: フラッシュ表示は一覧ページ側の `FlashMessage` をそのまま使う。詳細ページ `[id].astro` への追加変更は不要。
+
+## Validation
+
+- AC1: `src/server/tests/Feature/Api/SongTag/DeleteSongTagTest.php` で認証済み 204 と存在しない ID でも 204 になることを確認する。
+- AC2: `src/admin/src/components/song-tag/EditableForm.tsx` から削除成功時に一覧へ戻ることと、一覧ページの `FlashMessage` で `setFlash('削除しました')` が表示されることを手動確認する。
+- AC3: `src/server/tests/Unit/Song/Application/Interactors/Tag/DeleteInteractorTest.php` と `src/server/tests/Feature/Api/SongTag/DeleteSongTagTest.php` を実行して、成功系と主要な失敗系が通ることを確認する。
+- AC4: `src/contracts/src/admin/song-tags/service.tsp` と `src/admin/src/generated` に差分が出ていないことを確認し、契約変更が混入していないことを保証する。

--- a/src/admin/src/components/song-tag/EditableForm.tsx
+++ b/src/admin/src/components/song-tag/EditableForm.tsx
@@ -65,6 +65,33 @@ export const EditableForm = (props: Props) => {
     handleError(status, error);
   });
 
+  const handleDelete = withSubmitting(async (e: Event) => {
+    e.preventDefault();
+
+    if (!window.confirm('削除します。よろしいですか？')) {
+      return;
+    }
+
+    clearErrors();
+
+    const songTagId = props.data?.tag.songTagId;
+
+    if (!songTagId) {
+      setFormError('削除対象の楽曲タグIDを取得できませんでした');
+      return;
+    }
+
+    const { error, status } = await client.api['song-tags']({ songTagId }).delete();
+
+    if (error) {
+      handleError(status, error);
+      return;
+    }
+
+    setFlash('削除しました');
+    window.location.href = listUrl;
+  });
+
   onMount(() => {
     if (props.status === 404) {
       setFlash('データがありません');
@@ -114,6 +141,18 @@ export const EditableForm = (props: Props) => {
           </div>
         </fieldset>
       </form>
+
+      <div class="divider max-w-lg" />
+
+      <div class="max-w-lg rounded-box border border-error/20 bg-error/5 p-6">
+        <h3 class="font-semibold text-error">危険な操作</h3>
+        <p class="mt-1 text-sm text-base-content/60">この操作は取り消せません。</p>
+        <div class="mt-4">
+          <button onClick={handleDelete} class="btn btn-outline btn-error btn-sm" disabled={isSubmitting()}>
+            {isSubmitting() ? '削除中...' : 'この楽曲タグを削除する'}
+          </button>
+        </div>
+      </div>
     </Show>
   );
 };

--- a/src/admin/src/server/routes/song-tags.ts
+++ b/src/admin/src/server/routes/song-tags.ts
@@ -1,5 +1,5 @@
 import { Elysia, t } from 'elysia';
-import { songTagServiceCreateSongTag, songTagServiceGetSongTag, songTagServiceListSongTags, songTagServiceSearchSongTags, songTagServiceUpdateSongTag } from '../../generated';
+import { songTagServiceCreateSongTag, songTagServiceDeleteSongTag, songTagServiceGetSongTag, songTagServiceListSongTags, songTagServiceSearchSongTags, songTagServiceUpdateSongTag } from '../../generated';
 import type { PerPage, SongTagSearchSortBy, SortOrder } from '../../generated';
 import { createAuthClient } from '../client';
 import { resolveApiResponse } from '../errors';
@@ -70,6 +70,17 @@ export const songTags = new Elysia({ prefix: '/song-tags' })
       body: t.Object({
         name: t.String(),
         orderNo: t.Number(),
+      }),
+    },
+  )
+  .delete(
+    '/:songTagId',
+    async ({ params: { songTagId }, credential }) => {
+      return resolveApiResponse(await songTagServiceDeleteSongTag({ client: createAuthClient(credential), path: { songTagId } }));
+    },
+    {
+      params: t.Object({
+        songTagId: t.String(),
       }),
     },
   );

--- a/src/server/app/Http/Controllers/Api/SongTag/DeleteSongTagController.php
+++ b/src/server/app/Http/Controllers/Api/SongTag/DeleteSongTagController.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\SongTag;
+
+use App\Http\Controllers\Controller;
+use App\Http\Presenters\Api\SongTag\DeletePresenter;
+use Illuminate\Http\JsonResponse;
+use Song\Application\UseCase\Tag\Delete\DeleteInputData;
+use Song\Application\UseCase\Tag\Delete\DeleteUseCaseInterface;
+
+class DeleteSongTagController extends Controller
+{
+    public function __construct(
+        private readonly DeleteUseCaseInterface $interactor,
+        private readonly DeletePresenter $presenter,
+    ) {
+    }
+
+    public function handle(string $songTagId): JsonResponse
+    {
+        return $this->presenter->present($this->interactor->handle(new DeleteInputData($songTagId)));
+    }
+}

--- a/src/server/app/Http/Presenters/Api/SongTag/DeletePresenter.php
+++ b/src/server/app/Http/Presenters/Api/SongTag/DeletePresenter.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Presenters\Api\SongTag;
+
+use App\Http\Presenters\Api\Support\ResolvesUseCaseError;
+use Illuminate\Http\JsonResponse;
+use ResultType\Result;
+use Support\UseCase\Error\UseCaseError;
+
+class DeletePresenter
+{
+    use ResolvesUseCaseError;
+
+    /**
+     * @param Result<null, UseCaseError> $result
+     */
+    public function present(Result $result): JsonResponse
+    {
+        return $result->match(
+            fn () => response()->json(status: 204),
+            fn (UseCaseError $error) => response()->json(...$this->resolveError($error)),
+        );
+    }
+}

--- a/src/server/app/Providers/Domain/SongServiceProvider.php
+++ b/src/server/app/Providers/Domain/SongServiceProvider.php
@@ -15,6 +15,7 @@ use Song\Application\Interactors\ListTypeInteractor;
 use Song\Application\Interactors\SearchInteractor;
 use Song\Application\Interactors\SearchTagInteractor;
 use Song\Application\Interactors\Tag\CreateInteractor as CreateTagInteractor;
+use Song\Application\Interactors\Tag\DeleteInteractor as DeleteTagInteractor;
 use Song\Application\Interactors\Tag\GetInteractor as GetTagInteractor;
 use Song\Application\Interactors\Tag\ListTagInteractor;
 use Song\Application\Interactors\Tag\UpdateInteractor as UpdateTagInteractor;
@@ -33,6 +34,7 @@ use Song\Application\UseCase\SearchTag\SearchInputData as SearchTagInputData;
 use Song\Application\UseCase\SearchTag\SearchUseCaseInterface as SearchTagUseCaseInterface;
 use Song\Application\UseCase\Tag\Create\CreateInputData as CreateSongTagInputData;
 use Song\Application\UseCase\Tag\Create\CreateUseCaseInterface as CreateSongTagUseCaseInterface;
+use Song\Application\UseCase\Tag\Delete\DeleteUseCaseInterface as DeleteSongTagUseCaseInterface;
 use Song\Application\UseCase\Tag\Get\GetUseCaseInterface as GetSongTagUseCaseInterface;
 use Song\Application\UseCase\Tag\Update\UpdateInputData as UpdateSongTagInputData;
 use Song\Application\UseCase\Tag\Update\UpdateUseCaseInterface as UpdateSongTagUseCaseInterface;
@@ -131,6 +133,8 @@ class SongServiceProvider extends EnvServiceProvider
         $this->app->bind(GetSongTagUseCaseInterface::class, GetTagInteractor::class);
 
         $this->app->bind(UpdateSongTagUseCaseInterface::class, UpdateTagInteractor::class);
+
+        $this->app->bind(DeleteSongTagUseCaseInterface::class, DeleteTagInteractor::class);
 
         $this->app->bind(UpdateSongTagInputData::class, function (): UpdateSongTagInputData {
             $request = $this->app->make(Request::class);

--- a/src/server/packages/Song/Application/Interactors/Tag/DeleteInteractor.php
+++ b/src/server/packages/Song/Application/Interactors/Tag/DeleteInteractor.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Song\Application\Interactors\Tag;
+
+use AdminUser\Domain\Models\Permission;
+use Auth\Domain\Models\AuthContext;
+use Override;
+use ResultType\Err;
+use ResultType\Ok;
+use ResultType\Result;
+use Song\Application\UseCase\Tag\Delete\DeleteInputData;
+use Song\Application\UseCase\Tag\Delete\DeleteUseCaseInterface;
+use Song\Domain\Models\Tag\SongTagId;
+use Song\Domain\Models\Tag\SongTagRepositoryInterface;
+use Support\UseCase\Error\AuthenticationError;
+use Support\UseCase\Error\AuthorizationError;
+use Support\UseCase\Error\InvalidInputError;
+use Support\UseCase\Error\UseCaseError;
+
+readonly class DeleteInteractor implements DeleteUseCaseInterface
+{
+    public function __construct(
+        private AuthContext $context,
+        private SongTagRepositoryInterface $repository,
+    ) {
+    }
+
+    #[Override]
+    public function handle(DeleteInputData $inputData): Result
+    {
+        $user = $this->context->get();
+
+        if (is_null($user)) {
+            return new Err(new AuthenticationError());
+        }
+
+        if (! $user->can(Permission::WriteSong)) {
+            return new Err(new AuthorizationError());
+        }
+
+        return SongTagId::create($inputData->songTagId)
+            ->mapErr(fn (): UseCaseError => new InvalidInputError(['songTagId' => ['IDが不正です']]))
+            ->andThen(function (SongTagId $songTagId): Result {
+                $this->repository->delete($songTagId);
+
+                return new Ok(null);
+            });
+    }
+}

--- a/src/server/packages/Song/Application/UseCase/Tag/Delete/DeleteInputData.php
+++ b/src/server/packages/Song/Application/UseCase/Tag/Delete/DeleteInputData.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Song\Application\UseCase\Tag\Delete;
+
+readonly class DeleteInputData
+{
+    public function __construct(public string $songTagId)
+    {
+    }
+}

--- a/src/server/packages/Song/Application/UseCase/Tag/Delete/DeleteUseCaseInterface.php
+++ b/src/server/packages/Song/Application/UseCase/Tag/Delete/DeleteUseCaseInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Song\Application\UseCase\Tag\Delete;
+
+use ResultType\Result;
+use Support\UseCase\Error\UseCaseError;
+
+interface DeleteUseCaseInterface
+{
+    /**
+     * @return Result<null, UseCaseError>
+     */
+    public function handle(DeleteInputData $inputData): Result;
+}

--- a/src/server/packages/Song/Domain/Models/Tag/SongTagRepositoryInterface.php
+++ b/src/server/packages/Song/Domain/Models/Tag/SongTagRepositoryInterface.php
@@ -26,5 +26,7 @@ interface SongTagRepositoryInterface
 
     public function save(SongTag $tag): SongTag;
 
+    public function delete(SongTagId $songTagId): void;
+
     public function getMaxOrderNo(): int;
 }

--- a/src/server/packages/Song/Infrastructures/Tag/SongTagRepository.php
+++ b/src/server/packages/Song/Infrastructures/Tag/SongTagRepository.php
@@ -113,6 +113,14 @@ readonly class SongTagRepository implements SongTagRepositoryInterface
     }
 
     #[Override]
+    public function delete(SongTagId $songTagId): void
+    {
+        ModelsSongTag::query()
+            ->where('song_tag_id', $this->converter->toBin($songTagId->value))
+            ->delete();
+    }
+
+    #[Override]
     public function getMaxOrderNo(): int
     {
         /** @var int */

--- a/src/server/routes/admin.php
+++ b/src/server/routes/admin.php
@@ -24,6 +24,7 @@ use App\Http\Controllers\Api\Song\SearchSongController;
 use App\Http\Controllers\Api\Song\UpdateSongController;
 use App\Http\Controllers\Api\SongAttribute\ListSongAttributeController;
 use App\Http\Controllers\Api\SongTag\CreateSongTagController;
+use App\Http\Controllers\Api\SongTag\DeleteSongTagController;
 use App\Http\Controllers\Api\SongTag\GetSongTagController;
 use App\Http\Controllers\Api\SongTag\ListSongTagController;
 use App\Http\Controllers\Api\SongTag\SearchSongTagController;
@@ -95,6 +96,7 @@ Route::middleware(OpenApiValidator::class)->group(function () {
                     Route::post('/', [CreateSongTagController::class, 'handle'])->name(SongTagRouteMap::Create);
                     Route::get('/', [ListSongTagController::class, 'handle'])->name(SongTagRouteMap::List);
                     Route::put('/{songTagId}', [UpdateSongTagController::class, 'handle'])->name(SongTagRouteMap::Update);
+                    Route::delete('/{songTagId}', [DeleteSongTagController::class, 'handle'])->name(SongTagRouteMap::Delete);
                     Route::get('/search', [SearchSongTagController::class, 'handle'])->name(SongTagRouteMap::Search);
                     Route::get('/{songTagId}', [GetSongTagController::class, 'handle'])->name(SongTagRouteMap::Get);
                 });

--- a/src/server/tests/Feature/Api/SongTag/DeleteSongTagTest.php
+++ b/src/server/tests/Feature/Api/SongTag/DeleteSongTagTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\SongTag;
+
+use PHPUnit\Framework\Attributes\Test;
+use Song\Infrastructures\Tag\SongTagRepository;
+use Song\Route\Tag\SongTagRouteMap;
+use Tests\Feature\Api\WithAuth;
+use Tests\Support\DatabaseTestCase;
+use Tests\Support\Domain\EntityFactory;
+
+class DeleteSongTagTest extends DatabaseTestCase
+{
+    use EntityFactory;
+    use WithAuth;
+
+    #[Test]
+    public function canDelete(): void
+    {
+        $uuid = $this->generateUuid();
+
+        $repository = $this->app->make(SongTagRepository::class);
+        $repository->save($this->createSongTag($uuid, '派生曲', 1));
+
+        $this->withAuth()
+            ->delete(route(SongTagRouteMap::Delete, $uuid))
+            ->assertStatus(204);
+
+        $this->assertNull($repository->find($this->createSongTag($uuid, '派生曲', 1)->songTagId));
+    }
+
+    #[Test]
+    public function canDeleteEvenIfTargetDoesNotExist(): void
+    {
+        $this->withAuth()
+            ->delete(route(SongTagRouteMap::Delete, 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'))
+            ->assertStatus(204);
+    }
+
+    #[Test]
+    public function requiresAuthentication(): void
+    {
+        $this->delete(route(SongTagRouteMap::Delete, 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'))
+            ->assertStatus(401);
+    }
+}

--- a/src/server/tests/Unit/Song/Application/Interactors/Tag/DeleteInteractorTest.php
+++ b/src/server/tests/Unit/Song/Application/Interactors/Tag/DeleteInteractorTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Song\Application\Interactors\Tag;
+
+use AdminUser\Domain\Models\AdminUser;
+use AdminUser\Domain\Models\Role;
+use Auth\Domain\Models\AuthContext;
+use DateTimeImmutable;
+use Mockery;
+use Mockery\MockInterface;
+use Override;
+use PHPUnit\Framework\Attributes\Test;
+use Song\Application\Interactors\Tag\DeleteInteractor;
+use Song\Application\UseCase\Tag\Delete\DeleteInputData;
+use Song\Domain\Models\Tag\SongTagId;
+use Song\Domain\Models\Tag\SongTagRepositoryInterface;
+use Support\UseCase\Error\AuthorizationError;
+use Support\UseCase\Error\InvalidInputError;
+use Tests\TestCase;
+
+class DeleteInteractorTest extends TestCase
+{
+    private MockInterface&SongTagRepositoryInterface $repository;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->repository = Mockery::mock(SongTagRepositoryInterface::class);
+    }
+
+    #[Test]
+    public function deleteSongTag(): void
+    {
+        $this->repository->shouldReceive('delete')
+            ->withArgs(fn (SongTagId $arg): bool => $arg->value === 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA')
+            ->once();
+
+        $result = $this->getInstance()->handle(new DeleteInputData('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'));
+
+        $this->assertTrue($result->isOk());
+    }
+
+    #[Test]
+    public function unauthorized(): void
+    {
+        $this->repository->shouldNotReceive('delete');
+
+        $context = $this->app->make(AuthContext::class);
+        $context->set(AdminUser::reconstruct(
+            $this->generateUuid(),
+            'テストユーザー',
+            'test@example.com',
+            new DateTimeImmutable(),
+            Role::General->value,
+            [],
+        ));
+
+        $result = $this->getInstance($context)->handle(new DeleteInputData('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'));
+
+        $this->assertTrue($result->isErr());
+        $this->assertInstanceOf(AuthorizationError::class, $result->unwrapErr());
+    }
+
+    #[Test]
+    public function invalidSongTagId(): void
+    {
+        $this->repository->shouldNotReceive('delete');
+
+        $result = $this->getInstance()->handle(new DeleteInputData('invalid-id'));
+
+        $this->assertTrue($result->isErr());
+        $this->assertInstanceOf(InvalidInputError::class, $result->unwrapErr());
+    }
+
+    private function getInstance(?AuthContext $context = null): DeleteInteractor
+    {
+        return new DeleteInteractor(
+            $context ?? $this->privilegedContext(),
+            $this->repository,
+        );
+    }
+}


### PR DESCRIPTION
resolve #566 

## Summary
- add SongTag delete API wiring on the server side
- add admin BFF delete route and delete action on the song tag detail screen
- add unit and feature tests for song tag deletion

## Validation
- docker compose exec php php artisan test tests/Unit/Song/Application/Interactors/Tag/DeleteInteractorTest.php
- docker compose exec php php artisan test tests/Feature/Api/SongTag/DeleteSongTagTest.php
- bunx tsc --noEmit (fails due to pre-existing type errors in creator/performer files)