### PR TITLE
Person delete 実装を追加

### DIFF
--- a/docs/exec-plans/active/20260504-person-delete.md
+++ b/docs/exec-plans/active/20260504-person-delete.md
@@ -4,7 +4,7 @@ Person Delete 実装
 
 ## Status
 
-planned
+completed
 
 ## Background
 
@@ -36,9 +36,9 @@ planned
 
 ## Steps
 
-1. delete use case を追加する。
-2. controller / presenter / route を追加する。
-3. feature / integration テストで delete を確認する。
+1. delete use case を追加した。
+2. controller / presenter / route を追加した。
+3. feature / integration テストで delete を確認した。
 
 ## Decision Log
 
@@ -46,5 +46,5 @@ planned
 
 ## Validation
 
-- `docker compose exec php php artisan test --env=testing tests/Feature/Api/Person/DeletePersonTest.php`
-- `docker compose exec php ./vendor/bin/paratest tests/Integration/Person/Application/UseCase/Delete`
+- `mise run api:ecs app/Http/Controllers/Api/Person/DeletePersonController.php app/Http/Presenters/Api/Person/DeletePresenter.php packages/Person/Application/UseCase/Delete packages/Person/Domain/Models/PersonRepositoryInterface.php packages/Person/Infrastructures/PersonRepository.php packages/Person/Route/PersonRouteMap.php routes/admin.php tests/Feature/Api/Person/DeletePersonTest.php tests/Integration/Person/Application/UseCase/Delete/DeleteUseCaseTest.php tests/Integration/Person/Infrastructures/PersonRepositoryTest.php`
+- `docker compose exec php php artisan test --env=testing tests/Feature/Api/Person/DeletePersonTest.php tests/Integration/Person/Application/UseCase/Delete/DeleteUseCaseTest.php tests/Integration/Person/Infrastructures/PersonRepositoryTest.php`

--- a/src/server/app/Http/Controllers/Api/Person/DeletePersonController.php
+++ b/src/server/app/Http/Controllers/Api/Person/DeletePersonController.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\Person;
+
+use App\Http\Controllers\Controller;
+use App\Http\Presenters\Api\Person\DeletePresenter;
+use Illuminate\Http\JsonResponse;
+use Person\Application\UseCase\Delete\DeleteInputData;
+use Person\Application\UseCase\Delete\DeleteUseCase;
+
+class DeletePersonController extends Controller
+{
+    public function __construct(
+        private readonly DeleteUseCase $useCase,
+        private readonly DeletePresenter $presenter,
+    ) {
+    }
+
+    public function handle(string $personId): JsonResponse
+    {
+        return $this->presenter->present($this->useCase->handle(new DeleteInputData($personId)));
+    }
+}

--- a/src/server/app/Http/Presenters/Api/Person/DeletePresenter.php
+++ b/src/server/app/Http/Presenters/Api/Person/DeletePresenter.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Presenters\Api\Person;
+
+use App\Http\Presenters\Api\Support\ResolvesUseCaseError;
+use Illuminate\Http\JsonResponse;
+use ResultType\Result;
+use Support\UseCase\Error\UseCaseError;
+
+class DeletePresenter
+{
+    use ResolvesUseCaseError;
+
+    /**
+     * @param Result<null, UseCaseError> $result
+     */
+    public function present(Result $result): JsonResponse
+    {
+        return $result->match(
+            fn () => response()->json(status: 204),
+            fn (UseCaseError $error) => response()->json(...$this->resolveError($error)),
+        );
+    }
+}

--- a/src/server/packages/Person/Application/UseCase/Delete/DeleteInputData.php
+++ b/src/server/packages/Person/Application/UseCase/Delete/DeleteInputData.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Person\Application\UseCase\Delete;
+
+readonly class DeleteInputData
+{
+    public function __construct(public string $personId)
+    {
+    }
+}

