### PR TITLE
Person create 実装を追加

### DIFF
--- a/docs/exec-plans/active/20260504-person-create.md
+++ b/docs/exec-plans/active/20260504-person-create.md
@@ -1,0 +1,67 @@
+# Title
+
+Person Create 実装
+
+## Status
+
+completed
+
+## Background
+
+`Person` の契約、DB、pure domain 定義は `feature/person-foundation` で追加済みだが、まだ runtime 実装は存在しない。CRUD 単位でレビューしやすくするため、最初に create だけを切り出して実装する。
+
+## Goal
+
+`feature/person-create` で `Person` の作成 API を server 側に実装し、生成済み契約に沿って人物を 1 件登録できる状態にする。
+
+## Scope
+
+- `src/server/app/Http/Controllers/Api/Person/CreatePersonController.php`
+- `src/server/app/Http/Presenters/Api/Person/{Converter,CreatePresenter}.php`
+- `src/server/app/Models/Person/Person.php`
+- `src/server/app/Providers/Domain/PersonServiceProvider.php`
+- `src/server/bootstrap/providers.php`
+- `src/server/packages/AdminUser/Domain/Models/Permission.php`
+- `src/server/packages/Person/Application/UseCase/Create`
+- `src/server/packages/Person/Domain/Services/PersonIntegrityService.php`
+- `src/server/packages/Person/Domain/Models/PersonRepositoryInterface.php`
+- `src/server/packages/Person/Infrastructures/PersonRepository.php`
+- `src/server/packages/Person/Route/PersonRouteMap.php`
+- `src/server/routes/admin.php`
+- `src/server/tests/Feature/Api/Person/CreatePersonTest.php`
+- `src/server/tests/Integration/Person/Application/UseCase/Create`
+- `src/server/tests/Integration/Person/Infrastructures/PersonRepositoryTest.php`
+- `src/server/tests/Support/Domain/EntityFactory.php`
+
+## Non-Scope
+
+- `Person` の list / search / get
+- `Person` の update / delete
+- admin の `/persons` 画面追加
+- `Creator` / `Performer` の削除
+
+## Acceptance Criteria
+
+- `/admin/v1/persons` への POST で `Person` を 1 件作成できる
+- 同名 `Person` の重複作成は business rule error になる
+- create 実装に必要な repository / model / provider / route が追加されている
+- feature / integration テストで create 導線が確認できる
+
+## Steps
+
+1. ✅ `src/server/app/Models/Person/Person.php`、`src/server/packages/Person/Domain/Models/PersonRepositoryInterface.php`、`src/server/packages/Person/Infrastructures/PersonRepository.php` を追加し、`persons` テーブルを永続化対象として扱えるようにする。
+2. ✅ `src/server/packages/Person/Domain/Services/PersonIntegrityService.php` と `src/server/packages/Person/Application/UseCase/Create/*` を追加し、名前重複検証を含む create use case を実装する。
+3. ✅ `src/server/app/Http/Controllers/Api/Person/CreatePersonController.php`、`src/server/app/Http/Presenters/Api/Person/{Converter,CreatePresenter}.php`、`src/server/packages/Person/Route/PersonRouteMap.php` を追加し、OpenAPI 生成物に沿った create 応答を返す。
+4. ✅ `src/server/app/Providers/Domain/PersonServiceProvider.php`、`src/server/bootstrap/providers.php`、`src/server/routes/admin.php`、`src/server/packages/AdminUser/Domain/Models/Permission.php` を更新し、create ルートと DI を配線する。
+5. ✅ `src/server/tests/Feature/Api/Person/CreatePersonTest.php`、`src/server/tests/Integration/Person/Application/UseCase/Create/*`、`src/server/tests/Integration/Person/Infrastructures/PersonRepositoryTest.php`、`src/server/tests/Support/Domain/EntityFactory.php` を追加・更新して、create 導線を検証する。
+
+## Decision Log
+
+- 2026-05-04: CRUD は 1 PR 1 機能に分け、`create` を最初に実装する。以降の read / update / delete が共通基盤の使い方を揃えやすくするため。
+
+## Validation
+
+- `docker compose exec php composer dump-autoload`
+- `docker compose exec php php artisan test --env=testing tests/Feature/Api/Person/CreatePersonTest.php`
+- `docker compose exec php php artisan test --env=testing tests/Integration/Person/Application/UseCase/Create/CreateUseCaseTest.php`
+- `docker compose exec php php artisan test --env=testing tests/Integration/Person/Infrastructures/PersonRepositoryTest.php`

