### PR TITLE
mise タスクを api/admin/viewer のプレフィックスで再編

### DIFF
--- a/.agents/skills/php-feature-test-creator/SKILL.md
+++ b/.agents/skills/php-feature-test-creator/SKILL.md
@@ -29,10 +29,10 @@ description: プロジェクトのフィーチャーテスト規約（API testin
    - **検証**:
      - API: `assertStatus()`, `assertJson()` 等。
      - Console: `expectsOutput()`, `assertSuccessful()`, `assertFailed()` 等。
-   - コードのフォーマットは `mise run ecs:fix` で適宜フォーマット修正を実行します。
+   - コードのフォーマットは `mise run api:ecs:fix` で適宜フォーマット修正を実行します。
 
 5. **テストの実行**:
-   - テストの実行は `mise run test:feature` または `mise run test 作成したテストのパス` を利用します。
+   - テストの実行は `mise run api:test:feature` または `mise run api:test 作成したテストのパス` を利用します。
 
 ## リファレンス
 

--- a/.agents/skills/php-integration-test-creator/SKILL.md
+++ b/.agents/skills/php-integration-test-creator/SKILL.md
@@ -28,10 +28,10 @@ description: プロジェクトのインテグレーションテスト規約に�
    - **検証**:
      - 戻り値（`ResultType` など）をアサートします。
      - `getAll()` メソッドを使用して、ファイルストアに正しく永続化されたかを確認します。
-   - コードのフォーマットは `mise run ecs:fix` で適宜フォーマット修正を実行します。
+   - コードのフォーマットは `mise run api:ecs:fix` で適宜フォーマット修正を実行します。
 
 5. **テストの実行**:
-   - テストの実行は `mise run test:integration` または `mise run test 作成したテストのパス` を利用します。
+   - テストの実行は `mise run api:test:integration` または `mise run api:test 作成したテストのパス` を利用します。
 
 ## リファレンス
 

--- a/.agents/skills/php-unit-test-creator/SKILL.md
+++ b/.agents/skills/php-unit-test-creator/SKILL.md
@@ -32,10 +32,10 @@ description: プロジェクトのテスト規約に従って、Laravel/PHP の�
      - **異常系**: 無効な入力、依存先の失敗（例: リポジトリが `Err` を返す場合）。
    - Mockery のエクスペクテーション（`shouldReceive`, `once`, `andReturn`）を使用します。
    - `$this->assertTrue($result->isOk())` または標準的な PHPUnit のアサーションを使用して結果を検証します。
-   - コードのフォーマットは `mise run ecs:fix` で適宜フォーマット修正を実行します。
+   - コードのフォーマットは `mise run api:ecs:fix` で適宜フォーマット修正を実行します。
 
 5. **テストの実行**:
-   - テストの実行は `mise run test:unit` または `mise run test 作成したテストのパス` を利用します。
+   - テストの実行は `mise run api:test:unit` または `mise run api:test 作成したテストのパス` を利用します。
 
 ## リファレンス
 

--- a/.apm/instructions/01-backend.instructions.md
+++ b/.apm/instructions/01-backend.instructions.md
@@ -35,4 +35,4 @@ applyTo: 'src/server/**'
 ## 検証
 
 - 変更に最も近いタスクから実行する
-- 代表例: `mise run ecs`, `mise run phpstan`, `mise run arkitect`, `mise run test`
+- 代表例: `mise run api:ecs`, `mise run api:phpstan`, `mise run api:arkitect`, `mise run api:test`

--- a/.apm/instructions/02-admin.instructions.md
+++ b/.apm/instructions/02-admin.instructions.md
@@ -25,7 +25,7 @@ applyTo: 'src/admin/**'
 
 - ページ責務は `.astro` に保ち、対話的な UI は `.tsx` に分離する
 - API クライアントや型は `src/admin/src/generated/` を Source of Truth とし、手動編集しない
-- API shape を変える場合は `src/contracts` を更新してから `mise run generate:client:admin` を使う
+- API shape を変える場合は `src/contracts` を更新してから `mise run admin:generate` を使う
 
 ## 検証
 

--- a/.apm/skills/php-feature-test-creator/SKILL.md
+++ b/.apm/skills/php-feature-test-creator/SKILL.md
@@ -29,10 +29,10 @@ description: プロジェクトのフィーチャーテスト規約（API testin
    - **検証**:
      - API: `assertStatus()`, `assertJson()` 等。
      - Console: `expectsOutput()`, `assertSuccessful()`, `assertFailed()` 等。
-   - コードのフォーマットは `mise run ecs:fix` で適宜フォーマット修正を実行します。
+   - コードのフォーマットは `mise run api:ecs:fix` で適宜フォーマット修正を実行します。
 
 5. **テストの実行**:
-   - テストの実行は `mise run test:feature` または `mise run test 作成したテストのパス` を利用します。
+   - テストの実行は `mise run api:test:feature` または `mise run api:test 作成したテストのパス` を利用します。
 
 ## リファレンス
 

--- a/.apm/skills/php-integration-test-creator/SKILL.md
+++ b/.apm/skills/php-integration-test-creator/SKILL.md
@@ -28,10 +28,10 @@ description: プロジェクトのインテグレーションテスト規約に�
    - **検証**:
      - 戻り値（`ResultType` など）をアサートします。
      - `getAll()` メソッドを使用して、ファイルストアに正しく永続化されたかを確認します。
-   - コードのフォーマットは `mise run ecs:fix` で適宜フォーマット修正を実行します。
+   - コードのフォーマットは `mise run api:ecs:fix` で適宜フォーマット修正を実行します。
 
 5. **テストの実行**:
-   - テストの実行は `mise run test:integration` または `mise run test 作成したテストのパス` を利用します。
+   - テストの実行は `mise run api:test:integration` または `mise run api:test 作成したテストのパス` を利用します。
 
 ## リファレンス
 

--- a/.apm/skills/php-unit-test-creator/SKILL.md
+++ b/.apm/skills/php-unit-test-creator/SKILL.md
@@ -32,10 +32,10 @@ description: プロジェクトのテスト規約に従って、Laravel/PHP の�
      - **異常系**: 無効な入力、依存先の失敗（例: リポジトリが `Err` を返す場合）。
    - Mockery のエクスペクテーション（`shouldReceive`, `once`, `andReturn`）を使用します。
    - `$this->assertTrue($result->isOk())` または標準的な PHPUnit のアサーションを使用して結果を検証します。
-   - コードのフォーマットは `mise run ecs:fix` で適宜フォーマット修正を実行します。
+   - コードのフォーマットは `mise run api:ecs:fix` で適宜フォーマット修正を実行します。
 
 5. **テストの実行**:
-   - テストの実行は `mise run test:unit` または `mise run test 作成したテストのパス` を利用します。
+   - テストの実行は `mise run api:test:unit` または `mise run api:test 作成したテストのパス` を利用します。
 
 ## リファレンス
 

--- a/.claude/rules/01-backend.md
+++ b/.claude/rules/01-backend.md
@@ -34,4 +34,4 @@ paths:
 ## 検証
 
 - 変更に最も近いタスクから実行する
-- 代表例: `mise run ecs`, `mise run phpstan`, `mise run arkitect`, `mise run test`
+- 代表例: `mise run api:ecs`, `mise run api:phpstan`, `mise run api:arkitect`, `mise run api:test`

--- a/.claude/rules/02-admin.md
+++ b/.claude/rules/02-admin.md
@@ -24,7 +24,7 @@ paths:
 
 - ページ責務は `.astro` に保ち、対話的な UI は `.tsx` に分離する
 - API クライアントや型は `src/admin/src/generated/` を Source of Truth とし、手動編集しない
-- API shape を変える場合は `src/contracts` を更新してから `mise run generate:client:admin` を使う
+- API shape を変える場合は `src/contracts` を更新してから `mise run admin:generate` を使う
 
 ## 検証
 

--- a/.claude/skills/php-feature-test-creator/SKILL.md
+++ b/.claude/skills/php-feature-test-creator/SKILL.md
@@ -29,10 +29,10 @@ description: プロジェクトのフィーチャーテスト規約（API testin
    - **検証**:
      - API: `assertStatus()`, `assertJson()` 等。
      - Console: `expectsOutput()`, `assertSuccessful()`, `assertFailed()` 等。
-   - コードのフォーマットは `mise run ecs:fix` で適宜フォーマット修正を実行します。
+   - コードのフォーマットは `mise run api:ecs:fix` で適宜フォーマット修正を実行します。
 
 5. **テストの実行**:
-   - テストの実行は `mise run test:feature` または `mise run test 作成したテストのパス` を利用します。
+   - テストの実行は `mise run api:test:feature` または `mise run api:test 作成したテストのパス` を利用します。
 
 ## リファレンス
 

--- a/.claude/skills/php-integration-test-creator/SKILL.md
+++ b/.claude/skills/php-integration-test-creator/SKILL.md
@@ -28,10 +28,10 @@ description: プロジェクトのインテグレーションテスト規約に�
    - **検証**:
      - 戻り値（`ResultType` など）をアサートします。
      - `getAll()` メソッドを使用して、ファイルストアに正しく永続化されたかを確認します。