--- a/src/server/packages/Person/Application/UseCase/Delete/DeleteUseCase.php
+++ b/src/server/packages/Person/Application/UseCase/Delete/DeleteUseCase.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Person\Application\UseCase\Delete;
+
+use AdminUser\Domain\Models\Permission;
+use Person\Domain\Models\PersonId;
+use Person\Domain\Models\PersonRepositoryInterface;
+use ResultType\Ok;
+use ResultType\Result;
+use Support\Domain\Error\EntityRuleViolationError;
+use Support\UseCase\Authorizer\UseCaseAuthorizer;
+use Support\UseCase\Error\InvalidInputError;
+use Support\UseCase\Error\UseCaseError;
+
+readonly class DeleteUseCase
+{
+    public function __construct(
+        private UseCaseAuthorizer $authorizer,
+        private PersonRepositoryInterface $repository,
+    ) {
+    }
+
+    /**
+     * @return Result<null, UseCaseError>
+     */
+    public function handle(DeleteInputData $inputData): Result
+    {
+        return $this->authorizer->require(Permission::WritePerson)
+            ->andThen(fn () => $this->deletePerson($inputData));
+    }
+
+    /**
+     * @return Result<null, UseCaseError>
+     */
+    private function deletePerson(DeleteInputData $inputData): Result
+    {
+        return PersonId::create($inputData->personId)
+            ->mapErr(fn (EntityRuleViolationError $e): UseCaseError => new InvalidInputError([$e->field => [$e->message]]))
+            ->andThen(function (PersonId $personId): Result {
+                $this->repository->delete($personId);
+
+                return new Ok(null);
+            });
+    }
+}

--- a/src/server/packages/Person/Domain/Models/PersonRepositoryInterface.php
+++ b/src/server/packages/Person/Domain/Models/PersonRepositoryInterface.php
@@ -26,5 +26,7 @@ interface PersonRepositoryInterface
 
     public function save(Person $person): Person;
 
+    public function delete(PersonId $personId): void;
+
     public function getMaxOrderNo(): int;
 }

--- a/src/server/packages/Person/Infrastructures/PersonRepository.php
+++ b/src/server/packages/Person/Infrastructures/PersonRepository.php
@@ -113,6 +113,12 @@ readonly class PersonRepository implements PersonRepositoryInterface
     }
 
     #[Override]
+    public function delete(PersonId $personId): void
+    {
+        ModelsPerson::query()->where('person_id', $this->converter->toBin($personId->value))->delete();
+    }
+
+    #[Override]
     public function getMaxOrderNo(): int
     {
         /** @var int */

--- a/src/server/packages/Person/Route/PersonRouteMap.php
+++ b/src/server/packages/Person/Route/PersonRouteMap.php
@@ -15,4 +15,6 @@ enum PersonRouteMap: string
     case Get = 'persons.get';
 
     case Update = 'persons.update';
+
+    case Delete = 'persons.delete';
 }

--- a/src/server/routes/admin.php
+++ b/src/server/routes/admin.php
@@ -19,6 +19,7 @@ use App\Http\Controllers\Api\Performer\ListPerformerController;
 use App\Http\Controllers\Api\Performer\SearchPerformerController;
 use App\Http\Controllers\Api\Performer\UpdatePerformerController;
 use App\Http\Controllers\Api\Person\CreatePersonController;
+use App\Http\Controllers\Api\Person\DeletePersonController;
 use App\Http\Controllers\Api\Person\GetPersonController;
 use App\Http\Controllers\Api\Person\ListPersonController;
 use App\Http\Controllers\Api\Person\SearchPersonController;
@@ -77,6 +78,7 @@ Route::middleware(OpenApiValidator::class)->group(function () {
                     Route::post('/', [CreatePersonController::class, 'handle'])->name(PersonRouteMap::Create);
                     Route::get('/', [ListPersonController::class, 'handle'])->name(PersonRouteMap::List);
                     Route::put('/{personId}', [UpdatePersonController::class, 'handle'])->name(PersonRouteMap::Update);
+                    Route::delete('/{personId}', [DeletePersonController::class, 'handle'])->name(PersonRouteMap::Delete);
                     Route::get('/search', [SearchPersonController::class, 'handle'])->name(PersonRouteMap::Search);
                     Route::get('/{personId}', [GetPersonController::class, 'handle'])->name(PersonRouteMap::Get);
                 });