--- a/docs/exec-plans/active/20260504-person-delete.md
+++ b/docs/exec-plans/active/20260504-person-delete.md
@@ -1,0 +1,50 @@
+# Title
+
+Person Delete 実装
+
+## Status
+
+planned
+
+## Background
+
+削除は後続の song relation 実装と依存関係を持ちやすいため、最後に単独 PR で入れる。現時点では `Person` 単体削除だけを実装し、利用中チェックの拡張は song relation 追加後に調整する。
+
+## Goal
+
+`feature/person-delete` で `Person` の delete API を実装する。
+
+## Scope
+
+- `src/server/app/Http/Controllers/Api/Person/DeletePersonController.php`
+- `src/server/app/Http/Presenters/Api/Person/DeletePresenter.php`
+- `src/server/packages/Person/Application/UseCase/Delete`
+- `src/server/routes/admin.php`
+- `src/server/tests/Feature/Api/Person/DeletePersonTest.php`
+- `src/server/tests/Integration/Person/Application/UseCase/Delete`
+
+## Non-Scope
+
+- song relation を考慮した利用中チェック
+- `Person` の create / read / update
+- admin の `/persons` 画面追加
+
+## Acceptance Criteria
+
+- `/admin/v1/persons/{personId}` の DELETE で未使用 `Person` を削除できる
+- 不正 ID は validation error になる
+
+## Steps
+
+1. delete use case を追加する。
+2. controller / presenter / route を追加する。
+3. feature / integration テストで delete を確認する。
+
+## Decision Log
+
+- 2026-05-04: delete の利用中チェックは song relation 実装前に複雑化させず、必要最小限で入れる。
+
+## Validation
+
+- `docker compose exec php php artisan test --env=testing tests/Feature/Api/Person/DeletePersonTest.php`
+- `docker compose exec php ./vendor/bin/paratest tests/Integration/Person/Application/UseCase/Delete`

--- a/docs/exec-plans/active/20260504-person-master-unification.md
+++ b/docs/exec-plans/active/20260504-person-master-unification.md
@@ -39,6 +39,10 @@ blocked
 
 - `feature/person` を土台ブランチとして保持し、`feature/person-foundation`: [20260504-person-foundation.md](/tmp/person/docs/exec-plans/active/20260504-person-foundation.md)
   契約、DB、pure domain 定義、生成物のみを扱う。runtime 実装は含めない。
+- `feature/person-create`: [20260504-person-create.md](/tmp/person/docs/exec-plans/active/20260504-person-create.md)
+- `feature/person-read`: [20260504-person-read.md](/tmp/person/docs/exec-plans/active/20260504-person-read.md)
+- `feature/person-update`: [20260504-person-update.md](/tmp/person/docs/exec-plans/active/20260504-person-update.md)
+- `feature/person-delete`: [20260504-person-delete.md](/tmp/person/docs/exec-plans/active/20260504-person-delete.md)
 - `feature/person-song-relations`: [20260504-song-person-relations.md](/tmp/person/docs/exec-plans/active/20260504-song-person-relations.md)
 - `feature/person-admin`: [20260504-person-admin.md](/tmp/person/docs/exec-plans/active/20260504-person-admin.md)
 - `feature/remove-creator-performer`: [20260504-remove-creator-performer.md](/tmp/person/docs/exec-plans/active/20260504-remove-creator-performer.md)