-   - コードのフォーマットは `mise run ecs:fix` で適宜フォーマット修正を実行します。
+   - コードのフォーマットは `mise run api:ecs:fix` で適宜フォーマット修正を実行します。
 
 5. **テストの実行**:
-   - テストの実行は `mise run test:integration` または `mise run test 作成したテストのパス` を利用します。
+   - テストの実行は `mise run api:test:integration` または `mise run api:test 作成したテストのパス` を利用します。
 
 ## リファレンス
 

--- a/.claude/skills/php-unit-test-creator/SKILL.md
+++ b/.claude/skills/php-unit-test-creator/SKILL.md
@@ -32,10 +32,10 @@ description: プロジェクトのテスト規約に従って、Laravel/PHP の�
      - **異常系**: 無効な入力、依存先の失敗（例: リポジトリが `Err` を返す場合）。
    - Mockery のエクスペクテーション（`shouldReceive`, `once`, `andReturn`）を使用します。
    - `$this->assertTrue($result->isOk())` または標準的な PHPUnit のアサーションを使用して結果を検証します。
-   - コードのフォーマットは `mise run ecs:fix` で適宜フォーマット修正を実行します。
+   - コードのフォーマットは `mise run api:ecs:fix` で適宜フォーマット修正を実行します。
 
 5. **テストの実行**:
-   - テストの実行は `mise run test:unit` または `mise run test 作成したテストのパス` を利用します。
+   - テストの実行は `mise run api:test:unit` または `mise run api:test 作成したテストのパス` を利用します。
 
 ## リファレンス
 

--- a/.github/hooks/post-lint.sh
+++ b/.github/hooks/post-lint.sh
@@ -46,10 +46,10 @@ case "$file" in
     container_path="${file#*src/server/}"
 
     # 自動修正
-    mise run ecs:fix -- "$container_path" >/dev/null 2>&1 || true
+    mise run api:ecs:fix -- "$container_path" >/dev/null 2>&1 || true
 
     # 残った違反をチェック
-    diag="$(mise run ecs -- "$container_path" 2>&1 | head -30)" || true
+    diag="$(mise run api:ecs -- "$container_path" 2>&1 | head -30)" || true
 
     if [ -n "$diag" ] && echo "$diag" | grep -qiE 'error|found'; then
       jq -n --arg msg "$diag" '{

--- a/.github/instructions/01-backend.instructions.md
+++ b/.github/instructions/01-backend.instructions.md
@@ -35,4 +35,4 @@ applyTo: 'src/server/**'
 ## 検証
 
 - 変更に最も近いタスクから実行する
-- 代表例: `mise run ecs`, `mise run phpstan`, `mise run arkitect`, `mise run test`
+- 代表例: `mise run api:ecs`, `mise run api:phpstan`, `mise run api:arkitect`, `mise run api:test`

--- a/.github/instructions/02-admin.instructions.md
+++ b/.github/instructions/02-admin.instructions.md
@@ -25,7 +25,7 @@ applyTo: 'src/admin/**'
 
 - ページ責務は `.astro` に保ち、対話的な UI は `.tsx` に分離する
 - API クライアントや型は `src/admin/src/generated/` を Source of Truth とし、手動編集しない
-- API shape を変える場合は `src/contracts` を更新してから `mise run generate:client:admin` を使う
+- API shape を変える場合は `src/contracts` を更新してから `mise run admin:generate` を使う
 
 ## 検証
 

--- a/.github/skills/php-feature-test-creator/SKILL.md
+++ b/.github/skills/php-feature-test-creator/SKILL.md
@@ -29,10 +29,10 @@ description: プロジェクトのフィーチャーテスト規約（API testin
    - **検証**:
      - API: `assertStatus()`, `assertJson()` 等。
      - Console: `expectsOutput()`, `assertSuccessful()`, `assertFailed()` 等。
-   - コードのフォーマットは `mise run ecs:fix` で適宜フォーマット修正を実行します。
+   - コードのフォーマットは `mise run api:ecs:fix` で適宜フォーマット修正を実行します。
 
 5. **テストの実行**:
-   - テストの実行は `mise run test:feature` または `mise run test 作成したテストのパス` を利用します。
+   - テストの実行は `mise run api:test:feature` または `mise run api:test 作成したテストのパス` を利用します。
 
 ## リファレンス
 

--- a/.github/skills/php-integration-test-creator/SKILL.md
+++ b/.github/skills/php-integration-test-creator/SKILL.md
@@ -28,10 +28,10 @@ description: プロジェクトのインテグレーションテスト規約に�
    - **検証**:
      - 戻り値（`ResultType` など）をアサートします。
      - `getAll()` メソッドを使用して、ファイルストアに正しく永続化されたかを確認します。
