### PR TITLE
Person update 実装を追加

### DIFF
--- a/docs/exec-plans/active/20260504-person-update.md
+++ b/docs/exec-plans/active/20260504-person-update.md
@@ -4,7 +4,7 @@ Person Update 実装
 
 ## Status
 
-planned
+completed
 
 ## Background
 
@@ -36,9 +36,9 @@ planned
 
 ## Steps
 
-1. update use case と input / output を追加する。
-2. controller / presenter / provider / route を更新する。
-3. feature / integration テストで update を確認する。
+1. update use case と input / output を追加した。
+2. controller / presenter / provider / route を更新した。
+3. feature / integration テストで update を確認した。
 
 ## Decision Log
 
@@ -46,5 +46,5 @@ planned
 
 ## Validation
 
-- `docker compose exec php php artisan test --env=testing tests/Feature/Api/Person/UpdatePersonTest.php`
-- `docker compose exec php ./vendor/bin/paratest tests/Integration/Person/Application/UseCase/Update`
+- `mise run api:ecs app/Http/Controllers/Api/Person/UpdatePersonController.php app/Http/Presenters/Api/Person/UpdatePresenter.php app/Providers/Domain/PersonServiceProvider.php packages/Person/Application/UseCase/Update packages/Person/Domain/Services/PersonIntegrityService.php packages/Person/Route/PersonRouteMap.php routes/admin.php tests/Feature/Api/Person/UpdatePersonTest.php tests/Integration/Person/Application/UseCase/Update/UpdateUseCaseTest.php`
+- `docker compose exec php php artisan test --env=testing tests/Feature/Api/Person/UpdatePersonTest.php tests/Integration/Person/Application/UseCase/Update/UpdateUseCaseTest.php`

--- a/src/server/app/Http/Controllers/Api/Person/UpdatePersonController.php
+++ b/src/server/app/Http/Controllers/Api/Person/UpdatePersonController.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\Person;
+
+use App\Http\Controllers\Controller;
+use App\Http\Presenters\Api\Person\UpdatePresenter;
+use Illuminate\Http\JsonResponse;
+use Person\Application\UseCase\Update\UpdateInputData;
+use Person\Application\UseCase\Update\UpdateUseCase;
+
+class UpdatePersonController extends Controller
+{
+    public function __construct(
+        private readonly UpdateUseCase $useCase,
+        private readonly UpdatePresenter $presenter,
+    ) {
+    }
+
+    public function handle(UpdateInputData $inputData): JsonResponse
+    {
+        return $this->presenter->present($this->useCase->handle($inputData));
+    }
+}

--- a/src/server/app/Http/Presenters/Api/Person/UpdatePresenter.php
+++ b/src/server/app/Http/Presenters/Api/Person/UpdatePresenter.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Presenters\Api\Person;
+
+use App\Http\Presenters\Api\Support\ResolvesUseCaseError;
+use Illuminate\Http\JsonResponse;
+use OpenAPI\Client\Model\PersonUpdateResponse;
+use Person\Application\UseCase\Update\UpdateOutputData;
+use ResultType\Result;
+use Support\UseCase\Error\UseCaseError;
+
+class UpdatePresenter
+{
+    use ResolvesUseCaseError;
+
+    public function __construct(private readonly Converter $converter)
+    {
+    }
+
+    /**
+     * @param Result<UpdateOutputData, UseCaseError> $result
+     */
+    public function present(Result $result): JsonResponse
+    {
+        [$data, $status] = $result->match(
+            fn (UpdateOutputData $outputData) => [
+                new PersonUpdateResponse()->setPerson($this->converter->toOpenApiPerson($outputData->person)),
+                200,
+            ],
+            fn (UseCaseError $error) => $this->resolveError($error),
+        );
+
+        return response()->json($data, $status);
+    }
+}

--- a/src/server/app/Providers/Domain/PersonServiceProvider.php
+++ b/src/server/app/Providers/Domain/PersonServiceProvider.php
@@ -8,6 +8,7 @@ use Illuminate\Http\Request;
 use Override;
 use Person\Application\UseCase\Create\CreateInputData;
 use Person\Application\UseCase\Search\SearchInputData;
+use Person\Application\UseCase\Update\UpdateInputData;
 use Person\Domain\Models\PersonRepositoryInterface;
 use Person\Infrastructures\PersonRepository;
 
@@ -28,6 +29,18 @@ class PersonServiceProvider extends EnvServiceProvider
             $request = $this->app->make(Request::class);
 
             return $this->getMapper()->map(CreateInputData::class, $request->all());