--- a/src/server/tests/Feature/Api/Person/DeletePersonTest.php
+++ b/src/server/tests/Feature/Api/Person/DeletePersonTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\Person;
+
+use Person\Route\PersonRouteMap;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Feature\Api\WithAuth;
+use Tests\Support\DatabaseTestCase;
+use Tests\Support\Domain\EntityFactory;
+use Tests\Support\Domain\EntityStore;
+
+class DeletePersonTest extends DatabaseTestCase
+{
+    use EntityFactory;
+    use EntityStore;
+    use WithAuth;
+
+    #[Test]
+    public function canDelete(): void
+    {
+        $uuid = $this->generateUuid();
+
+        $this->storePersons($this->createPerson($uuid, '人物', 1));
+
+        $this->withAuth()
+            ->delete(route(PersonRouteMap::Delete, $uuid))
+            ->assertStatus(204);
+    }
+
+    #[Test]
+    public function invalidPersonId(): void
+    {
+        $this->withAuth()
+            ->delete(route(PersonRouteMap::Delete, 'invalid-id'))
+            ->assertStatus(422)
+            ->assertExactJson([
+                'errors' => [
+                    [
+                        'field' => '',
+                        'message' => '予期せぬエラー',
+                    ],
+                ],
+            ]);
+    }
+}

--- a/src/server/tests/Integration/Person/Application/UseCase/Delete/DeleteUseCaseTest.php
+++ b/src/server/tests/Integration/Person/Application/UseCase/Delete/DeleteUseCaseTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Person\Application\UseCase\Delete;
+
+use App\Models\Person\Person as ModelsPerson;
+use Person\Application\UseCase\Delete\DeleteInputData;
+use Person\Application\UseCase\Delete\DeleteUseCase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Support\DatabaseTestCase;
+use Tests\Support\Domain\EntityFactory;
+use Tests\Support\Domain\EntityStore;
+
+class DeleteUseCaseTest extends DatabaseTestCase
+{
+    use EntityFactory;
+    use EntityStore;
+
+    #[Test]
+    public function canDelete(): void
+    {
+        $uuid = $this->generateUuid();
+
+        $this->storePersons($this->createPerson($uuid, '人物', 1));
+
+        $result = $this->getInstance()->handle(new DeleteInputData($uuid));
+
+        $this->assertTrue($result->isOk());
+        $this->assertCount(0, ModelsPerson::query()->get()->all());
+    }
+
+    private function getInstance(): DeleteUseCase
+    {
+        $this->privilegedContext();
+
+        return $this->app->make(DeleteUseCase::class);
+    }
+}

--- a/src/server/tests/Integration/Person/Infrastructures/PersonRepositoryTest.php
+++ b/src/server/tests/Integration/Person/Infrastructures/PersonRepositoryTest.php
@@ -71,6 +71,19 @@ class PersonRepositoryTest extends DatabaseTestCase
     }
 
     #[Test]
+    public function deleting(): void
+    {
+        $repository = $this->getInstance();
+
+        $person = $this->createPerson($this->generateUuid(), 'ヰ世界情緒', 1);
+
+        $repository->save($person);
+        $repository->delete($person->personId);
+
+        $this->assertNull($repository->find($person->personId));
+    }
+
+    #[Test]
     public function searchWithoutName(): void
     {
         $repository = $this->getInstance();


### PR DESCRIPTION
## 概要
- Person の delete API を追加
- repository / use case / route を delete 導線へ拡張
- feature / integration テストを追加し、exec plan を更新

## 確認
- `mise run api:ecs app/Http/Controllers/Api/Person/DeletePersonController.php app/Http/Presenters/Api/Person/DeletePresenter.php packages/Person/Application/UseCase/Delete packages/Person/Domain/Models/PersonRepositoryInterface.php packages/Person/Infrastructures/PersonRepository.php packages/Person/Route/PersonRouteMap.php routes/admin.php tests/Feature/Api/Person/DeletePersonTest.php tests/Integration/Person/Application/UseCase/Delete/DeleteUseCaseTest.php tests/Integration/Person/Infrastructures/PersonRepositoryTest.php`
- `docker compose exec php php artisan test --env=testing tests/Feature/Api/Person/DeletePersonTest.php tests/Integration/Person/Application/UseCase/Delete/DeleteUseCaseTest.php tests/Integration/Person/Infrastructures/PersonRepositoryTest.php`

## スコープ外
- song relation を考慮した利用中チェック
- admin の /persons 画面追加