-   - コードのフォーマットは `mise run ecs:fix` で適宜フォーマット修正を実行します。
+   - コードのフォーマットは `mise run api:ecs:fix` で適宜フォーマット修正を実行します。
 
 5. **テストの実行**:
-   - テストの実行は `mise run test:integration` または `mise run test 作成したテストのパス` を利用します。
+   - テストの実行は `mise run api:test:integration` または `mise run api:test 作成したテストのパス` を利用します。
 
 ## リファレンス
 

--- a/.github/skills/php-unit-test-creator/SKILL.md
+++ b/.github/skills/php-unit-test-creator/SKILL.md
@@ -32,10 +32,10 @@ description: プロジェクトのテスト規約に従って、Laravel/PHP の�
      - **異常系**: 無効な入力、依存先の失敗（例: リポジトリが `Err` を返す場合）。
    - Mockery のエクスペクテーション（`shouldReceive`, `once`, `andReturn`）を使用します。
    - `$this->assertTrue($result->isOk())` または標準的な PHPUnit のアサーションを使用して結果を検証します。
-   - コードのフォーマットは `mise run ecs:fix` で適宜フォーマット修正を実行します。
+   - コードのフォーマットは `mise run api:ecs:fix` で適宜フォーマット修正を実行します。
 
 5. **テストの実行**:
-   - テストの実行は `mise run test:unit` または `mise run test 作成したテストのパス` を利用します。
+   - テストの実行は `mise run api:test:unit` または `mise run api:test 作成したテストのパス` を利用します。
 
 ## リファレンス
 

--- a/.github/workflows/admin-qa.yaml
+++ b/.github/workflows/admin-qa.yaml
@@ -40,7 +40,7 @@ jobs:
         run: mise run bun:install
 
       - name: Check generate code has diff
-        run: mise run generate:client:admin
+        run: mise run admin:generate
 
   lint:
     name: ESLint
@@ -70,7 +70,7 @@ jobs:
         run: mise run bun:install
 
       - name: Run ESLint
-        run: mise run lint
+        run: mise run admin:lint
 
   style:
     name: Stylelint
@@ -100,7 +100,7 @@ jobs:
         run: mise run bun:install
 
       - name: Run Stylelint
-        run: mise run style
+        run: mise run admin:style
 
       # - name: Run Build
       #   run: bun run build

--- a/.github/workflows/server-qa.yaml
+++ b/.github/workflows/server-qa.yaml
@@ -88,10 +88,10 @@ jobs:
 
       - name: Composer install
         if: steps.cache-composer.outputs.cache-hit != 'true'
-        run: mise run composer:install
+        run: mise run api:composer:install
 
       - name: Check generate code has diff
-        run: mise run generate:server
+        run: mise run api:generate
 
   arkitect:
     needs: setup
@@ -124,7 +124,7 @@ jobs:
           key: ${{ needs.setup.outputs.vendor-key }}
 
       - name: Check Layer
-        run: mise run arkitect
+        run: mise run api:arkitect
 
   ecs:
     needs: setup
@@ -157,7 +157,7 @@ jobs:
           key: ${{ needs.setup.outputs.vendor-key }}
 
       - name: Run ecs
-        run: mise run ecs
+        run: mise run api:ecs
 
   phpstan:
     needs: setup
@@ -190,7 +190,7 @@ jobs:
           key: ${{ needs.setup.outputs.vendor-key }}
 
       - name: Run PHPStan
-        run: mise run phpstan
+        run: mise run api:phpstan
 
   phpunit:
     needs: setup
@@ -243,4 +243,4 @@ jobs:
         run: mise run migrate:local --auto-approve
 
       - name: Run PHPUnit
-        run: mise run test:all
+        run: mise run api:test:all

--- a/docs/design-docs/local-runtime-topology.md
+++ b/docs/design-docs/local-runtime-topology.md
@@ -41,7 +41,7 @@
 1. ベースブランチを最新化する
 2. タスクごとに `git worktree add <path> <branch>` で worktree を作る
 3. 各 worktree で `mise run worktree:init` を実行する
-4. 必要に応じて `mise run up`、`mise run dev:admin`、`mise run dev:viewer` を起動する
+4. 必要に応じて `mise run up`、`mise run admin:dev`、`mise run viewer:dev` を起動する
 5. `mise run worktree:status` で URL とポートの衝突がないことを確認する
 6. タスクごとの局所検証を回しながら実装を進める
 7. 依存元の変更が進んだら、他 worktree はベースブランチまたは owner worktree の結果を再取り込みする
@@ -77,7 +77,7 @@
 ## Minimum Validation
 
 - `src/contracts`: `mise run contract:format:check`, `mise run contract:test`