+        });
+
+        $this->app->bind(UpdateInputData::class, function (): UpdateInputData {
+            $request = $this->app->make(Request::class);
+
+            return $this->getMapper()->map(
+                UpdateInputData::class,
+                [
+                    ...$request->all(),
+                    'personId' => $request->route('personId'),
+                ],
+            );
         });
     }
 }

--- a/src/server/packages/Person/Application/UseCase/Update/UpdateInputData.php
+++ b/src/server/packages/Person/Application/UseCase/Update/UpdateInputData.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Person\Application\UseCase\Update;
+
+readonly class UpdateInputData
+{
+    public function __construct(
+        public string $personId,
+        public string $name,
+        public int $orderNo,
+    ) {
+    }
+}

--- a/src/server/packages/Person/Application/UseCase/Update/UpdateOutputData.php
+++ b/src/server/packages/Person/Application/UseCase/Update/UpdateOutputData.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Person\Application\UseCase\Update;
+
+use Person\Domain\Models\Person;
+
+readonly class UpdateOutputData
+{
+    public function __construct(public Person $person)
+    {
+    }
+}

--- a/src/server/packages/Person/Application/UseCase/Update/UpdateUseCase.php
+++ b/src/server/packages/Person/Application/UseCase/Update/UpdateUseCase.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Person\Application\UseCase\Update;
+
+use AdminUser\Domain\Models\Permission;
+use LogicException;
+use Person\Domain\Models\PersonRepositoryInterface;
+use Person\Domain\Services\PersonIntegrityService;
+use ResultType\Err;
+use ResultType\Ok;
+use ResultType\Result;
+use Support\Contracts\TransactionInterface;
+use Support\Domain\Error\BusinessRuleViolationError;
+use Support\Domain\Error\DomainError;
+use Support\Domain\Error\DomainValidationError;
+use Support\Domain\Error\EntityRuleViolationError;
+use Support\UseCase\Authorizer\UseCaseAuthorizer;
+use Support\UseCase\Error\BusinessLogicError;
+use Support\UseCase\Error\InvalidInputError;
+use Support\UseCase\Error\UseCaseError;
+
+readonly class UpdateUseCase
+{
+    public function __construct(
+        private UseCaseAuthorizer $authorizer,
+        private TransactionInterface $transaction,
+        private PersonRepositoryInterface $repository,
+        private PersonIntegrityService $service,
+    ) {
+    }
+
+    /**
+     * @return Result<UpdateOutputData, UseCaseError>
+     */
+    public function handle(UpdateInputData $inputData): Result
+    {
+        return $this->authorizer->require(Permission::WritePerson)
+            ->andThen(fn () => $this->updatePerson($inputData));
+    }
+
+    /**
+     * @return Result<UpdateOutputData, UseCaseError>
+     */
+    private function updatePerson(UpdateInputData $inputData): Result
+    {
+        return $this->transaction->scope(function () use ($inputData): Result {
+            $result = $this->service->prepareForUpdate($inputData->personId, $inputData->name, $inputData->orderNo);
+
+            if ($result->isErr()) {
+                return new Err($this->handleError($result->unwrapErr()));
+            }
+
+            $person = $result->unwrap();
+
+            $this->repository->save($person);
+
+            return new Ok(new UpdateOutputData($person));
+        });
+    }
+
+    private function handleError(DomainError $error): UseCaseError
+    {
+        return match (true) {
+            $error instanceof DomainValidationError => new InvalidInputError($error->errors),
+            $error instanceof EntityRuleViolationError => new InvalidInputError([$error->field => [$error->message]]),
+            $error instanceof BusinessRuleViolationError => new BusinessLogicError($error->message),
+            default => throw new LogicException('予期しないドメインエラーが発生しました: ' . $error::class),
+        };
+    }
+}

