### PR TITLE
Person read 実装を追加

### DIFF
--- a/docs/exec-plans/active/20260504-person-read.md
+++ b/docs/exec-plans/active/20260504-person-read.md
@@ -4,7 +4,7 @@ Person Read 実装
 
 ## Status
 
-planned
+completed
 
 ## Background
 
@@ -36,10 +36,10 @@ planned
 
 ## Steps
 
-1. `Person` の criteria と list / search / get use case を追加する。
-2. controller / presenter を追加する。
-3. route と provider を read 導線へ拡張する。
-4. feature / integration テストで list / search / get を確認する。
+1. `Person` の criteria と list / search / get use case を追加した。
+2. controller / presenter を追加した。
+3. route と provider を read 導線へ拡張した。
+4. feature / integration テストで list / search / get を確認した。
 
 ## Decision Log
 
@@ -47,6 +47,5 @@ planned
 
 ## Validation
 
-- `docker compose exec php php artisan test --env=testing tests/Feature/Api/Person/ListPersonTest.php`
-- `docker compose exec php php artisan test --env=testing tests/Feature/Api/Person/SearchPersonTest.php`
-- `docker compose exec php php artisan test --env=testing tests/Feature/Api/Person/GetPersonTest.php`
+- `mise run api:ecs app/Http/Controllers/Api/Person app/Http/Presenters/Api/Person app/Providers/Domain/PersonServiceProvider.php packages/Person routes/admin.php tests/Feature/Api/Person tests/Integration/Person tests/Support/Domain/EntityStore.php`
+- `docker compose exec php php artisan test --env=testing tests/Feature/Api/Person/ListPersonTest.php tests/Feature/Api/Person/SearchPersonTest.php tests/Feature/Api/Person/GetPersonTest.php tests/Integration/Person/Application/UseCase/List/ListUseCaseTest.php tests/Integration/Person/Application/UseCase/Search/SearchUseCaseTest.php tests/Integration/Person/Application/UseCase/Get/GetUseCaseTest.php tests/Integration/Person/Infrastructures/PersonRepositoryTest.php`

--- a/src/server/app/Http/Controllers/Api/Person/GetPersonController.php
+++ b/src/server/app/Http/Controllers/Api/Person/GetPersonController.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\Person;
+
+use App\Http\Controllers\Controller;
+use App\Http\Presenters\Api\Person\GetPresenter;
+use Illuminate\Http\JsonResponse;
+use Person\Application\UseCase\Get\GetInputData;
+use Person\Application\UseCase\Get\GetUseCase;
+
+class GetPersonController extends Controller
+{
+    public function __construct(
+        private readonly GetUseCase $useCase,
+        private readonly GetPresenter $presenter,
+    ) {
+    }
+
+    public function handle(string $personId): JsonResponse
+    {
+        return $this->presenter->present($this->useCase->handle(new GetInputData($personId)));
+    }
+}

--- a/src/server/app/Http/Controllers/Api/Person/ListPersonController.php
+++ b/src/server/app/Http/Controllers/Api/Person/ListPersonController.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\Person;
+
+use App\Http\Controllers\Controller;
+use App\Http\Presenters\Api\Person\ListPresenter;
+use Illuminate\Http\JsonResponse;
+use Person\Application\UseCase\List\ListUseCase;
+
+class ListPersonController extends Controller
+{
+    public function __construct(
+        private readonly ListUseCase $useCase,
+        private readonly ListPresenter $presenter,
+    ) {
+    }
+
+    public function handle(): JsonResponse
+    {
+        return $this->presenter->present($this->useCase->handle());
+    }
+}

--- a/src/server/app/Http/Controllers/Api/Person/SearchPersonController.php
+++ b/src/server/app/Http/Controllers/Api/Person/SearchPersonController.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\Person;
+
+use App\Http\Controllers\Controller;
+use App\Http\Presenters\Api\Person\SearchPresenter;
+use Illuminate\Http\JsonResponse;
+use Person\Application\UseCase\Search\SearchInputData;
+use Person\Application\UseCase\Search\SearchUseCase;
+
+class SearchPersonController extends Controller
+{
+    public function __construct(
+        private readonly SearchUseCase $useCase,
+        private readonly SearchPresenter $presenter,
+    ) {
+    }
+
+    public function handle(SearchInputData $inputData): JsonResponse
+    {
+        return $this->presenter->present($this->useCase->handle($inputData));
+    }
+}