-- `src/server`: `mise run ecs`, `mise run phpstan`, `mise run test`
+- `src/server`: `mise run api:ecs`, `mise run api:phpstan`, `mise run api:test`
 - `src/admin`: `cd src && bun --filter admin lint:check`, `cd src && bun --filter admin build`
 - `src/viewer`: `cd src && bun --filter viewer lint:check`, `cd src && bun --filter viewer build`
 - 開発基盤: `mise run worktree:status` と対象サービスの起動確認

--- a/mise.ci.toml
+++ b/mise.ci.toml
@@ -55,11 +55,11 @@ run = "docker compose up -d php"
 description = "CI 環境でテスト用コンテナを起動する"
 run = "docker compose up -d php mysql"
 
-[tasks."composer:install"]
+[tasks."api:composer:install"]
 description = "CI 環境で composer install を実行する"
 run = "docker compose exec -T php composer install -n --prefer-dist"
 
-[tasks."generate:server"]
+[tasks."api:generate"]
 description = "CI 環境でコード生成を行い、差分をチェックする"
 run = '''
 docker run --rm -u $(id -u):$(id -g) -v ".:/local" $OPENAPI_IMAGE generate \
@@ -90,7 +90,7 @@ run = 'atlas schema apply --env local --var "db_name=${DB_DATABASE}" --auto-appr
 [tasks.migrate.env]
 _.file = "src/server/.env"
 
-[tasks."generate:client:admin"]
+[tasks."admin:generate"]
 description = "CI 環境でクライアントコード生成を行い、差分をチェックする"
 dir = "src"
 run = '''

--- a/mise.toml
+++ b/mise.toml
@@ -28,13 +28,15 @@ NODE_EXTRA_CA_CERTS = "../../docker/php/certs/rootCA.pem"
 ADMIN_OAS_FILE = "IsekaiObservatory.Admin.v1.yaml"
 VIEWER_OAS_FILE = "IsekaiObservatory.Viewer.v1.yaml"
 
+# -- 環境構築 / コンテナ --
+
 [tasks.setup]
 description = "環境構築をする"
 run = [
   { task = "cert:make" },
   { task = "cert:copy-pem" },
   { task = "build" },
-  { tasks = ["composer:install", "bun:install"] },
+  { tasks = ["api:composer:install", "bun:install"] },
   { task = "up" },
 ]
 
@@ -80,161 +82,6 @@ run = "docker compose up -d"
 description = "コンテナを削除する"
 run = "docker compose down"
 