--- a/src/server/packages/Person/Domain/Services/PersonIntegrityService.php
+++ b/src/server/packages/Person/Domain/Services/PersonIntegrityService.php
@@ -31,10 +31,54 @@ class PersonIntegrityService
      */
     public function prepareForCreate(string $name): Result
     {
-        $result = Result::collect3(
-            PersonId::create($this->generator->generate()),
+        $result = $this->build(
+            $this->generator->generate(),
+            $name,
+            $this->repository->getMaxOrderNo() + 10,
+        );
+
+        if ($result->isErr()) {
+            return new Err($result->unwrapErr());
+        }
+
+        $person = $result->unwrap();
+
+        if (! is_null($this->repository->findByName($person->name))) {
+            return new Err(new BusinessRuleViolationError(sprintf('すでに使われている名前です "%s"', $name)));
+        }
+
+        return new Ok($person);
+    }
+
+    /**
+     * @return Result<Person, DomainError>
+     */
+    public function prepareForUpdate(string $personId, string $name, int $orderNo): Result
+    {
+        $result = $this->build($personId, $name, $orderNo);
+
+        if ($result->isErr()) {
+            return new Err($result->unwrapErr());
+        }
+
+        $person = $result->unwrap();
+
+        if (! is_null($found = $this->repository->findByName($person->name)) && ! $found->equals($person)) {
+            return new Err(new BusinessRuleViolationError(sprintf('すでに使われている名前です "%s"', $name)));
+        }
+
+        return new Ok($person);
+    }
+
+    /**
+     * @return Result<Person, DomainError>
+     */
+    private function build(string $personId, string $name, int $orderNo): Result
+    {
+        return Result::collect3(
+            PersonId::create($personId),
             PersonName::create($name),
-            OrderNo::create($this->repository->getMaxOrderNo() + 10),
+            OrderNo::create($orderNo),
         )
             ->mapErr(function (array $errors): DomainValidationError {
                 $messages = [];
@@ -48,17 +92,5 @@ class PersonIntegrityService
                 return new DomainValidationError($messages);
             })
             ->map(fn (array $values): Person => new Person(...$values));
-
-        if ($result->isErr()) {
-            return new Err($result->unwrapErr());
-        }
-
-        $person = $result->unwrap();
-
-        if (! is_null($this->repository->findByName($person->name))) {
-            return new Err(new BusinessRuleViolationError(sprintf('すでに使われている名前です "%s"', $name)));
-        }
-
-        return new Ok($person);
     }
 }

--- a/src/server/packages/Person/Route/PersonRouteMap.php
+++ b/src/server/packages/Person/Route/PersonRouteMap.php
@@ -13,4 +13,6 @@ enum PersonRouteMap: string
     case Search = 'persons.search';
 
     case Get = 'persons.get';
+
+    case Update = 'persons.update';
 }

--- a/src/server/routes/admin.php
+++ b/src/server/routes/admin.php
@@ -22,6 +22,7 @@ use App\Http\Controllers\Api\Person\CreatePersonController;
 use App\Http\Controllers\Api\Person\GetPersonController;
 use App\Http\Controllers\Api\Person\ListPersonController;
 use App\Http\Controllers\Api\Person\SearchPersonController;
+use App\Http\Controllers\Api\Person\UpdatePersonController;
 use App\Http\Controllers\Api\Song\CreateSongController;
 use App\Http\Controllers\Api\Song\DeleteSongController;
 use App\Http\Controllers\Api\Song\GetSongController;