--- a/src/server/app/Http/Presenters/Api/Person/GetPresenter.php
+++ b/src/server/app/Http/Presenters/Api/Person/GetPresenter.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Presenters\Api\Person;
+
+use App\Http\Presenters\Api\Support\ResolvesUseCaseError;
+use Illuminate\Http\JsonResponse;
+use OpenAPI\Client\Model\PersonGetResponse;
+use Person\Application\UseCase\Get\GetOutputData;
+use ResultType\Result;
+use Support\UseCase\Error\UseCaseError;
+
+class GetPresenter
+{
+    use ResolvesUseCaseError;
+
+    public function __construct(private readonly Converter $converter)
+    {
+    }
+
+    /**
+     * @param Result<GetOutputData, UseCaseError> $result
+     */
+    public function present(Result $result): JsonResponse
+    {
+        [$data, $status] = $result->match(
+            fn (GetOutputData $outputData) => [
+                new PersonGetResponse()->setPerson($this->converter->toOpenApiPerson($outputData->person)),
+                200,
+            ],
+            fn (UseCaseError $error) => $this->resolveError($error),
+        );
+
+        return response()->json($data, $status);
+    }
+}

--- a/src/server/app/Http/Presenters/Api/Person/ListPresenter.php
+++ b/src/server/app/Http/Presenters/Api/Person/ListPresenter.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Presenters\Api\Person;
+
+use App\Http\Presenters\Api\Support\ResolvesUseCaseError;
+use Illuminate\Http\JsonResponse;
+use OpenAPI\Client\Model\PersonListResponse;
+use Person\Application\UseCase\List\ListOutputData;
+use Person\Domain\Models\Person;
+use ResultType\Result;
+use Support\UseCase\Error\UseCaseError;
+
+class ListPresenter
+{
+    use ResolvesUseCaseError;
+
+    public function __construct(private readonly Converter $converter)
+    {
+    }
+
+    /**
+     * @param Result<ListOutputData, UseCaseError> $result
+     */
+    public function present(Result $result): JsonResponse
+    {
+        [$data, $status] = $result->match(
+            fn (ListOutputData $outputData) => [
+                new PersonListResponse()->setPersons(
+                    array_map(
+                        fn (Person $person) => $this->converter->toOpenApiPerson($person),
+                        $outputData->persons,
+                    ),
+                ),
+                200,
+            ],
+            fn (UseCaseError $error) => $this->resolveError($error),
+        );
+
+        return response()->json($data, $status);
+    }
+}

--- a/src/server/app/Http/Presenters/Api/Person/SearchPresenter.php
+++ b/src/server/app/Http/Presenters/Api/Person/SearchPresenter.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Presenters\Api\Person;
+
+use App\Http\Presenters\Api\Support\ResolvesUseCaseError;
+use Illuminate\Http\JsonResponse;
+use OpenAPI\Client\Model\PersonSearchResponse;
+use Person\Application\UseCase\Search\SearchOutputData;
+use Person\Domain\Models\Person;
+use ResultType\Result;
+use Support\UseCase\Error\UseCaseError;
+
+class SearchPresenter
+{
+    use ResolvesUseCaseError;
+
+    public function __construct(private readonly Converter $converter)
+    {
+    }
+
+    /**
+     * @param Result<SearchOutputData, UseCaseError> $result
+     */
+    public function present(Result $result): JsonResponse
+    {
+        [$data, $status] = $result->match(
+            fn (SearchOutputData $outputData) => [
+                new PersonSearchResponse()->setPersons(
+                    array_map(
+                        fn (Person $person) => $this->converter->toOpenApiPerson($person),
+                        $outputData->persons,
+                    ),
+                )->setMaxPage($outputData->maxPage),
+                200,
+            ],
+            fn (UseCaseError $error) => $this->resolveError($error),
+        );
+
+        return response()->json($data, $status);
+    }
+}

--- a/src/server/app/Providers/Domain/PersonServiceProvider.php
+++ b/src/server/app/Providers/Domain/PersonServiceProvider.php
@@ -7,6 +7,7 @@ namespace App\Providers\Domain;
 use Illuminate\Http\Request;
 use Override;
 use Person\Application\UseCase\Create\CreateInputData;
+use Person\Application\UseCase\Search\SearchInputData;
 use Person\Domain\Models\PersonRepositoryInterface;
 use Person\Infrastructures\PersonRepository;
 