-[tasks.php]
-description = "php コンテナの中に入る"
-run = "docker compose exec php bash"
-
-[tasks."composer:install"]
-description = "composer パッケージをインストールする"
-run = "docker compose run --rm php composer install"
-
-[tasks.phpstan]
-description = "PHPStan を実行する"
-usage = 'arg "[path]" var=#true help="静的解析対象パス"'
-run = "docker compose exec php composer phpstan ${usage_path}"
-
-[tasks."phpstan:clear-cache"]
-description = "PHPStan のキャッシュを削除する"
-run = "docker compose exec php composer phpstan-clear-cache"
-
-[tasks.arkitect]
-description = "PHPArkitect を実行する"
-run = "docker compose exec php composer arkitect"
-
-[tasks.ecs]
-description = "ECS を実行し、コードフォーマットをチェックする"
-usage = 'arg "[path]" var=#true help="フォーマットチェック対象パス"'
-run = "docker compose exec php composer ecs ${usage_path}"
-
-[tasks."ecs:fix"]
-description = "ECS を実行し、フォーマットを自動修正する"
-usage = 'arg "[path]" var=#true help="フォーマット自動修正対象パス"'
-run = "docker compose exec php composer ecs-fix ${usage_path}"
-
-[tasks.test]
-description = "テストを実行する"
-usage = '''
-arg "[path]" var=#true help="テスト対象パス"
-'''
-run = "docker compose exec php ./vendor/bin/paratest ${usage_path}"
-
-[tasks."test:all"]
-description = "すべてのテストを実行する"
-run = "docker compose exec php composer test-all"
-
-[tasks."test:unit"]
-description = "Unit テストを実行する"
-run = "docker compose exec php composer test-unit"
-
-[tasks."test:integration"]
-description = "Integration テストを実行する"
-run = "docker compose exec php composer test-integration"
-
-[tasks."test:feature"]
-description = "Feature テストを実行する"
-run = "docker compose exec php composer test-feature"
-
-[tasks.coverage]
-description = "テストカバレッジを出力する"
-run = "docker compose exec php composer coverage"
-
-[tasks.infection]
-description = "ミューテーションテストを実行する"
-run = "docker compose exec php composer infection"
-
-[tasks.metrics]
-description = "コードメトリクスを出力する"
-run = "docker compose exec php composer metrics"
-
-[tasks.migrate]
-description = "スキーマをデータベースに適用する"
-depends = ["migrate:local", "migrate:testing"]
-
-[tasks."migrate:local"]
-description = "スキーマを local データベースに適用する"
-dir = "src/server/database/atlas"
-run = 'atlas schema apply --env local --var "db_name=${DB_DATABASE}"'
-
-[tasks."migrate:local".env]
-_.file = "src/server/.env"
-
-[tasks."migrate:testing"]
-description = "スキーマを testing データベースに適用する"
-dir = "src/server/database/atlas"
-run = 'atlas schema apply --env testing --var "db_name=${DB_DATABASE}"'
-
-[tasks."migrate:testing".env]
-_.file = "src/server/.env.testing"
-
-[tasks."migrate:dry-run"]
-quiet = true
-description = "適用されるスキーマの差分を確認する（適用はしない）"
-dir = "src/server/database/atlas"
-run = 'atlas schema apply --env local --var "db_name=${DB_DATABASE}" --dry-run'
-
-[tasks."migrate:dry-run".env]
-_.file = "src/server/.env"
-
-[tasks.tinker]
-description = "Laravel tinker を実行する"
-run = "docker compose exec php php artisan tinker"
-
-[tasks."ide:doc"]
-description = "Eloquent にカラム情報を書き込む"
-run = "docker compose exec php php artisan ide-helper:models -RW -n"
-
-[tasks."worktree:init"]
-description = "worktree ごとのローカル実行設定を生成する"
-run = "./tools/worktree/init.sh"
-
-[tasks."worktree:status"]
-description = "現在の worktree に割り当てられたポートと URL を表示する"
-run = "./tools/worktree/init.sh --status"
-
-[tasks."dev:admin"]
-description = "Admin の dev サーバーを worktree 専用ポートで起動する"
-dir = "src"
-run = "bun --filter admin dev -- --host 0.0.0.0 --port \"${WORKTREE_ADMIN_PORT:-4321}\""
-
-[tasks."dev:viewer"]
-description = "Viewer の dev サーバーを worktree 専用ポートで起動する"
-dir = "src"
-run = "bun --filter viewer dev -- --host 0.0.0.0 --port \"${WORKTREE_VIEWER_PORT:-3000}\""
-
-[tasks.generate]
-description = "OAS からコードを生成する"
-depends = "generate:*"
-
-[tasks."generate:server"]
-description = "OAS からサーバーのコードを生成する"
-run = '''
-rm -rf ./src/server/Generated
-
-docker run --rm -u {{vars.uid}}:{{vars.gid}} -v ".:/local" ${OPENAPI_IMAGE} generate \
-  -i /local/src/contracts/generated/oas/${ADMIN_OAS_FILE} \
-  -g php \
-  -t /local/src/server/tools/openapi-generator/templates \
-  -o /local/src/server/Generated
-'''
-
-[tasks."generate:client:viewer"]
-description = "OAS から Viewer のコードを生成する"
-dir = "src/viewer"
-run = '''
-rm -rf src/generated
-
-bun run generate:api
-'''
-
-[tasks."generate:client:admin"]
-description = "OAS から Admin のコードを生成する"
-dir = "src/admin"
-run = '''
-rm -rf src/generated
-
-bun run generate:api
-'''
-
 [tasks."cert:make"]
 description = "自己署名証明書を作成する"
 run = '''
@@ -259,6 +106,22 @@ cp ${caroot_pem} docker/php/certs/
 description = "bun のパッケージをインストールする"
 dir = "src"
 run = "bun install"
+
+# -- worktree --
+
+[tasks."worktree:init"]
+description = "worktree ごとのローカル実行設定を生成し、開発環境を起動する"
+run = [
+  "./tools/worktree/init.sh",
+  { task = "up" },
+  { tasks = ["api:composer:install", "bun:install"] },
+]
+
+[tasks."worktree:status"]
+description = "現在の worktree に割り当てられたポートと URL を表示する"
+run = "./tools/worktree/init.sh --status"
+
+# -- contract --
 
 [tasks."contract:format"]
 description = "TypeSpec をフォーマットする"
@@ -308,41 +171,198 @@ bun --filter contracts compile:viewer
 bun --filter contracts compile:admin
 '''
 
-[tasks.format]
-description = "ESLint と Stylelint を --fix オプション付きで実行する"
-depends = ["lint:fix", "style:fix"]
+# -- generate --
 