--- a/docs/exec-plans/active/20260504-person-read.md
+++ b/docs/exec-plans/active/20260504-person-read.md
@@ -1,0 +1,52 @@
+# Title
+
+Person Read 実装
+
+## Status
+
+planned
+
+## Background
+
+`create` 実装後、人物の一覧・検索・単体取得がないと admin や後続機能で `Person` を参照できない。read 系は同じ repository を共有するため、list / search / get を 1 PR にまとめる。
+
+## Goal
+
+`feature/person-read` で `Person` の list / search / get API を実装する。
+
+## Scope
+
+- `src/server/app/Http/Controllers/Api/Person/{ListPersonController,SearchPersonController,GetPersonController}.php`
+- `src/server/app/Http/Presenters/Api/Person/{ListPresenter,SearchPresenter,GetPresenter}.php`
+- `src/server/packages/Person/Application/UseCase/{List,Search,Get}`
+- `src/server/packages/Person/Domain/Criteria`
+- `src/server/routes/admin.php`
+- `src/server/tests/Feature/Api/Person/{ListPersonTest,SearchPersonTest,GetPersonTest}.php`
+- `src/server/tests/Integration/Person/Application/UseCase/{List,Search,Get}`
+
+## Non-Scope
+
+- `Person` の create / update / delete
+- admin の `/persons` 画面追加
+
+## Acceptance Criteria
+
+- `/admin/v1/persons` の GET、`/admin/v1/persons/search`、`/admin/v1/persons/{personId}` が動作する
+- 名前検索と sort 条件が `Person` 契約どおりに機能する
+
+## Steps
+
+1. `Person` の criteria と list / search / get use case を追加する。
+2. controller / presenter を追加する。
+3. route と provider を read 導線へ拡張する。
+4. feature / integration テストで list / search / get を確認する。
+
+## Decision Log
+
+- 2026-05-04: read は list / search / get を 1 PR にまとめる。repository と presenter の重複差分を減らすため。
+
+## Validation
+
+- `docker compose exec php php artisan test --env=testing tests/Feature/Api/Person/ListPersonTest.php`
+- `docker compose exec php php artisan test --env=testing tests/Feature/Api/Person/SearchPersonTest.php`
+- `docker compose exec php php artisan test --env=testing tests/Feature/Api/Person/GetPersonTest.php`

--- a/docs/exec-plans/active/20260504-person-update.md
+++ b/docs/exec-plans/active/20260504-person-update.md
@@ -1,0 +1,50 @@
+# Title
+
+Person Update 実装
+
+## Status
+
+planned
+
+## Background
+
+`Person` を登録・参照できても更新できなければ運用上の修正ができない。update は create の integrity service と repository を再利用するため、単独 PR に切り出しやすい。
+
+## Goal
+
+`feature/person-update` で `Person` の update API を実装する。
+
+## Scope
+
+- `src/server/app/Http/Controllers/Api/Person/UpdatePersonController.php`
+- `src/server/app/Http/Presenters/Api/Person/UpdatePresenter.php`
+- `src/server/app/Providers/Domain/PersonServiceProvider.php`
+- `src/server/packages/Person/Application/UseCase/Update`
+- `src/server/routes/admin.php`
+- `src/server/tests/Feature/Api/Person/UpdatePersonTest.php`
+- `src/server/tests/Integration/Person/Application/UseCase/Update`
+
+## Non-Scope
+
+- `Person` の create / read / delete
+- admin の `/persons` 画面追加
+
+## Acceptance Criteria
+
+- `/admin/v1/persons/{personId}` の PUT で `name` と `orderNo` を更新できる
+- 同名競合は business rule error になる
+
+## Steps
+
+1. update use case と input / output を追加する。
+2. controller / presenter / provider / route を更新する。
+3. feature / integration テストで update を確認する。
+
+## Decision Log
+
+- 2026-05-04: update は create と同じ integrity service を再利用し、重複ロジックを増やさない。
+
+## Validation
+
+- `docker compose exec php php artisan test --env=testing tests/Feature/Api/Person/UpdatePersonTest.php`
+- `docker compose exec php ./vendor/bin/paratest tests/Integration/Person/Application/UseCase/Update`

--- a/src/server/app/Http/Controllers/Api/Person/CreatePersonController.php
+++ b/src/server/app/Http/Controllers/Api/Person/CreatePersonController.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\Person;
+
+use App\Http\Controllers\Controller;
+use App\Http\Presenters\Api\Person\CreatePresenter;
+use Illuminate\Http\JsonResponse;
+use Person\Application\UseCase\Create\CreateInputData;
+use Person\Application\UseCase\Create\CreateUseCase;
+
+class CreatePersonController extends Controller
+{
+    public function __construct(
+        private readonly CreateUseCase $useCase,
+        private readonly CreatePresenter $presenter,
+    ) {
+    }
+
+    public function handle(CreateInputData $inputData): JsonResponse
+    {
+        return $this->presenter->present($this->useCase->handle($inputData));
+    }
+}