@@ -16,6 +17,12 @@ class PersonServiceProvider extends EnvServiceProvider
     public function register(): void
     {
         $this->app->bind(PersonRepositoryInterface::class, PersonRepository::class);
+
+        $this->app->bind(SearchInputData::class, function (): SearchInputData {
+            $request = $this->app->make(Request::class);
+
+            return $this->getMapper()->map(SearchInputData::class, $request->query());
+        });
 
         $this->app->bind(CreateInputData::class, function (): CreateInputData {
             $request = $this->app->make(Request::class);

--- a/src/server/packages/AdminUser/Domain/Models/Permission.php
+++ b/src/server/packages/AdminUser/Domain/Models/Permission.php
@@ -14,6 +14,8 @@ enum Permission: string
 
     case WriteCreator = 'write_creator';
 
+    case ReadPerson = 'read_person';
+
     case WritePerson = 'write_person';
 
     case ReadPerformer = 'read_performer';
@@ -31,6 +33,7 @@ enum Permission: string
             self::WriteAdminUser => '管理ユーザー編集',
             self::ReadCreator => 'クリエイター閲覧',
             self::WriteCreator => 'クリエイター編集',
+            self::ReadPerson => '人物閲覧',
             self::WritePerson => '人物編集',
             self::ReadPerformer => '共演者閲覧',
             self::WritePerformer => '共演者編集',

--- a/src/server/packages/Person/Application/UseCase/Get/GetInputData.php
+++ b/src/server/packages/Person/Application/UseCase/Get/GetInputData.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Person\Application\UseCase\Get;
+
+readonly class GetInputData
+{
+    public function __construct(public string $personId)
+    {
+    }
+}

--- a/src/server/packages/Person/Application/UseCase/Get/GetOutputData.php
+++ b/src/server/packages/Person/Application/UseCase/Get/GetOutputData.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Person\Application\UseCase\Get;
+
+use Person\Domain\Models\Person;
+
+readonly class GetOutputData
+{
+    public function __construct(public Person $person)
+    {
+    }
+}

--- a/src/server/packages/Person/Application/UseCase/Get/GetUseCase.php
+++ b/src/server/packages/Person/Application/UseCase/Get/GetUseCase.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Person\Application\UseCase\Get;
+
+use AdminUser\Domain\Models\Permission;
+use Person\Domain\Models\PersonId;
+use Person\Domain\Models\PersonRepositoryInterface;
+use ResultType\Err;
+use ResultType\Ok;
+use ResultType\Result;
+use Support\Domain\Error\EntityRuleViolationError;
+use Support\UseCase\Authorizer\UseCaseAuthorizer;
+use Support\UseCase\Error\InvalidInputError;
+use Support\UseCase\Error\NotFoundError;
+use Support\UseCase\Error\UseCaseError;
+
+readonly class GetUseCase
+{
+    public function __construct(
+        private UseCaseAuthorizer $authorizer,
+        private PersonRepositoryInterface $repository,
+    ) {
+    }
+
+    /**
+     * @return Result<GetOutputData, UseCaseError>
+     */
+    public function handle(GetInputData $inputData): Result
+    {
+        return $this->authorizer->require(Permission::ReadPerson)
+            ->andThen(fn () => $this->getPerson($inputData));
+    }
+
+    /**
+     * @return Result<GetOutputData, UseCaseError>
+     */
+    private function getPerson(GetInputData $inputData): Result
+    {
+        return PersonId::create($inputData->personId)
+            ->mapErr(fn (EntityRuleViolationError $e): UseCaseError => new InvalidInputError([$e->field => [$e->message]]))
+            ->andThen(function (PersonId $personId): Result {
+                if (is_null($found = $this->repository->find($personId))) {
+                    return new Err(new NotFoundError('Person', $personId->value));
+                }
+
+                return new Ok(new GetOutputData($found));
+            });
+    }
+}

--- a/src/server/packages/Person/Application/UseCase/List/ListOutputData.php
+++ b/src/server/packages/Person/Application/UseCase/List/ListOutputData.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Person\Application\UseCase\List;
+
+use Person\Domain\Models\Person;
+
+readonly class ListOutputData
+{
+    /**
+     * @param array<Person> $persons
+     */
+    public function __construct(public array $persons)
+    {
+    }
+}

--- a/src/server/packages/Person/Application/UseCase/List/ListUseCase.php
+++ b/src/server/packages/Person/Application/UseCase/List/ListUseCase.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Person\Application\UseCase\List;
+
+use AdminUser\Domain\Models\Permission;
+use Person\Domain\Models\PersonRepositoryInterface;
+use ResultType\Ok;
+use ResultType\Result;
+use Support\UseCase\Authorizer\UseCaseAuthorizer;
+use Support\UseCase\Error\UseCaseError;
+
+readonly class ListUseCase
+{
+    public function __construct(
+        private UseCaseAuthorizer $authorizer,
+        private PersonRepositoryInterface $repository,
+    ) {
+    }
+
+    /**
+     * @return Result<ListOutputData, UseCaseError>
+     */
+    public function handle(): Result
+    {
+        return $this->authorizer->require(Permission::ReadPerson)
+            ->andThen(fn () => new Ok(new ListOutputData($this->repository->all())));
+    }
+}

--- a/src/server/packages/Person/Application/UseCase/Search/SearchInputData.php
+++ b/src/server/packages/Person/Application/UseCase/Search/SearchInputData.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Person\Application\UseCase\Search;
+
+use Person\Domain\Criteria\Sort;
+use Support\Domain\SearchCriteria\Order;
+use Support\Domain\SearchCriteria\PerPage;
+use Support\Optional\Arg;
+
+readonly class SearchInputData
+{
+    public function __construct(
+        public Arg|string $name = Arg::Optional,
+        public Sort $sort = Sort::OrderNo,
+        public Order $order = Order::Asc,
+        public int $page = 1,
+        public PerPage $perPage = PerPage::TwentyFive,
+    ) {
+    }
+}

--- a/src/server/packages/Person/Application/UseCase/Search/SearchOutputData.php
+++ b/src/server/packages/Person/Application/UseCase/Search/SearchOutputData.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Person\Application\UseCase\Search;
+
+use Person\Domain\Models\Person;
+
+readonly class SearchOutputData
+{
+    /**
+     * @param array<Person> $persons
+     */
+    public function __construct(
+        public array $persons,
+        public int $maxPage,
+    ) {
+    }
+}

--- a/src/server/packages/Person/Application/UseCase/Search/SearchUseCase.php
+++ b/src/server/packages/Person/Application/UseCase/Search/SearchUseCase.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Person\Application\UseCase\Search;
+
+use AdminUser\Domain\Models\Permission;
+use Person\Domain\Criteria\PersonSearchCriteria;
+use Person\Domain\Models\PersonRepositoryInterface;
+use ResultType\Ok;
+use ResultType\Result;
+use Support\Optional\Arg;
+use Support\Optional\None;
+use Support\Optional\Some;
+use Support\UseCase\Authorizer\UseCaseAuthorizer;
+use Support\UseCase\Error\UseCaseError;
+
+readonly class SearchUseCase
+{
+    public function __construct(
+        private UseCaseAuthorizer $authorizer,
+        private PersonRepositoryInterface $repository,
+    ) {
+    }
+
+    /**
+     * @return Result<SearchOutputData, UseCaseError>
+     */
+    public function handle(SearchInputData $inputData): Result
+    {
+        return $this->authorizer->require(Permission::ReadPerson)
+            ->andThen(fn () => $this->searchPersons($inputData));
+    }
+
+    /**
+     * @return Result<SearchOutputData, UseCaseError>
+     */
+    private function searchPersons(SearchInputData $inputData): Result
+    {
+        $criteria = new PersonSearchCriteria(
+            $inputData->name === Arg::Optional
+                ? new None()
+                : new Some($inputData->name),
+            $inputData->sort,
+            $inputData->order,
+            $inputData->page,
+            $inputData->perPage,
+        );
+
+        return new Ok(
+            new SearchOutputData(
+                $this->repository->search($criteria),
+                $this->repository->maxPage($criteria),
+            ),
+        );
+    }
+}

--- a/src/server/packages/Person/Domain/Criteria/PersonSearchCriteria.php
+++ b/src/server/packages/Person/Domain/Criteria/PersonSearchCriteria.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Person\Domain\Criteria;
+
+use Support\Domain\SearchCriteria\Order;
+use Support\Domain\SearchCriteria\PerPage;
+use Support\Optional\Optional;
+
+readonly class PersonSearchCriteria
+{
+    /**
+     * @param Optional<string> $name
+     */
+    public function __construct(
+        public Optional $name,
+        public Sort $sort = Sort::OrderNo,
+        public Order $order = Order::Asc,
+        public int $page = 1,
+        public PerPage $perPage = PerPage::Fifty,
+    ) {
+    }
+}

--- a/src/server/packages/Person/Domain/Criteria/Sort.php
+++ b/src/server/packages/Person/Domain/Criteria/Sort.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Person\Domain\Criteria;
+
+enum Sort: string
+{
+    case Name = 'name';
+
+    case OrderNo = 'order_no';
+}

--- a/src/server/packages/Person/Domain/Models/PersonRepositoryInterface.php
+++ b/src/server/packages/Person/Domain/Models/PersonRepositoryInterface.php
@@ -4,8 +4,24 @@ declare(strict_types=1);
 
 namespace Person\Domain\Models;
 
+use Person\Domain\Criteria\PersonSearchCriteria;
+
 interface PersonRepositoryInterface
 {
+    /**
+     * @return array<Person>
+     */
+    public function all(): array;
+
+    /**
+     * @return array<Person>
+     */
+    public function search(PersonSearchCriteria $criteria): array;
+
+    public function maxPage(PersonSearchCriteria $criteria): int;
+
+    public function find(PersonId $personId): ?Person;
+
     public function findByName(PersonName $name): ?Person;
 
     public function save(Person $person): Person;

--- a/src/server/packages/Person/Infrastructures/PersonRepository.php
+++ b/src/server/packages/Person/Infrastructures/PersonRepository.php
@@ -6,15 +6,75 @@ namespace Person\Infrastructures;
 
 use App\Models\Person\Person as ModelsPerson;
 use Override;
+use Person\Domain\Criteria\PersonSearchCriteria;
 use Person\Domain\Models\Person;
+use Person\Domain\Models\PersonId;
 use Person\Domain\Models\PersonName;
 use Person\Domain\Models\PersonRepositoryInterface;
 use Support\Contracts\Uuid\UuidConverterInterface;
+use Support\Infrastructures\Database\SqlHelper;
 
 readonly class PersonRepository implements PersonRepositoryInterface
 {
     public function __construct(private UuidConverterInterface $converter)
     {
+    }
+
+    #[Override]
+    public function all(): array
+    {
+        return ModelsPerson::query()
+            ->orderBy('order_no')
+            ->get()
+            ->map($this->hydrate(...))
+            ->all();
+    }
+
+    #[Override]
+    public function search(PersonSearchCriteria $criteria): array
+    {
+        $query = ModelsPerson::query();
+
+        if ($criteria->name->isPresent()) {
+            $keyword = SqlHelper::escapeLike(mb_strtolower($criteria->name->get()));
+            $query = $query->whereLike('name_lower', $keyword . '%');
+        }
+
+        $offset = ($criteria->page - 1) * $criteria->perPage->value;
+
+        return $query->orderBy($criteria->sort->value, $criteria->order->value)
+            ->limit($criteria->perPage->value)
+            ->offset($offset)
+            ->get()
+            ->map($this->hydrate(...))
+            ->all();
+    }
+
+    #[Override]
+    public function maxPage(PersonSearchCriteria $criteria): int
+    {
+        $query = ModelsPerson::query();
+
+        if ($criteria->name->isPresent()) {
+            $keyword = SqlHelper::escapeLike(mb_strtolower($criteria->name->get()));
+            $query = $query->whereLike('name_lower', $keyword . '%');
+        }
+
+        return (int)ceil($query->count() / $criteria->perPage->value);
+    }
+
+    #[Override]
+    public function find(PersonId $personId): ?Person
+    {
+        $found = ModelsPerson::query()
+            ->where('person_id', $this->converter->toBin($personId->value))
+            ->first();
+
+        if (is_null($found)) {
+            return null;
+        }
+
+        return $this->hydrate($found);
     }
 
     #[Override]

--- a/src/server/packages/Person/Route/PersonRouteMap.php
+++ b/src/server/packages/Person/Route/PersonRouteMap.php
@@ -7,4 +7,10 @@ namespace Person\Route;
 enum PersonRouteMap: string
 {
     case Create = 'persons.create';
+
+    case List = 'persons.list';
+
+    case Search = 'persons.search';
+
+    case Get = 'persons.get';
 }

--- a/src/server/routes/admin.php
+++ b/src/server/routes/admin.php
@@ -19,6 +19,9 @@ use App\Http\Controllers\Api\Performer\ListPerformerController;
 use App\Http\Controllers\Api\Performer\SearchPerformerController;
 use App\Http\Controllers\Api\Performer\UpdatePerformerController;
 use App\Http\Controllers\Api\Person\CreatePersonController;
+use App\Http\Controllers\Api\Person\GetPersonController;
+use App\Http\Controllers\Api\Person\ListPersonController;
+use App\Http\Controllers\Api\Person\SearchPersonController;
 use App\Http\Controllers\Api\Song\CreateSongController;
 use App\Http\Controllers\Api\Song\DeleteSongController;
 use App\Http\Controllers\Api\Song\GetSongController;
@@ -71,6 +74,9 @@ Route::middleware(OpenApiValidator::class)->group(function () {
 
                 Route::prefix('persons')->group(function () {
                     Route::post('/', [CreatePersonController::class, 'handle'])->name(PersonRouteMap::Create);
+                    Route::get('/', [ListPersonController::class, 'handle'])->name(PersonRouteMap::List);
+                    Route::get('/search', [SearchPersonController::class, 'handle'])->name(PersonRouteMap::Search);
+                    Route::get('/{personId}', [GetPersonController::class, 'handle'])->name(PersonRouteMap::Get);
                 });
 
                 Route::prefix('performers')->group(function () {

--- a/src/server/tests/Feature/Api/Person/GetPersonTest.php
+++ b/src/server/tests/Feature/Api/Person/GetPersonTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\Person;
+
+use Person\Route\PersonRouteMap;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Feature\Api\WithAuth;
+use Tests\Support\DatabaseTestCase;
+use Tests\Support\Domain\EntityFactory;
+use Tests\Support\Domain\EntityStore;
+
+class GetPersonTest extends DatabaseTestCase
+{
+    use EntityFactory;
+    use EntityStore;
+    use WithAuth;
+
+    #[Test]
+    public function found(): void
+    {
+        $uuid = $this->generateUuid();
+
+        $this->storePersons($this->createPerson($uuid, 'ヰ世界情緒', 1));
+
+        $this->withAuth()
+            ->get(route(PersonRouteMap::Get, $uuid))
+            ->assertStatus(200)
+            ->assertExactJson([
+                'person' => [
+                    'personId' => $uuid,
+                    'name' => 'ヰ世界情緒',
+                    'orderNo' => 1,
+                ],
+            ]);
+    }
+
+    #[Test]
+    public function notFound(): void
+    {
+        $this->withAuth()
+            ->get(route(PersonRouteMap::Get, $this->generateUuid()))
+            ->assertStatus(404);
+    }
+}

--- a/src/server/tests/Feature/Api/Person/ListPersonTest.php
+++ b/src/server/tests/Feature/Api/Person/ListPersonTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\Person;
+
+use Person\Route\PersonRouteMap;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Feature\Api\WithAuth;
+use Tests\Support\DatabaseTestCase;
+use Tests\Support\Domain\EntityFactory;
+use Tests\Support\Domain\EntityStore;
+
+class ListPersonTest extends DatabaseTestCase
+{
+    use EntityFactory;
+    use EntityStore;
+    use WithAuth;
+
+    #[Test]
+    public function showList(): void
+    {
+        $uuid = $this->generateUuid();
+
+        $this->storePersons($this->createPerson($uuid, 'ヰ世界情緒', 1));
+
+        $this->withAuth()
+            ->get(route(PersonRouteMap::List))
+            ->assertStatus(200)
+            ->assertExactJson([
+                'persons' => [
+                    [
+                        'personId' => $uuid,
+                        'name' => 'ヰ世界情緒',
+                        'orderNo' => 1,
+                    ],
+                ],
+            ]);
+    }
+
+    #[Test]
+    public function showEmptyList(): void
+    {
+        $this->withAuth()
+            ->get(route(PersonRouteMap::List))
+            ->assertStatus(200)
+            ->assertExactJson(['persons' => []]);
+    }
+}

--- a/src/server/tests/Feature/Api/Person/SearchPersonTest.php
+++ b/src/server/tests/Feature/Api/Person/SearchPersonTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\Person;
+
+use Person\Route\PersonRouteMap;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Feature\Api\WithAuth;
+use Tests\Support\DatabaseTestCase;
+use Tests\Support\Domain\EntityFactory;
+use Tests\Support\Domain\EntityStore;
+
+class SearchPersonTest extends DatabaseTestCase
+{
+    use EntityFactory;
+    use EntityStore;
+    use WithAuth;
+
+    #[Test]
+    public function searchAll(): void
+    {
+        $uuid = $this->generateUuid();
+
+        $this->storePersons($this->createPerson($uuid, 'ヰ世界情緒', 1));
+
+        $this->withAuth()
+            ->get(route(PersonRouteMap::Search))
+            ->assertStatus(200)
+            ->assertExactJson([
+                'persons' => [
+                    [
+                        'personId' => $uuid,
+                        'name' => 'ヰ世界情緒',
+                        'orderNo' => 1,
+                    ],
+                ],
+                'maxPage' => 1,
+            ]);
+    }
+
+    #[Test]
+    public function searchByName(): void
+    {
+        $uuid1 = $this->generateUuid();
+        $uuid2 = $this->generateUuid();
+
+        $this->storePersons(
+            $this->createPerson($uuid1, 'ヰ世界情緒', 1),
+            $this->createPerson($uuid2, '香椎モイミ', 2),
+        );
+
+        $this->withAuth()
+            ->get(route(PersonRouteMap::Search, ['name' => 'ヰ世界情緒']))
+            ->assertStatus(200)
+            ->assertExactJson([
+                'persons' => [
+                    [
+                        'personId' => $uuid1,
+                        'name' => 'ヰ世界情緒',
+                        'orderNo' => 1,
+                    ],
+                ],
+                'maxPage' => 1,
+            ]);
+    }
+
+    #[Test]
+    public function searchSortByNameDesc(): void
+    {
+        $uuid1 = $this->generateUuid();
+        $uuid2 = $this->generateUuid();
+
+        $this->storePersons(
+            $this->createPerson($uuid1, 'あ', 1),
+            $this->createPerson($uuid2, 'い', 2),
+        );
+
+        $this->withAuth()
+            ->get(route(PersonRouteMap::Search, ['sort' => 'name', 'order' => 'desc']))
+            ->assertStatus(200)
+            ->assertExactJson([
+                'persons' => [
+                    [
+                        'personId' => $uuid2,
+                        'name' => 'い',
+                        'orderNo' => 2,
+                    ],
+                    [
+                        'personId' => $uuid1,
+                        'name' => 'あ',
+                        'orderNo' => 1,
+                    ],
+                ],
+                'maxPage' => 1,
+            ]);
+    }
+}

--- a/src/server/tests/Integration/Person/Application/UseCase/Get/GetUseCaseTest.php
+++ b/src/server/tests/Integration/Person/Application/UseCase/Get/GetUseCaseTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Person\Application\UseCase\Get;
+
+use Person\Application\UseCase\Get\GetInputData;
+use Person\Application\UseCase\Get\GetUseCase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Support\DatabaseTestCase;
+use Tests\Support\Domain\EntityFactory;
+use Tests\Support\Domain\EntityStore;
+
+class GetUseCaseTest extends DatabaseTestCase
+{
+    use EntityFactory;
+    use EntityStore;
+
+    #[Test]
+    public function getting(): void
+    {
+        $person = $this->createPerson($this->generateUuid(), 'ヰ世界情緒', 1);
+        $this->storePersons($person);
+
+        $result = $this->getInstance()->handle(new GetInputData($person->personId->value));
+
+        $this->assertTrue($result->isOk());
+        $this->assertEquals($person, $result->unwrap()->person);
+    }
+
+    private function getInstance(): GetUseCase
+    {
+        $this->privilegedContext();
+
+        return $this->app->make(GetUseCase::class);
+    }
+}

--- a/src/server/tests/Integration/Person/Application/UseCase/List/ListUseCaseTest.php
+++ b/src/server/tests/Integration/Person/Application/UseCase/List/ListUseCaseTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Person\Application\UseCase\List;
+
+use Person\Application\UseCase\List\ListUseCase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Support\DatabaseTestCase;
+use Tests\Support\Domain\EntityFactory;
+use Tests\Support\Domain\EntityStore;
+
+class ListUseCaseTest extends DatabaseTestCase
+{
+    use EntityFactory;
+    use EntityStore;
+
+    #[Test]
+    public function list(): void
+    {
+        $person = $this->createPerson($this->generateUuid(), 'ヰ世界情緒', 1);
+        $this->storePersons($person);
+
+        $result = $this->getInstance()->handle();
+
+        $this->assertTrue($result->isOk());
+        $this->assertEquals([$person], $result->unwrap()->persons);
+    }
+
+    private function getInstance(): ListUseCase
+    {
+        $this->privilegedContext();
+
+        return $this->app->make(ListUseCase::class);
+    }
+}

--- a/src/server/tests/Integration/Person/Application/UseCase/Search/SearchUseCaseTest.php
+++ b/src/server/tests/Integration/Person/Application/UseCase/Search/SearchUseCaseTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Person\Application\UseCase\Search;
+
+use Person\Application\UseCase\Search\SearchInputData;
+use Person\Application\UseCase\Search\SearchUseCase;
+use Person\Domain\Criteria\Sort;
+use PHPUnit\Framework\Attributes\Test;
+use Support\Domain\SearchCriteria\Order;
+use Tests\Support\DatabaseTestCase;
+use Tests\Support\Domain\EntityFactory;
+use Tests\Support\Domain\EntityStore;
+
+class SearchUseCaseTest extends DatabaseTestCase
+{
+    use EntityFactory;
+    use EntityStore;
+
+    #[Test]
+    public function search(): void
+    {
+        $person = $this->createPerson($this->generateUuid(), 'ヰ世界情緒', 1);
+        $this->storePersons($person, $this->createPerson($this->generateUuid(), '春猿火', 2));
+
+        $result = $this->getInstance()->handle(new SearchInputData(name: 'ヰ世界情緒'));
+
+        $this->assertTrue($result->isOk());
+        $this->assertEquals([$person], $result->unwrap()->persons);
+        $this->assertSame(1, $result->unwrap()->maxPage);
+    }
+
+    #[Test]
+    public function searchSorted(): void
+    {
+        $person1 = $this->createPerson($this->generateUuid(), 'あ', 1);
+        $person2 = $this->createPerson($this->generateUuid(), 'い', 2);
+        $this->storePersons($person1, $person2);
+
+        $result = $this->getInstance()->handle(new SearchInputData(sort: Sort::Name, order: Order::Desc));
+
+        $this->assertTrue($result->isOk());
+        $this->assertEquals([$person2, $person1], $result->unwrap()->persons);
+    }
+
+    private function getInstance(): SearchUseCase
+    {
+        $this->privilegedContext();
+
+        return $this->app->make(SearchUseCase::class);
+    }
+}

--- a/src/server/tests/Integration/Person/Infrastructures/PersonRepositoryTest.php
+++ b/src/server/tests/Integration/Person/Infrastructures/PersonRepositoryTest.php
@@ -4,14 +4,56 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Person\Infrastructures;
 
+use Person\Domain\Criteria\PersonSearchCriteria;
+use Person\Domain\Criteria\Sort;
+use Person\Domain\Models\PersonId;
 use Person\Infrastructures\PersonRepository;
 use PHPUnit\Framework\Attributes\Test;
+use Support\Domain\SearchCriteria\Order;
+use Support\Optional\None;
+use Support\Optional\Some;
 use Tests\Support\DatabaseTestCase;
 use Tests\Support\Domain\EntityFactory;
 
 class PersonRepositoryTest extends DatabaseTestCase
 {
     use EntityFactory;
+
+    #[Test]
+    public function all(): void
+    {
+        $repository = $this->getInstance();
+
+        $person1 = $this->createPerson($this->generateUuid(), 'ヰ世界情緒', 1);
+        $person2 = $this->createPerson($this->generateUuid(), '春猿火', 2);
+
+        $repository->save($person1);
+        $repository->save($person2);
+
+        $this->assertEquals([$person1, $person2], $repository->all());
+    }
+
+    #[Test]
+    public function find(): void
+    {
+        $repository = $this->getInstance();
+
+        $person = $this->createPerson($this->generateUuid(), 'ヰ世界情緒', 1);
+        $repository->save($person);
+
+        $found = $repository->find($person->personId);
+
+        $this->assertNotNull($found);
+        $this->assertEquals($person, $found);
+    }
+
+    #[Test]
+    public function findNotFound(): void
+    {
+        $found = $this->getInstance()->find(PersonId::reconstruct($this->generateUuid()));
+
+        $this->assertNull($found);
+    }
 
     #[Test]
     public function findByName(): void
@@ -26,6 +68,67 @@ class PersonRepositoryTest extends DatabaseTestCase
 
         $this->assertNotNull($found);
         $this->assertEquals($person, $found);
+    }
+
+    #[Test]
+    public function searchWithoutName(): void
+    {
+        $repository = $this->getInstance();
+
+        $person1 = $this->createPerson($this->generateUuid(), 'ヰ世界情緒', 10);
+        $person2 = $this->createPerson($this->generateUuid(), '春猿火', 20);
+
+        $repository->save($person1);
+        $repository->save($person2);
+
+        $persons = $repository->search(new PersonSearchCriteria(new None()));
+
+        $this->assertCount(2, $persons);
+    }
+
+    #[Test]
+    public function searchWithName(): void
+    {
+        $repository = $this->getInstance();
+
+        $person1 = $this->createPerson($this->generateUuid(), 'ヰ世界情緒', 10);
+        $person2 = $this->createPerson($this->generateUuid(), '春猿火', 20);
+
+        $repository->save($person1);
+        $repository->save($person2);
+
+        $persons = $repository->search(new PersonSearchCriteria(new Some('ヰ世界情緒')));
+
+        $this->assertCount(1, $persons);
+        $this->assertEquals($person1, $persons[0]);
+    }
+
+    #[Test]
+    public function searchSortByNameDesc(): void
+    {
+        $repository = $this->getInstance();
+
+        $person1 = $this->createPerson($this->generateUuid(), 'あ', 10);
+        $person2 = $this->createPerson($this->generateUuid(), 'い', 20);
+
+        $repository->save($person1);
+        $repository->save($person2);
+
+        $persons = $repository->search(new PersonSearchCriteria(new None(), Sort::Name, Order::Desc));
+
+        $this->assertCount(2, $persons);
+        $this->assertEquals($person2, $persons[0]);
+        $this->assertEquals($person1, $persons[1]);
+    }
+
+    #[Test]
+    public function maxPage(): void
+    {
+        $repository = $this->getInstance();
+
+        $repository->save($this->createPerson($this->generateUuid(), 'ヰ世界情緒', 10));
+
+        $this->assertSame(1, $repository->maxPage(new PersonSearchCriteria(new None())));
     }
 
     #[Test]

--- a/src/server/tests/Support/Domain/EntityStore.php
+++ b/src/server/tests/Support/Domain/EntityStore.php
@@ -13,6 +13,8 @@ use Creator\Domain\Models\Creator;
 use Creator\Domain\Models\CreatorRepositoryInterface;
 use Performer\Domain\Models\Performer;
 use Performer\Domain\Models\PerformerRepositoryInterface;
+use Person\Domain\Models\Person;
+use Person\Domain\Models\PersonRepositoryInterface;
 use Song\Domain\Models\Song;
 use Song\Domain\Models\SongRepositoryInterface;
 use Song\Domain\Models\Tag\SongTag;
@@ -30,6 +32,12 @@ trait EntityStore
     {
         $repository = $this->makeRepository(PerformerRepositoryInterface::class);
         array_map(fn (Performer $item) => $repository->save($item), $items);
+    }
+
+    protected function storePersons(Person ...$items): void
+    {
+        $repository = $this->makeRepository(PersonRepositoryInterface::class);
+        array_map(fn (Person $item) => $repository->save($item), $items);
     }
 
     protected function storeSongs(Song ...$items): void


### PR DESCRIPTION
## 概要
- Person の list / search / get API を追加
- criteria / repository / use case / route / presenter を read 導線へ拡張
- feature / integration テストを追加し、exec plan を更新

## 確認
- `mise run api:ecs app/Http/Controllers/Api/Person app/Http/Presenters/Api/Person app/Providers/Domain/PersonServiceProvider.php packages/Person routes/admin.php tests/Feature/Api/Person tests/Integration/Person tests/Support/Domain/EntityStore.php`
- `docker compose exec php php artisan test --env=testing tests/Feature/Api/Person/ListPersonTest.php tests/Feature/Api/Person/SearchPersonTest.php tests/Feature/Api/Person/GetPersonTest.php tests/Integration/Person/Application/UseCase/List/ListUseCaseTest.php tests/Integration/Person/Application/UseCase/Search/SearchUseCaseTest.php tests/Integration/Person/Application/UseCase/Get/GetUseCaseTest.php tests/Integration/Person/Infrastructures/PersonRepositoryTest.php`

## スコープ外
- Person update / delete
- admin の /persons 画面追加