-[tasks.lint]
+[tasks.generate]
+description = "OAS からコードを生成する"
+depends = ["api:generate", "admin:generate", "viewer:generate"]
+
+# -- api --
+
+[tasks."api:shell"]
+description = "php コンテナの中に入る"
+run = "docker compose exec php bash"
+
+[tasks."api:composer:install"]
+description = "composer パッケージをインストールする"
+run = "docker compose run --rm php composer install"
+
+[tasks."api:generate"]
+description = "OAS からサーバーのコードを生成する"
+run = '''
+rm -rf ./src/server/Generated
+
+docker run --rm -u {{vars.uid}}:{{vars.gid}} -v ".:/local" ${OPENAPI_IMAGE} generate \
+  -i /local/src/contracts/generated/oas/${ADMIN_OAS_FILE} \
+  -g php \
+  -t /local/src/server/tools/openapi-generator/templates \
+  -o /local/src/server/Generated
+'''
+
+[tasks."api:phpstan"]
+description = "PHPStan を実行する"
+usage = 'arg "[path]" var=#true help="静的解析対象パス"'
+run = "docker compose exec php composer phpstan ${usage_path}"
+
+[tasks."api:phpstan:clear-cache"]
+description = "PHPStan のキャッシュを削除する"
+run = "docker compose exec php composer phpstan-clear-cache"
+
+[tasks."api:arkitect"]
+description = "PHPArkitect を実行する"
+run = "docker compose exec php composer arkitect"
+
+[tasks."api:ecs"]
+description = "ECS を実行し、コードフォーマットをチェックする"
+usage = 'arg "[path]" var=#true help="フォーマットチェック対象パス"'
+run = "docker compose exec php composer ecs ${usage_path}"
+
+[tasks."api:ecs:fix"]
+description = "ECS を実行し、フォーマットを自動修正する"
+usage = 'arg "[path]" var=#true help="フォーマット自動修正対象パス"'
+run = "docker compose exec php composer ecs-fix ${usage_path}"
+
+[tasks."api:test"]
+description = "テストを実行する"
+usage = '''
+arg "[path]" var=#true help="テスト対象パス"
+'''
+run = "docker compose exec php ./vendor/bin/paratest ${usage_path}"
+
+[tasks."api:test:all"]
+description = "すべてのテストを実行する"
+run = "docker compose exec php composer test-all"
+
+[tasks."api:test:unit"]
+description = "Unit テストを実行する"
+run = "docker compose exec php composer test-unit"
+
+[tasks."api:test:integration"]
+description = "Integration テストを実行する"
+run = "docker compose exec php composer test-integration"
+
+[tasks."api:test:feature"]
+description = "Feature テストを実行する"
+run = "docker compose exec php composer test-feature"
+
+[tasks."api:coverage"]
+description = "テストカバレッジを出力する"
+run = "docker compose exec php composer coverage"
+
+[tasks."api:infection"]
+description = "ミューテーションテストを実行する"
+run = "docker compose exec php composer infection"
+
+[tasks."api:metrics"]
+description = "コードメトリクスを出力する"
+run = "docker compose exec php composer metrics"
+
+[tasks."api:tinker"]
+description = "Laravel tinker を実行する"
+run = "docker compose exec php php artisan tinker"
+
+[tasks."api:ide:doc"]
+description = "Eloquent にカラム情報を書き込む"
+run = "docker compose exec php php artisan ide-helper:models -RW -n"
+
+# -- migrate --
+
+[tasks.migrate]
+description = "スキーマをデータベースに適用する"
+depends = ["migrate:local", "migrate:testing"]
+
+[tasks."migrate:local"]
+description = "スキーマを local データベースに適用する"
+dir = "src/server/database/atlas"
+run = 'atlas schema apply --env local --var "db_name=${DB_DATABASE}"'
+
+[tasks."migrate:local".env]
+_.file = "src/server/.env"
+
+[tasks."migrate:testing"]
+description = "スキーマを testing データベースに適用する"
+dir = "src/server/database/atlas"
+run = 'atlas schema apply --env testing --var "db_name=${DB_DATABASE}"'
+
+[tasks."migrate:testing".env]
+_.file = "src/server/.env.testing"
+
+[tasks."migrate:dry-run"]
+quiet = true
+description = "適用されるスキーマの差分を確認する（適用はしない）"
+dir = "src/server/database/atlas"
+run = 'atlas schema apply --env local --var "db_name=${DB_DATABASE}" --dry-run'
+
+[tasks."migrate:dry-run".env]
+_.file = "src/server/.env"
+
+# -- admin --
+
+[tasks."admin:dev"]
+description = "Admin の dev サーバーを worktree 専用ポートで起動する"
+dir = "src"
+run = "bun --filter admin dev -- --host 0.0.0.0 --port \"${WORKTREE_ADMIN_PORT:-4321}\""
+
+[tasks."admin:generate"]
+description = "OAS から Admin のコードを生成する"
+dir = "src/admin"
+run = '''
+rm -rf src/generated
+
+bun run generate:api
+'''
+
+[tasks."admin:format"]
+description = "ESLint と Stylelint を --fix オプション付きで実行する"
+depends = ["admin:lint:fix", "admin:style:fix"]
+
+[tasks."admin:lint"]
 description = "ESLint を実行する"
 dir = "src"
 run = "bun --filter admin lint:check"
 