--- a/src/server/app/Http/Presenters/Api/Person/Converter.php
+++ b/src/server/app/Http/Presenters/Api/Person/Converter.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Presenters\Api\Person;
+
+use OpenAPI\Client\Model\Person as OpenApiPerson;
+use Person\Domain\Models\Person;
+
+class Converter
+{
+    public function toOpenApiPerson(Person $person): OpenApiPerson
+    {
+        return new OpenApiPerson()
+            ->setPersonId($person->personId->value)
+            ->setName($person->name->value)
+            ->setOrderNo($person->orderNo->value);
+    }
+}

--- a/src/server/app/Http/Presenters/Api/Person/CreatePresenter.php
+++ b/src/server/app/Http/Presenters/Api/Person/CreatePresenter.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Presenters\Api\Person;
+
+use App\Http\Presenters\Api\Support\ResolvesUseCaseError;
+use Illuminate\Http\JsonResponse;
+use OpenAPI\Client\Model\PersonCreateResponse;
+use Person\Application\UseCase\Create\CreateOutputData;
+use ResultType\Result;
+use Support\UseCase\Error\UseCaseError;
+
+class CreatePresenter
+{
+    use ResolvesUseCaseError;
+
+    public function __construct(private readonly Converter $converter)
+    {
+    }
+
+    /**
+     * @param Result<CreateOutputData, UseCaseError> $result
+     */
+    public function present(Result $result): JsonResponse
+    {
+        [$data, $status] = $result->match(
+            function (CreateOutputData $outputData) {
+                $person = $outputData->person;
+
+                return [
+                    new PersonCreateResponse()->setPerson($this->converter->toOpenApiPerson($person)),
+                    200,
+                ];
+            },
+            fn (UseCaseError $error) => $this->resolveError($error),
+        );
+
+        return response()->json($data, $status);
+    }
+}

--- a/src/server/app/Models/Person/Person.php
+++ b/src/server/app/Models/Person/Person.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\Person;
+
+use Carbon\CarbonImmutable;
+use Illuminate\Database\Eloquent\Model;
+use Override;
+
+/**
+ * @property string          $person_id  人物ID
+ * @property string          $name       人物名
+ * @property int             $order_no   表示順
+ * @property CarbonImmutable $created_at 作成日時
+ * @property CarbonImmutable $updated_at 更新日時
+ *
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Person newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Person newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Person query()
+ *
+ * @mixin \Eloquent
+ */
+class Person extends Model
+{
+    #[Override]
+    protected $table = 'persons';
+
+    #[Override]
+    protected $primaryKey = 'person_id';
+
+    #[Override]
+    protected $keyType = 'string';
+
+    #[Override]
+    protected function casts()
+    {
+        return [
+            'created_at' => 'immutable_datetime',
+            'updated_at' => 'immutable_datetime',
+        ];
+    }
+}

--- a/src/server/app/Providers/Domain/PersonServiceProvider.php
+++ b/src/server/app/Providers/Domain/PersonServiceProvider.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Providers\Domain;
+
+use Illuminate\Http\Request;
+use Override;
+use Person\Application\UseCase\Create\CreateInputData;
+use Person\Domain\Models\PersonRepositoryInterface;
+use Person\Infrastructures\PersonRepository;
+
+class PersonServiceProvider extends EnvServiceProvider
+{
+    #[Override]
+    public function register(): void
+    {
+        $this->app->bind(PersonRepositoryInterface::class, PersonRepository::class);
+
+        $this->app->bind(CreateInputData::class, function (): CreateInputData {
+            $request = $this->app->make(Request::class);
+
+            return $this->getMapper()->map(CreateInputData::class, $request->all());
+        });
+    }
+}