@@ -75,6 +76,7 @@ Route::middleware(OpenApiValidator::class)->group(function () {
                 Route::prefix('persons')->group(function () {
                     Route::post('/', [CreatePersonController::class, 'handle'])->name(PersonRouteMap::Create);
                     Route::get('/', [ListPersonController::class, 'handle'])->name(PersonRouteMap::List);
+                    Route::put('/{personId}', [UpdatePersonController::class, 'handle'])->name(PersonRouteMap::Update);
                     Route::get('/search', [SearchPersonController::class, 'handle'])->name(PersonRouteMap::Search);
                     Route::get('/{personId}', [GetPersonController::class, 'handle'])->name(PersonRouteMap::Get);
                 });

--- a/src/server/tests/Feature/Api/Person/UpdatePersonTest.php
+++ b/src/server/tests/Feature/Api/Person/UpdatePersonTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\Person;
+
+use Illuminate\Testing\Fluent\AssertableJson;
+use Person\Route\PersonRouteMap;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Feature\Api\WithAuth;
+use Tests\Support\DatabaseTestCase;
+use Tests\Support\Domain\EntityFactory;
+use Tests\Support\Domain\EntityStore;
+
+class UpdatePersonTest extends DatabaseTestCase
+{
+    use EntityFactory;
+    use EntityStore;
+    use WithAuth;
+
+    #[Test]
+    public function canUpdate(): void
+    {
+        $uuid = $this->generateUuid();
+
+        $this->storePersons($this->createPerson($uuid, '人物', 10));
+
+        $this->withAuth()
+            ->putJson(route(PersonRouteMap::Update, $uuid), [
+                'name' => 'ヰ世界情緒',
+                'orderNo' => 20,
+            ])->assertStatus(200)
+            ->assertExactJson([
+                'person' => [
+                    'personId' => $uuid,
+                    'name' => 'ヰ世界情緒',
+                    'orderNo' => 20,
+                ],
+            ]);
+    }
+
+    #[Test]
+    public function routePersonIdIsPrioritizedOverBodyPersonId(): void
+    {
+        $routePersonId = $this->generateUuid();
+        $bodyPersonId = $this->generateUuid();
+
+        $this->storePersons($this->createPerson($routePersonId, '人物', 10));
+
+        $this->withAuth()
+            ->putJson(route(PersonRouteMap::Update, $routePersonId), [
+                'personId' => $bodyPersonId,
+                'name' => 'ヰ世界情緒',
+                'orderNo' => 20,
+            ])->assertStatus(200)
+            ->assertExactJson([
+                'person' => [
+                    'personId' => $routePersonId,
+                    'name' => 'ヰ世界情緒',
+                    'orderNo' => 20,
+                ],
+            ]);
+    }
+
+    #[Test]
+    public function updateFailsWhenNameAlreadyExists(): void
+    {
+        $targetId = $this->generateUuid();
+        $otherId = $this->generateUuid();
+
+        $this->storePersons(
+            $this->createPerson($targetId, '人物', 10),
+            $this->createPerson($otherId, 'ヰ世界情緒', 20),
+        );
+
+        $this->withAuth()
+            ->putJson(route(PersonRouteMap::Update, $targetId), [
+                'name' => 'ヰ世界情緒',
+                'orderNo' => 30,
+            ])->assertStatus(400)
+            ->assertExactJson([
+                'message' => 'すでに使われている名前です "ヰ世界情緒"',
+            ]);
+    }
+
+    #[Test]
+    public function emptyParameters(): void
+    {
+        $uuid = $this->generateUuid();
+
+        $this->storePersons($this->createPerson($uuid, '人物', 10));
+
+        $this->withAuth()
+            ->putJson(route(PersonRouteMap::Update, $uuid), [
+                'name' => '',
+                'orderNo' => 0,
+            ])->assertStatus(422)
+            ->assertJson(
+                fn (AssertableJson $json) => $json
+                    ->has(
+                        'errors',
+                        1,
+                        fn (AssertableJson $json) => $json
+                            ->where('field', 'name')
+                            ->whereType('message', 'string'),
+                    ),
+            );
+    }
+}

--- a/src/server/tests/Integration/Person/Application/UseCase/Update/UpdateUseCaseTest.php
+++ b/src/server/tests/Integration/Person/Application/UseCase/Update/UpdateUseCaseTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Person\Application\UseCase\Update;
+
+use Person\Application\UseCase\Update\UpdateInputData;
+use Person\Application\UseCase\Update\UpdateUseCase;
+use Person\Domain\Models\PersonRepositoryInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Support\DatabaseTestCase;
+use Tests\Support\Domain\EntityFactory;
+use Tests\Support\Domain\EntityStore;
+
+class UpdateUseCaseTest extends DatabaseTestCase
+{
+    use EntityFactory;
+    use EntityStore;
+
+    #[Test]
+    public function canUpdate(): void
+    {
+        $personId = $this->generateUuid();
+
+        $this->storePersons($this->createPerson($personId, '人物', 10));
+
+        $result = $this->getInstance()->handle(new UpdateInputData($personId, 'ヰ世界情緒', 20));
+
+        $this->assertTrue($result->isOk());
+
+        $persons = $this->app->make(PersonRepositoryInterface::class)->all();
+        $this->assertCount(1, $persons);
+        $this->assertSame('ヰ世界情緒', array_first($persons)->name->value);
+        $this->assertSame(20, array_first($persons)->orderNo->value);
+    }
+
+    private function getInstance(): UpdateUseCase
+    {
+        $this->privilegedContext();
+
+        return $this->app->make(UpdateUseCase::class);
+    }
+}


### PR DESCRIPTION
## 概要
- Person の update API を追加
- integrity service / use case / provider / route を update 導線へ拡張
- feature / integration テストを追加し、exec plan を更新

## 確認
- `mise run api:ecs app/Http/Controllers/Api/Person/UpdatePersonController.php app/Http/Presenters/Api/Person/UpdatePresenter.php app/Providers/Domain/PersonServiceProvider.php packages/Person/Application/UseCase/Update packages/Person/Domain/Services/PersonIntegrityService.php packages/Person/Route/PersonRouteMap.php routes/admin.php tests/Feature/Api/Person/UpdatePersonTest.php tests/Integration/Person/Application/UseCase/Update/UpdateUseCaseTest.php`
- `docker compose exec php php artisan test --env=testing tests/Feature/Api/Person/UpdatePersonTest.php tests/Integration/Person/Application/UseCase/Update/UpdateUseCaseTest.php`

## スコープ外
- Person delete
- admin の /persons 画面追加