-[tasks."lint:fix"]
+[tasks."admin:lint:fix"]
 description = "ESLint を --fix オプション付きで実行する"
 dir = "src"
 run = "bun --filter admin lint"
 
-[tasks.style]
+[tasks."admin:style"]
 description = "Stylelint を実行する"
 dir = "src"
 run = "bun --filter admin style:check"
 
-[tasks."style:fix"]
+[tasks."admin:style:fix"]
 description = "Stylelint を --fix オプション付きで実行する"
 dir = "src"
 run = "bun --filter admin style"
 
-[tasks.tcm]
+[tasks."admin:tcm"]
 description = "tcm を実行する"
 dir = "src"
 run = "bun --filter admin tcm"
 
-[tasks."tcm:watch"]
+[tasks."admin:tcm:watch"]
 description = "tcm を --watch オプション付きで実行する"
 dir = "src"
 run = "bun --filter admin tcm:watch"
 
-[tasks.prism]
+[tasks."admin:prism"]
 description = "Prism のモックサーバーを起動する"
 dir = "src"
 run = "bun --filter admin prism"
+
+# -- viewer --
+
+[tasks."viewer:dev"]
+description = "Viewer の dev サーバーを worktree 専用ポートで起動する"
+dir = "src"
+run = "bun --filter viewer dev -- --host 0.0.0.0 --port \"${WORKTREE_VIEWER_PORT:-3000}\""
+
+[tasks."viewer:generate"]
+description = "OAS から Viewer のコードを生成する"
+dir = "src/viewer"
+run = '''
+rm -rf src/generated
+
+bun run generate:api
+'''


### PR DESCRIPTION
## Summary

- `mise.toml` のタスク名を `api:` / `admin:` / `viewer:` の3系統で再編し、`mise tasks` の見通しを向上させた（`migrate:*` は据え置き）
- `mise.toml` 内をセクションコメントで分割し、同一系統のタスク定義をまとめて配置した
- `worktree:init` を `init.sh` → `up` → `api:composer:install` + `bun:install` の多段タスクに変更し、worktree 初期化 1 コマンドで開発環境が起動するようにした
- 主な参照箇所（CI workflow / lefthook 周辺の post-lint.sh / `.claude` `.apm` `.github` `.agents` 配下の rules / instructions / SKILL / `docs/design-docs/local-runtime-topology.md`）も追従。`docs/exec-plans/completed/*.md` は履歴として未変更

## 主なリネーム

| before | after |
| --- | --- |
| `composer:install` | `api:composer:install` |
| `php` | `api:shell` |
| `phpstan` / `phpstan:clear-cache` | `api:phpstan` / `api:phpstan:clear-cache` |
| `arkitect` / `ecs` / `ecs:fix` | `api:arkitect` / `api:ecs` / `api:ecs:fix` |
| `test` / `test:all` / `test:unit` / `test:integration` / `test:feature` | `api:test` / `api:test:*` |
| `coverage` / `infection` / `metrics` | `api:coverage` / `api:infection` / `api:metrics` |
| `tinker` / `ide:doc` | `api:tinker` / `api:ide:doc` |
| `generate:server` | `api:generate` |
| `dev:admin` / `generate:client:admin` | `admin:dev` / `admin:generate` |
| `lint`(:fix) / `style`(:fix) / `format` | `admin:lint`(:fix) / `admin:style`(:fix) / `admin:format` |
| `tcm`(:watch) / `prism` | `admin:tcm`(:watch) / `admin:prism` |
| `dev:viewer` / `generate:client:viewer` | `viewer:dev` / `viewer:generate` |

## Test plan

- [ ] `mise tasks` で `api:*` / `admin:*` / `viewer:*` が網羅されていることを確認
- [ ] `mise run api:phpstan` / `mise run admin:lint` など主要タスクが従来同等に動作することを確認
- [ ] `mise run worktree:init` で `up` と composer/bun install まで連続実行されることを確認
- [ ] CI（server-qa / admin-qa workflow）が新タスク名で通ることを確認