--- a/src/server/bootstrap/providers.php
+++ b/src/server/bootstrap/providers.php
@@ -7,6 +7,7 @@ return [
     App\Providers\DatabaseServiceProvider::class,
     App\Providers\Domain\AuthServiceProvider::class,
     App\Providers\Domain\CreatorServiceProvider::class,
+    App\Providers\Domain\PersonServiceProvider::class,
     App\Providers\Domain\PerformerServiceProvider::class,
     App\Providers\Domain\SongServiceProvider::class,
     App\Providers\Domain\SupportServiceProvider::class,

--- a/src/server/packages/AdminUser/Domain/Models/Permission.php
+++ b/src/server/packages/AdminUser/Domain/Models/Permission.php
@@ -14,6 +14,8 @@ enum Permission: string
 
     case WriteCreator = 'write_creator';
 
+    case WritePerson = 'write_person';
+
     case ReadPerformer = 'read_performer';
 
     case WritePerformer = 'write_performer';
@@ -29,6 +31,7 @@ enum Permission: string
             self::WriteAdminUser => '管理ユーザー編集',
             self::ReadCreator => 'クリエイター閲覧',
             self::WriteCreator => 'クリエイター編集',
+            self::WritePerson => '人物編集',
             self::ReadPerformer => '共演者閲覧',
             self::WritePerformer => '共演者編集',
             self::ReadSong => '楽曲閲覧',

--- a/src/server/packages/Person/Application/UseCase/Create/CreateInputData.php
+++ b/src/server/packages/Person/Application/UseCase/Create/CreateInputData.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Person\Application\UseCase\Create;
+
+readonly class CreateInputData
+{
+    public function __construct(public string $name)
+    {
+    }
+}

--- a/src/server/packages/Person/Application/UseCase/Create/CreateOutputData.php
+++ b/src/server/packages/Person/Application/UseCase/Create/CreateOutputData.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Person\Application\UseCase\Create;
+
+use Person\Domain\Models\Person;
+
+readonly class CreateOutputData
+{
+    public function __construct(public Person $person)
+    {
+    }
+}

--- a/src/server/packages/Person/Application/UseCase/Create/CreateUseCase.php
+++ b/src/server/packages/Person/Application/UseCase/Create/CreateUseCase.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Person\Application\UseCase\Create;
+
+use AdminUser\Domain\Models\Permission;
+use LogicException;
+use Person\Domain\Models\PersonRepositoryInterface;
+use Person\Domain\Services\PersonIntegrityService;
+use ResultType\Err;
+use ResultType\Ok;
+use ResultType\Result;
+use Support\Contracts\TransactionInterface;
+use Support\Domain\Error\BusinessRuleViolationError;
+use Support\Domain\Error\DomainError;
+use Support\Domain\Error\DomainValidationError;
+use Support\Domain\Error\EntityRuleViolationError;
+use Support\UseCase\Authorizer\UseCaseAuthorizer;
+use Support\UseCase\Error\BusinessLogicError;
+use Support\UseCase\Error\InvalidInputError;
+use Support\UseCase\Error\UseCaseError;
+
+readonly class CreateUseCase
+{
+    public function __construct(
+        private UseCaseAuthorizer $authorizer,
+        private TransactionInterface $transaction,
+        private PersonRepositoryInterface $repository,
+        private PersonIntegrityService $service,
+    ) {
+    }
+
+    /**
+     * @return Result<CreateOutputData, UseCaseError>
+     */
+    public function handle(CreateInputData $inputData): Result
+    {
+        return $this->authorizer->require(Permission::WritePerson)
+            ->andThen(fn () => $this->createPerson($inputData));
+    }
+
+    /**
+     * @return Result<CreateOutputData, UseCaseError>
+     */
+    private function createPerson(CreateInputData $inputData): Result
+    {
+        return $this->transaction->scope(function () use ($inputData): Result {
+            $result = $this->service->prepareForCreate($inputData->name);
+
+            if ($result->isErr()) {
+                return new Err($this->handleError($result->unwrapErr()));
+            }
+
+            $person = $result->unwrap();
+
+            $this->repository->save($person);
+
+            return new Ok(new CreateOutputData($person));
+        });
+    }
+
+    private function handleError(DomainError $error): UseCaseError
+    {
+        return match (true) {
+            $error instanceof DomainValidationError => new InvalidInputError($error->errors),
+            $error instanceof EntityRuleViolationError => new InvalidInputError([$error->field => [$error->message]]),
+            $error instanceof BusinessRuleViolationError => new BusinessLogicError($error->message),
+            default => throw new LogicException('予期しないドメインエラーが発生しました: ' . $error::class),
+        };
+    }
+}

--- a/src/server/packages/Person/Domain/Models/PersonRepositoryInterface.php
+++ b/src/server/packages/Person/Domain/Models/PersonRepositoryInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Person\Domain\Models;
+
+interface PersonRepositoryInterface
+{
+    public function findByName(PersonName $name): ?Person;
+
+    public function save(Person $person): Person;
+
+    public function getMaxOrderNo(): int;
+}

--- a/src/server/packages/Person/Domain/Services/PersonIntegrityService.php
+++ b/src/server/packages/Person/Domain/Services/PersonIntegrityService.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Person\Domain\Services;
+
+use Person\Domain\Models\Person;
+use Person\Domain\Models\PersonId;
+use Person\Domain\Models\PersonName;
+use Person\Domain\Models\PersonRepositoryInterface;
+use ResultType\Err;
+use ResultType\Ok;
+use ResultType\Result;
+use Support\Contracts\Uuid\UuidGeneratorInterface;
+use Support\Domain\Error\BusinessRuleViolationError;
+use Support\Domain\Error\DomainError;
+use Support\Domain\Error\DomainValidationError;
+use Support\Domain\Error\EntityRuleViolationError;
+use Support\Domain\ValueObjects\OrderNo;
+
+class PersonIntegrityService
+{
+    public function __construct(
+        private readonly UuidGeneratorInterface $generator,
+        private readonly PersonRepositoryInterface $repository,
+    ) {
+    }
+
+    /**
+     * @return Result<Person, DomainError>
+     */
+    public function prepareForCreate(string $name): Result
+    {
+        $result = Result::collect3(
+            PersonId::create($this->generator->generate()),
+            PersonName::create($name),
+            OrderNo::create($this->repository->getMaxOrderNo() + 10),
+        )
+            ->mapErr(function (array $errors): DomainValidationError {
+                $messages = [];
+                foreach ($errors as $error) {
+                    if ($error instanceof EntityRuleViolationError) {
+                        $messages[$error->field] ??= [];
+                        $messages[$error->field][] = $error->message;
+                    }
+                }
+
+                return new DomainValidationError($messages);
+            })
+            ->map(fn (array $values): Person => new Person(...$values));
+
+        if ($result->isErr()) {
+            return new Err($result->unwrapErr());
+        }
+
+        $person = $result->unwrap();
+
+        if (! is_null($this->repository->findByName($person->name))) {
+            return new Err(new BusinessRuleViolationError(sprintf('すでに使われている名前です "%s"', $name)));
+        }
+
+        return new Ok($person);
+    }
+}

--- a/src/server/packages/Person/Infrastructures/PersonRepository.php
+++ b/src/server/packages/Person/Infrastructures/PersonRepository.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Person\Infrastructures;
+
+use App\Models\Person\Person as ModelsPerson;
+use Override;
+use Person\Domain\Models\Person;
+use Person\Domain\Models\PersonName;
+use Person\Domain\Models\PersonRepositoryInterface;
+use Support\Contracts\Uuid\UuidConverterInterface;
+
+readonly class PersonRepository implements PersonRepositoryInterface
+{
+    public function __construct(private UuidConverterInterface $converter)
+    {
+    }
+
+    #[Override]
+    public function findByName(PersonName $name): ?Person
+    {
+        $found = ModelsPerson::query()
+            ->where('name', $name->value)
+            ->first();
+
+        if (is_null($found)) {
+            return null;
+        }
+
+        return $this->hydrate($found);
+    }
+
+    #[Override]
+    public function save(Person $person): Person
+    {
+        ModelsPerson::query()->upsert(
+            [
+                ...$person->toArray(),
+                'person_id' => $this->converter->toBin($person->personId->value),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            ['person_id'],
+            [
+                'name',
+                'order_no',
+                'updated_at',
+            ],
+        );
+
+        return $person;
+    }
+
+    #[Override]
+    public function getMaxOrderNo(): int
+    {
+        /** @var int */
+        return ModelsPerson::query()->max('order_no') ?? 0;
+    }
+
+    private function hydrate(ModelsPerson $row): Person
+    {
+        return Person::reconstruct(
+            $this->converter->toUuid($row->person_id),
+            $row->name,
+            $row->order_no,
+        );
+    }
+}

--- a/src/server/packages/Person/Route/PersonRouteMap.php
+++ b/src/server/packages/Person/Route/PersonRouteMap.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Person\Route;
+
+enum PersonRouteMap: string
+{
+    case Create = 'persons.create';
+}

--- a/src/server/routes/admin.php
+++ b/src/server/routes/admin.php
@@ -18,6 +18,7 @@ use App\Http\Controllers\Api\Performer\GetPerformerController;
 use App\Http\Controllers\Api\Performer\ListPerformerController;
 use App\Http\Controllers\Api\Performer\SearchPerformerController;
 use App\Http\Controllers\Api\Performer\UpdatePerformerController;
+use App\Http\Controllers\Api\Person\CreatePersonController;
 use App\Http\Controllers\Api\Song\CreateSongController;
 use App\Http\Controllers\Api\Song\DeleteSongController;
 use App\Http\Controllers\Api\Song\GetSongController;
@@ -37,6 +38,7 @@ use Creator\Route\CreatorRouteMap;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use Performer\Route\PerformerRouteMap;
+use Person\Route\PersonRouteMap;
 use Song\Route\SongRouteMap;
 use Song\Route\SongTypeRouteMap;
 use Song\Route\Tag\SongTagRouteMap;
@@ -65,6 +67,10 @@ Route::middleware(OpenApiValidator::class)->group(function () {
                     Route::delete('/{creatorId}', [DeleteCreatorController::class, 'handle'])->name(CreatorRouteMap::Delete);
                     Route::get('/search', [SearchCreatorController::class, 'handle'])->name(CreatorRouteMap::Search);
                     Route::get('/{creatorId}', [GetCreatorController::class, 'handle'])->name(CreatorRouteMap::Get);
+                });
+
+                Route::prefix('persons')->group(function () {
+                    Route::post('/', [CreatePersonController::class, 'handle'])->name(PersonRouteMap::Create);
                 });
 
                 Route::prefix('performers')->group(function () {

--- a/src/server/tests/Feature/Api/Person/CreatePersonTest.php
+++ b/src/server/tests/Feature/Api/Person/CreatePersonTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\Person;
+
+use Illuminate\Testing\Fluent\AssertableJson;
+use Person\Infrastructures\PersonRepository;
+use Person\Route\PersonRouteMap;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Feature\Api\WithAuth;
+use Tests\Support\DatabaseTestCase;
+use Tests\Support\Domain\EntityFactory;
+
+class CreatePersonTest extends DatabaseTestCase
+{
+    use EntityFactory;
+    use WithAuth;
+
+    #[Test]
+    public function canCreate(): void
+    {
+        $this->withAuth()
+            ->postJson(route(PersonRouteMap::Create), [
+                'name' => 'ヰ世界情緒',
+            ])->assertStatus(200)
+            ->assertJson(
+                fn (AssertableJson $json) => $json
+                    ->has(
+                        'person',
+                        fn (AssertableJson $json) => $json
+                            ->whereType('personId', 'string')
+                            ->where('name', 'ヰ世界情緒')
+                            ->whereType('orderNo', 'integer'),
+                    ),
+            );
+    }
+
+    #[Test]
+    public function createFailsWhenNameAlreadyExists(): void
+    {
+        $this->app->make(PersonRepository::class)->save(
+            $this->createPerson($this->generateUuid(), 'ヰ世界情緒', 10),
+        );
+
+        $this->withAuth()
+            ->postJson(route(PersonRouteMap::Create), [
+                'name' => 'ヰ世界情緒',
+            ])->assertStatus(400)
+            ->assertExactJson([
+                'message' => 'すでに使われている名前です "ヰ世界情緒"',
+            ]);
+    }
+
+    #[Test]
+    public function emptyParameters(): void
+    {
+        $this->withAuth()
+            ->postJson(route(PersonRouteMap::Create), [
+                'name' => '',
+            ])->assertStatus(422)
+            ->assertJson(
+                fn (AssertableJson $json) => $json
+                    ->has(
+                        'errors',
+                        1,
+                        fn (AssertableJson $json) => $json
+                            ->where('field', 'name')
+                            ->whereType('message', 'string'),
+                    ),
+            );
+    }
+}

--- a/src/server/tests/Integration/Person/Application/UseCase/Create/CreateUseCaseTest.php
+++ b/src/server/tests/Integration/Person/Application/UseCase/Create/CreateUseCaseTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Person\Application\UseCase\Create;
+
+use App\Models\Person\Person as ModelsPerson;
+use Person\Application\UseCase\Create\CreateInputData;
+use Person\Application\UseCase\Create\CreateUseCase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Support\DatabaseTestCase;
+
+class CreateUseCaseTest extends DatabaseTestCase
+{
+    #[Test]
+    public function create(): void
+    {
+        $result = $this->getInstance()->handle(new CreateInputData('ヰ世界情緒'));
+
+        $this->assertTrue($result->isOk());
+
+        $persons = ModelsPerson::query()->get();
+        $this->assertCount(1, $persons);
+        $this->assertSame('ヰ世界情緒', $persons->first()->name);
+    }
+
+    private function getInstance(): CreateUseCase
+    {
+        $this->privilegedContext();
+
+        return $this->app->make(CreateUseCase::class);
+    }
+}

--- a/src/server/tests/Integration/Person/Infrastructures/PersonRepositoryTest.php
+++ b/src/server/tests/Integration/Person/Infrastructures/PersonRepositoryTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Person\Infrastructures;
+
+use Person\Infrastructures\PersonRepository;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Support\DatabaseTestCase;
+use Tests\Support\Domain\EntityFactory;
+
+class PersonRepositoryTest extends DatabaseTestCase
+{
+    use EntityFactory;
+
+    #[Test]
+    public function findByName(): void
+    {
+        $repository = $this->getInstance();
+
+        $person = $this->createPerson($this->generateUuid(), 'ヰ世界情緒', 1);
+
+        $repository->save($person);
+
+        $found = $repository->findByName($person->name);
+
+        $this->assertNotNull($found);
+        $this->assertEquals($person, $found);
+    }
+
+    #[Test]
+    public function getMaxOrderNoWhenEmpty(): void
+    {
+        $this->assertSame(0, $this->getInstance()->getMaxOrderNo());
+    }
+
+    private function getInstance(): PersonRepository
+    {
+        return $this->app->make(PersonRepository::class);
+    }
+}

--- a/src/server/tests/Support/Domain/EntityFactory.php
+++ b/src/server/tests/Support/Domain/EntityFactory.php
@@ -21,6 +21,9 @@ use DateTimeImmutable;
 use Performer\Domain\Models\Performer;
 use Performer\Domain\Models\PerformerId;
 use Performer\Domain\Models\PerformerName;
+use Person\Domain\Models\Person;
+use Person\Domain\Models\PersonId;
+use Person\Domain\Models\PersonName;
 use Song\Domain\Models\Creators\Arrangers;
 use Song\Domain\Models\Creators\Composers;
 use Song\Domain\Models\Creators\Lyricists;
@@ -52,6 +55,15 @@ trait EntityFactory
         return new Performer(
             PerformerId::reconstruct($performerId),
             PerformerName::reconstruct($name),
+            OrderNo::reconstruct($orderNo),
+        );
+    }
+
+    protected function createPerson(string $personId, string $name, int $orderNo): Person
+    {
+        return new Person(
+            PersonId::reconstruct($personId),
+            PersonName::reconstruct($name),
             OrderNo::reconstruct($orderNo),
         );
     }


### PR DESCRIPTION
## 概要
- Person の create 用 model、repository、integrity service、use case を追加
- Person create の controller、presenter、provider、route、permission を追加
- feature と integration で create 導線を検証
- CRUD 単位に分割した exec plan を追加

## 確認内容
- docker compose exec php composer dump-autoload
- docker compose exec php php artisan test --env=testing tests/Feature/Api/Person/CreatePersonTest.php
- docker compose exec php php artisan test --env=testing tests/Integration/Person/Application/UseCase/Create/CreateUseCaseTest.php
- docker compose exec php php artisan test --env=testing tests/Integration/Person/Infrastructures/PersonRepositoryTest.php