### PR TITLE
ci: required QA を条件付き実行にする

### DIFF
--- a/.github/workflows/admin-qa.yaml
+++ b/.github/workflows/admin-qa.yaml
@@ -12,9 +12,54 @@ env:
   MISE_ENV: ci
 
 jobs:
+  changes:
+    name: Detect related changes
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.filter.outputs.should_run }}
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Detect changes
+        id: filter
+        run: |
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base_sha="${{ github.event.pull_request.base.sha }}"
+            head_sha="${{ github.event.pull_request.head.sha }}"
+          elif [ "${{ github.event_name }}" = "push" ]; then
+            base_sha="${{ github.event.before }}"
+            head_sha="${{ github.sha }}"
+          else
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$base_sha" = "0000000000000000000000000000000000000000" ]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          changed_files="$(git diff --name-only "$base_sha" "$head_sha")"
+          echo "$changed_files"
+
+          if echo "$changed_files" | grep -Eq '^(src/admin/|src/contracts/|src/package.json$|src/bun.lock$|mise(\.ci|\.local)?\.toml$|\.github/workflows/admin-qa\.yaml$)'; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+          fi
+
   diff:
     name: Generated Code Diff Check
-
+    needs: changes
+    if: needs.changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -44,7 +89,8 @@ jobs:
 
   lint:
     name: ESLint
-
+    needs: changes
+    if: needs.changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -74,7 +120,8 @@ jobs:
 
   style:
     name: Stylelint
-
+    needs: changes
+    if: needs.changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/contracts-qa.yaml
+++ b/.github/workflows/contracts-qa.yaml
@@ -7,9 +7,49 @@ on:
       - dev
 
 jobs:
+  changes:
+    name: Detect related changes
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.filter.outputs.should_run }}
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Detect changes
+        id: filter
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base_sha="${{ github.event.pull_request.base.sha }}"
+            head_sha="${{ github.event.pull_request.head.sha }}"
+          elif [ "${{ github.event_name }}" = "push" ]; then
+            base_sha="${{ github.event.before }}"
+            head_sha="${{ github.sha }}"
+          else
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$base_sha" = "0000000000000000000000000000000000000000" ]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          changed_files="$(git diff --name-only "$base_sha" "$head_sha")"
+          echo "$changed_files"
+
+          if echo "$changed_files" | grep -Eq '^(src/contracts/|src/package.json$|src/bun.lock$|mise(\.ci|\.local)?\.toml$|\.github/workflows/contracts-qa\.yaml$)'; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+          fi
+
   format:
     name: Format Check
-
+    needs: changes
+    if: needs.changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -39,7 +79,8 @@ jobs:
 
   diff:
     name: Generated Code Diff Check
-
+    needs: changes
+    if: needs.changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/server-qa.yaml
+++ b/.github/workflows/server-qa.yaml
@@ -12,8 +12,54 @@ env:
   MISE_ENV: ci
 
 jobs:
+  changes:
+    name: Detect related changes
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.filter.outputs.should_run }}
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Detect changes
+        id: filter
+        run: |
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base_sha="${{ github.event.pull_request.base.sha }}"
+            head_sha="${{ github.event.pull_request.head.sha }}"
+          elif [ "${{ github.event_name }}" = "push" ]; then
+            base_sha="${{ github.event.before }}"
+            head_sha="${{ github.sha }}"
+          else
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$base_sha" = "0000000000000000000000000000000000000000" ]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          changed_files="$(git diff --name-only "$base_sha" "$head_sha")"
+          echo "$changed_files"
+
+          if echo "$changed_files" | grep -Eq '^(src/server/|src/contracts/|docker/|compose\.yaml$|mise(\.ci|\.local)?\.toml$|\.github/workflows/server-qa\.yaml$)'; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+          fi
+
   setup:
     name: Setup server
+    needs: changes
+    if: needs.changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     outputs:
       vendor-key: ${{ steps.define-variables.outputs.VENDOR_KEY }}
@@ -94,10 +140,20 @@ jobs:
         run: mise run generate:server
 
   arkitect:
-    needs: setup
+    needs:
+      - changes
+      - setup
+    if: always() && needs.changes.outputs.should_run == 'true'
     name: Arkitect
     runs-on: ubuntu-latest
     steps:
+      - name: Validate setup
+        run: |
+          if [ "${{ needs.setup.result }}" != "success" ]; then
+            echo "Setup server failed"
+            exit 1
+          fi
+
       - name: Checkout the code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -127,10 +183,20 @@ jobs:
         run: mise run arkitect
 
   ecs:
-    needs: setup
+    needs:
+      - changes
+      - setup
+    if: always() && needs.changes.outputs.should_run == 'true'
     name: EasyCodingStandard
     runs-on: ubuntu-latest
     steps:
+      - name: Validate setup
+        run: |
+          if [ "${{ needs.setup.result }}" != "success" ]; then
+            echo "Setup server failed"
+            exit 1
+          fi
+
       - name: Checkout the code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -160,10 +226,20 @@ jobs:
         run: mise run ecs
 
   phpstan:
-    needs: setup
+    needs:
+      - changes
+      - setup
+    if: always() && needs.changes.outputs.should_run == 'true'
     name: PHPStan
     runs-on: ubuntu-latest
     steps:
+      - name: Validate setup
+        run: |
+          if [ "${{ needs.setup.result }}" != "success" ]; then
+            echo "Setup server failed"
+            exit 1
+          fi
+
       - name: Checkout the code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -193,10 +269,20 @@ jobs:
         run: mise run phpstan
 
   phpunit:
-    needs: setup
+    needs:
+      - changes
+      - setup
+    if: always() && needs.changes.outputs.should_run == 'true'
     name: PHPUnit
     runs-on: ubuntu-latest
     steps:
+      - name: Validate setup
+        run: |
+          if [ "${{ needs.setup.result }}" != "success" ]; then
+            echo "Setup server failed"
+            exit 1
+          fi
+
       - name: Checkout the code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/viewer-qa.yaml
+++ b/.github/workflows/viewer-qa.yaml
@@ -7,9 +7,49 @@ on:
       - dev
 
 jobs:
+  changes:
+    name: Detect related changes
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.filter.outputs.should_run }}
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Detect changes
+        id: filter
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base_sha="${{ github.event.pull_request.base.sha }}"
+            head_sha="${{ github.event.pull_request.head.sha }}"
+          elif [ "${{ github.event_name }}" = "push" ]; then
+            base_sha="${{ github.event.before }}"
+            head_sha="${{ github.sha }}"
+          else
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$base_sha" = "0000000000000000000000000000000000000000" ]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          changed_files="$(git diff --name-only "$base_sha" "$head_sha")"
+          echo "$changed_files"
+
+          if echo "$changed_files" | grep -Eq '^(src/viewer/|src/contracts/|src/package.json$|src/bun.lock$|mise(\.ci|\.local)?\.toml$|\.github/workflows/viewer-qa\.yaml$)'; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+          fi
+
   none:
     name: None
-
+    needs: changes
+    if: needs.changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
 
     # TODO 将来的に整備する


### PR DESCRIPTION
## 概要
- Admin QA / Contracts QA / Server QA / Viewer QA に変更判定 job を追加
- workflow 自体は常に起動しつつ、本体 job は関連変更時だけ if で実行
- required check を維持したまま、非関連変更では skipped で通せるようにする

## 補足

- Server QA は setup 失敗を下流 job に明示的に伝播します