### PR TITLE
Person admin 導線を追加

### DIFF
--- a/docs/exec-plans/active/20260504-person-admin.md
+++ b/docs/exec-plans/active/20260504-person-admin.md
@@ -4,7 +4,7 @@ Person Admin 導線
 
 ## Status
 
-planned
+completed
 
 ## Background
 
@@ -39,11 +39,11 @@ planned
 
 ## Steps
 
-1. `src/admin/src/server/routes/persons.ts` を追加し、server index へ登録する。
-2. `src/admin/src/pages/persons/{index.astro,create/index.astro,[id].astro}` と `src/admin/src/components/person/*` を追加する。
-3. `src/admin/src/server/routes/songs.ts` と `src/admin/src/components/song/{CreateForm,EditableForm}.tsx` を新しい songs 契約へ合わせて更新する。
-4. `src/admin/src/components/Sidebar.tsx` を更新し、`/persons` 導線を追加する。
-5. 生成物追従と型検査を行う。
+1. ✅ `src/admin/src/server/routes/persons.ts` を追加し、server index へ登録した。
+2. ✅ `src/admin/src/pages/persons/{index.astro,create/index.astro,[id].astro}` と `src/admin/src/components/person/*` を追加した。
+3. ✅ `src/admin/src/server/routes/songs.ts` と `src/admin/src/components/song/{CreateForm,EditableForm}.tsx` を新しい songs 契約へ合わせて更新した。
+4. ✅ `src/admin/src/components/Sidebar.tsx` を更新し、`/persons` 導線を追加した。
+5. ✅ 生成物追従と型検査を行った。
 
 ## Decision Log
 

--- a/src/admin/src/components/Sidebar.tsx
+++ b/src/admin/src/components/Sidebar.tsx
@@ -126,6 +126,7 @@ const navSections: NavSection[] = [
   {
     title: '関係者',
     items: [
+      { href: '/persons', label: '人物', icon: UserIcon },
       { href: '/creators', label: 'クリエイター', icon: UserIcon },
       { href: '/performers', label: '共演者', icon: UsersIcon },
     ],

--- a/src/admin/src/components/person/CreateForm.tsx
+++ b/src/admin/src/components/person/CreateForm.tsx
@@ -1,0 +1,60 @@
+import { Show } from 'solid-js';
+import { client } from '../../utils/client';
+import { createFormErrors } from '../../utils/form-error';
+import { createSubmitting } from '../../utils/use-submitting';
+import { setFlash } from '../Flash';
+import { FormError } from '../FormError';
+
+export const CreateForm = () => {
+  const { formError, getFieldError, clearErrors, handleError } = createFormErrors();
+  const { isSubmitting, withSubmitting } = createSubmitting();
+
+  const handleSubmit = withSubmitting(async (e: Event) => {
+    e.preventDefault();
+    clearErrors();
+
+    const form = e.target as HTMLFormElement;
+    const formData = new FormData(form);
+
+    const { data, error, status } = await client.api.persons.post({
+      name: formData.get('name')?.toString() ?? '',
+    });
+
+    if (data) {
+      setFlash('作成しました');
+      window.location.href = '/persons';
+      return;
+    }
+
+    handleError(status, error);
+  });
+
+  return (
+    <form onsubmit={handleSubmit}>
+      <a href="/persons" class="btn btn-ghost btn-sm mb-4">
+        ← 一覧に戻る
+      </a>
+      <FormError message={formError()} onClose={clearErrors} />
+      <div class="max-w-4xl space-y-6">
+        <fieldset class="fieldset bg-base-200 border-base-300 rounded-box border p-6">
+          <legend class="px-2 text-sm font-semibold text-base-content/70">基本情報</legend>
+          <label class="label">人物名</label>
+          <input
+            type="text"
+            class="input w-full"
+            name="name"
+            required
+            classList={{ 'input-error': !!getFieldError('name') }}
+          />
+          <Show when={getFieldError('name')}>{message => <p class="mt-1 text-xs text-error">{message()}</p>}</Show>
+
+          <div class="mt-6 flex justify-end">
+            <button class="btn btn-primary" disabled={isSubmitting()}>
+              {isSubmitting() ? '作成中...' : '作成'}
+            </button>
+          </div>
+        </fieldset>
+      </div>
+    </form>
+  );
+};

--- a/src/admin/src/components/person/EditableForm.tsx
+++ b/src/admin/src/components/person/EditableForm.tsx
@@ -1,0 +1,159 @@
+import { Show, onMount } from 'solid-js';
+import type { Person } from '../../generated';
+import { client } from '../../utils/client';
+import { createFormErrors } from '../../utils/form-error';
+import { createSubmitting } from '../../utils/use-submitting';
+import { setFlash } from '../Flash';
+import { FormError } from '../FormError';
+
+interface Props {
+  data?: { person: Person };
+  status: number;
+}
+
+export const EditableForm = (props: Props) => {
+  const back = new URLSearchParams(window.location.search).get('back') ?? '';
+  const listQuery = (() => {
+    if (!back.startsWith('?')) return '';
+    try {
+      const query = new URLSearchParams(back.slice(1)).toString();
+      return query ? `?${query}` : '';
+    } catch {
+      return '';
+    }
+  })();
+  const listUrl = `/persons${listQuery}`;
+
+  const { formError, setFormError, getFieldError, clearErrors, handleError } = createFormErrors();
+  const { isSubmitting, withSubmitting } = createSubmitting();
+
+  const handleSubmit = async (e: Event) => {
+    e.preventDefault();
+  };
+
+  const handleUpdate = withSubmitting(async (e: Event) => {
+    e.preventDefault();
+    clearErrors();
+
+    const form = (e.target as HTMLButtonElement).form as HTMLFormElement;
+    const formData = new FormData(form);
+
+    const personId = props.data?.person.personId;
+
+    if (!personId) {
+      setFormError('更新対象の人物IDを取得できませんでした');
+      return;
+    }
+
+    const { data, error, status } = await client.api.persons({ personId }).put({
+      name: formData.get('name')?.toString() ?? '',
+      orderNo: Number(formData.get('orderNo')),
+    });
+
+    if (data) {
+      setFlash('更新しました');
+      window.location.href = listUrl;
+      return;
+    }
+
+    if (status === 404) {
+      setFlash('データがありません', 'error');
+      window.location.href = listUrl;
+      return;
+    }
+
+    handleError(status, error);
+  });
+
+  const handleDelete = withSubmitting(async (e: Event) => {
+    e.preventDefault();
+
+    if (!window.confirm('削除します。よろしいですか？')) {
+      return;
+    }
+
+    clearErrors();
+
+    const personId = props.data?.person.personId;
+
+    if (!personId) {
+      setFormError('削除対象の人物IDを取得できませんでした');
+      return;
+    }
+
+    const { error, status } = await client.api.persons({ personId }).delete();
+
+    if (error) {
+      handleError(status, error);
+      return;
+    }
+
+    setFlash('削除しました');
+    window.location.href = listUrl;
+  });
+
+  onMount(() => {
+    if (props.status === 404) {
+      setFlash('データがありません', 'error');
+      window.location.href = listUrl;
+    } else if (props.status === 422) {
+      setFlash('不正なリクエストです', 'error');
+      window.location.href = listUrl;
+    } else if (!props.data) {
+      setFormError('予期しないエラーが発生しました');
+    }
+  });
+
+  return (
+    <Show when={props.data} fallback={<p>読み込み中...</p>}>
+      <a href={listUrl} class="btn btn-ghost btn-sm mb-4">
+        ← 一覧に戻る
+      </a>
+      <FormError message={formError()} onClose={clearErrors} />
+      <div class="max-w-4xl space-y-6">
+        <form onsubmit={handleSubmit}>
+          <fieldset class="fieldset bg-base-200 border-base-300 rounded-box border p-6">
+            <legend class="px-2 text-sm font-semibold text-base-content/70">基本情報</legend>
+            <label class="label">人物名</label>
+            <input
+              type="text"
+              class="input w-full"
+              name="name"
+              value={props.data?.person.name}
+              classList={{ 'input-error': !!getFieldError('name') }}
+            />
+            <Show when={getFieldError('name')}>{message => <p class="mt-1 text-xs text-error">{message()}</p>}</Show>
+
+            <label class="label">表示順</label>
+            <input
+              type="number"
+              class="input w-full"
+              name="orderNo"
+              required
+              min="1"
+              value={props.data?.person.orderNo}
+              classList={{ 'input-error': !!getFieldError('orderNo') }}
+            />
+            <Show when={getFieldError('orderNo')}>{message => <p class="mt-1 text-xs text-error">{message()}</p>}</Show>
+
+            <div class="mt-6 flex justify-end">
+              <button onClick={handleUpdate} class="btn btn-primary" disabled={isSubmitting()}>
+                {isSubmitting() ? '更新中...' : '更新'}
+              </button>
+            </div>
+          </fieldset>
+        </form>
+
+        <fieldset class="rounded-box border border-error/20 bg-error/5 p-6">
+          <legend class="px-2 text-sm font-semibold text-error">危険な操作</legend>
+          <p class="mt-1 text-sm text-base-content/60">この操作は取り消せません。</p>
+          <div class="mt-4">
+            <button onClick={handleDelete} class="btn btn-outline btn-error btn-sm" disabled={isSubmitting()}>
+              {isSubmitting() ? '削除中...' : 'この人物を削除する'}
+            </button>
+          </div>
+        </fieldset>
+      </div>
+    </Show>
+  );
+};

--- a/src/admin/src/components/person/SearchList.tsx
+++ b/src/admin/src/components/person/SearchList.tsx
@@ -1,0 +1,255 @@
+import { For, Match, Show, Switch, createResource, createSignal } from 'solid-js';
+import type { PersonSearchSortBy, SortOrder } from '../../generated';
+import { client } from '../../utils/client';
+import { ListState } from '../ListState';
+
+const PER_PAGE_OPTIONS = [25, 50, 100] as const;
+type PerPage = (typeof PER_PAGE_OPTIONS)[number];
+
+const DEFAULT_PARAMS = {
+  name: '',
+  sort: 'order_no' as PersonSearchSortBy,
+  order: 'asc' as SortOrder,
+  page: 1,
+  perPage: 25 as PerPage,
+};
+
+const getInitialParams = () => {
+  const params = new URLSearchParams(window.location.search);
+  const perPageRaw = Number(params.get('per_page'));
+
+  return {
+    name: params.get('name') ?? DEFAULT_PARAMS.name,
+    sort: (params.get('sort') ?? DEFAULT_PARAMS.sort) as PersonSearchSortBy,
+    order: (params.get('order') ?? DEFAULT_PARAMS.order) as SortOrder,
+    page: Number(params.get('page') ?? String(DEFAULT_PARAMS.page)) || DEFAULT_PARAMS.page,
+    perPage: (PER_PAGE_OPTIONS.includes(perPageRaw as PerPage) ? perPageRaw : DEFAULT_PARAMS.perPage) as PerPage,
+  };
+};
+
+export const SearchList = () => {
+  const initial = getInitialParams();
+
+  const [name, setName] = createSignal(initial.name);
+  const [sort, setSort] = createSignal(initial.sort);
+  const [order, setOrder] = createSignal(initial.order);
+  const [page, setPage] = createSignal(initial.page);
+  const [perPage, setPerPage] = createSignal<PerPage>(initial.perPage);
+
+  const [inputName, setInputName] = createSignal(initial.name);
+  const [inputSort, setInputSort] = createSignal(initial.sort);
+  const [inputOrder, setInputOrder] = createSignal(initial.order);
+  const [inputPerPage, setInputPerPage] = createSignal<PerPage>(initial.perPage);
+
+  const updateUrl = (params: { name: string; sort: PersonSearchSortBy; order: SortOrder; page: number; perPage: number }) => {
+    const searchParams = new URLSearchParams();
+    if (params.name) searchParams.set('name', params.name);
+    if (params.sort) searchParams.set('sort', params.sort);
+    if (params.order) searchParams.set('order', params.order);
+    searchParams.set('page', String(params.page));
+    searchParams.set('per_page', String(params.perPage));
+    history.pushState(null, '', `?${searchParams.toString()}`);
+  };
+
+  const [fetchError, setFetchError] = createSignal<string | null>(null);
+
+  const [data, { refetch }] = createResource(
+    () => ({ name: name(), sort: sort(), order: order(), page: page(), perPage: perPage() }),
+    async (params) => {
+      setFetchError(null);
+
+      const { data, status } = await client.api.persons.search.get({
+        query: {
+          name: params.name,
+          sort: params.sort,
+          order: params.order,
+          page: params.page,
+          per_page: params.perPage,
+        },
+      });
+
+      if (status === 401) {
+        window.location.href = '/auth/login';
+        return;
+      }
+
+      if (!data) {
+        setFetchError('データの取得に失敗しました。再度お試しください。');
+        return;
+      }
+
+      return data;
+    },
+  );
+
+  const handleSearch = (e: Event) => {
+    e.preventDefault();
+
+    const newPage = 1;
+
+    setName(inputName());
+    setSort(inputSort());
+    setOrder(inputOrder());
+    setPerPage(inputPerPage());
+    setPage(newPage);
+    updateUrl({ name: inputName(), sort: inputSort(), order: inputOrder(), page: newPage, perPage: inputPerPage() });
+  };
+
+  const handlePageChange = (nextPage: number) => {
+    setPage(nextPage);
+    updateUrl({ name: name(), sort: sort(), order: order(), page: nextPage, perPage: perPage() });
+  };
+
+  const handleReset = () => {
+    setInputName(DEFAULT_PARAMS.name);
+    setInputSort(DEFAULT_PARAMS.sort);
+    setInputOrder(DEFAULT_PARAMS.order);
+    setInputPerPage(DEFAULT_PARAMS.perPage);
+
+    setName(DEFAULT_PARAMS.name);
+    setSort(DEFAULT_PARAMS.sort);
+    setOrder(DEFAULT_PARAMS.order);
+    setPage(DEFAULT_PARAMS.page);
+    setPerPage(DEFAULT_PARAMS.perPage);
+
+    updateUrl(DEFAULT_PARAMS);
+  };
+
+  return (
+    <>
+      <form onSubmit={handleSearch} class="mb-4 flex flex-wrap items-end gap-4">
+        <fieldset class="fieldset">
+          <label class="fieldset-label" for="name">
+            人物名
+          </label>
+          <input
+            type="text"
+            id="name"
+            name="name"
+            value={inputName()}
+            onInput={e => setInputName(e.currentTarget.value)}
+            class="input input-bordered input-sm"
+            placeholder="人物名で検索"
+          />
+        </fieldset>
+        <fieldset class="fieldset">
+          <label class="fieldset-label" for="sort">
+            ソート項目
+          </label>
+          <select
+            id="sort"
+            name="sort"
+            class="select select-bordered select-sm"
+            onChange={e => setInputSort(e.currentTarget.value as PersonSearchSortBy)}
+          >
+            <option value="order_no" selected={inputSort() === 'order_no'}>
+              表示順
+            </option>
+            <option value="name" selected={inputSort() === 'name'}>
+              人物名
+            </option>
+          </select>
+        </fieldset>
+        <fieldset class="fieldset">
+          <label class="fieldset-label" for="order">
+            並び順
+          </label>
+          <select
+            id="order"
+            name="order"
+            class="select select-bordered select-sm"
+            onChange={e => setInputOrder(e.currentTarget.value as SortOrder)}
+          >
+            <option value="asc" selected={inputOrder() === 'asc'}>
+              昇順
+            </option>
+            <option value="desc" selected={inputOrder() === 'desc'}>
+              降順
+            </option>
+          </select>
+        </fieldset>
+        <fieldset class="fieldset">
+          <label class="fieldset-label" for="perPage">
+            表示件数
+          </label>
+          <select
+            id="perPage"
+            name="perPage"
+            class="select select-bordered select-sm"
+            onChange={e => setInputPerPage(Number(e.currentTarget.value) as PerPage)}
+          >
+            <For each={PER_PAGE_OPTIONS}>{n => <option value={n} selected={inputPerPage() === n}>{n}件</option>}</For>
+          </select>
+        </fieldset>
+        <button type="submit" class="btn btn-primary btn-sm mb-1">
+          検索
+        </button>
+        <button type="button" class="btn btn-ghost btn-sm mb-1" onClick={handleReset}>
+          リセット
+        </button>
+      </form>
+      <div class="mb-4 flex justify-end">
+        <a href="/persons/create" class="btn btn-primary btn-sm">
+          新規作成
+        </a>
+      </div>
+      <div class="overflow-x-auto rounded-box border border-base-300 bg-base-100">
+        <table class="table table-zebra">
+          <thead>
+            <tr>
+              <th>人物名</th>
+              <th>表示順</th>
+              <th>操作</th>
+            </tr>
+          </thead>
+          <tbody>
+            <Switch>
+              <Match when={data.loading}>
+                <ListState state="loading" colSpan={3} />
+              </Match>
+              <Match when={fetchError()}>
+                {message => <ListState state="error" colSpan={3} message={message()} onRetry={() => refetch()} />}
+              </Match>
+              <Match when={data() && data()!.persons.length === 0}>
+                <ListState state="empty" colSpan={3} />
+              </Match>
+              <Match when={data()}>
+                {result => (
+                  <For each={result().persons}>
+                    {person => (
+                      <tr class="transition-colors hover:bg-primary/30 focus-within:bg-primary/30">
+                        <td>{person.name}</td>
+                        <td>{person.orderNo}</td>
+                        <td>
+                          <a href={`/persons/${person.personId}?back=${encodeURIComponent(window.location.search)}`} class="btn btn-ghost btn-xs">
+                            編集
+                          </a>
+                        </td>
+                      </tr>
+                    )}
+                  </For>
+                )}
+              </Match>
+            </Switch>
+          </tbody>
+        </table>
+      </div>
+      <Show when={!data.loading && !fetchError() && (data()?.maxPage ?? 0) > 1}>
+        <div class="mt-4 flex justify-center">
+          <div class="join">
+            <For each={Array.from({ length: data()!.maxPage }, (_, index) => index + 1)}>
+              {p => (
+                <button
+                  class={`join-item btn btn-sm${p === page() ? ' btn-active' : ''}`}
+                  onClick={() => handlePageChange(p)}
+                >
+                  {p}
+                </button>
+              )}
+            </For>
+          </div>
+        </div>
+      </Show>
+    </>
+  );
+};

--- a/src/admin/src/components/song/CreateForm.tsx
+++ b/src/admin/src/components/song/CreateForm.tsx
@@ -1,5 +1,5 @@
 import { createSignal, For, onMount, Show } from 'solid-js';
-import type { Creator, SongTag, SongType, SongTypeValue } from '../../generated';
+import type { Person, RequestSongPerson, SongPersonRole, SongTag, SongType, SongTypeValue } from '../../generated';
 import { client } from '../../utils/client';
 import { createFormErrors } from '../../utils/form-error';
 import { createSubmitting } from '../../utils/use-submitting';
@@ -7,8 +7,10 @@ import { setFlash } from '../Flash';
 import { FormError } from '../FormError';
 import { SearchableSelect } from '../SearchableSelect';
 
-type CreatorEntry = {
-  creatorId: string;
+type PersonEntry = {
+  personId: string;
+  role: SongPersonRole;
+  orderNo: number;
 };
 
 type SongTagEntry = {
@@ -16,13 +18,13 @@ type SongTagEntry = {
 };
 
 export const CreateForm = () => {
-  const [creators, setCreators] = createSignal<Creator[]>([]);
+  const [persons, setPersons] = createSignal<Person[]>([]);
   const [types, setTypes] = createSignal<SongType[]>([]);
   const [availableTags, setAvailableTags] = createSignal<SongTag[]>([]);
 
-  const [lyricists, setLyricists] = createSignal<CreatorEntry[]>([]);
-  const [composers, setComposers] = createSignal<CreatorEntry[]>([]);
-  const [arrangers, setArrangers] = createSignal<CreatorEntry[]>([]);
+  const [lyricists, setLyricists] = createSignal<PersonEntry[]>([]);
+  const [composers, setComposers] = createSignal<PersonEntry[]>([]);
+  const [arrangers, setArrangers] = createSignal<PersonEntry[]>([]);
   const [tags, setTags] = createSignal<SongTagEntry[]>([]);
   const [tagPickerValue, setTagPickerValue] = createSignal('');
 
@@ -38,21 +40,23 @@ export const CreateForm = () => {
   onMount(async () => {
     const { data } = await client.api.songs['create-form'].get();
     if (data) {
-      setCreators(data.creators);
+      setPersons(data.persons);
       setTypes(data.types);
       setAvailableTags(data.tags);
     }
   });
 
-  const addEntry = (setter: typeof setArrangers) => {
-    setter(prev => [...prev, { creatorId: '' }]);
+  const addEntry = (setter: typeof setLyricists, role: SongPersonRole) => {
+    setter(prev => [...prev, { personId: '', role, orderNo: prev.length + 1 }]);
   };
 
-  const removeEntry = (setter: typeof setArrangers, index: number) => {
-    setter(prev => prev.filter((_, i) => i !== index));
+  const removeEntry = (setter: typeof setLyricists, index: number) => {
+    setter(prev =>
+      prev.filter((_, i) => i !== index).map((entry, i) => ({ ...entry, orderNo: i + 1 })),
+    );
   };
 
-  const updateEntry = (setter: typeof setArrangers, index: number, field: keyof CreatorEntry, value: string) => {
+  const updateEntry = (setter: typeof setLyricists, index: number, field: keyof PersonEntry, value: string | number) => {
     setter(prev => prev.map((entry, i) => (i === index ? { ...entry, [field]: value } : entry)));
   };
 
@@ -69,6 +73,8 @@ export const CreateForm = () => {
     setTagPickerValue('');
   };
 
+  const buildPersons = (): RequestSongPerson[] => [...lyricists(), ...composers(), ...arrangers()];
+
   const handleSubmit = withSubmitting(async (e: Event) => {
     e.preventDefault();
     clearErrors();
@@ -82,9 +88,7 @@ export const CreateForm = () => {
       lyricsLink: normalizeOptionalString(formData.get('lyricsLink')),
       typeValue: Number(formData.get('typeValue')) as SongTypeValue,
       isDisplay: formData.get('isDisplay') === 'true',
-      arrangers: arrangers(),
-      composers: composers(),
-      lyricists: lyricists(),
+      persons: buildPersons(),
       tags: tags(),
     });
 
@@ -97,14 +101,16 @@ export const CreateForm = () => {
     handleError(status, error);
   });
 
-  const creatorOptions = (entries: CreatorEntry[], currentIndex: number) => {
-    const selectedCreatorIds = new Set(
-      entries.filter((entry, index) => index !== currentIndex && entry.creatorId !== '').map(entry => entry.creatorId),
+  const personOptions = (entries: PersonEntry[], currentPersonId: string) => {
+    const selectedPersonIds = new Set(
+      entries
+        .filter(entry => entry.personId !== '' && entry.personId !== currentPersonId)
+        .map(entry => entry.personId),
     );
 
-    return creators()
-      .filter(creator => !selectedCreatorIds.has(creator.creatorId) || creator.creatorId === entries[currentIndex]?.creatorId)
-      .map(creator => ({ value: creator.creatorId, label: creator.name }));
+    return persons()
+      .filter(person => !selectedPersonIds.has(person.personId) || person.personId === currentPersonId)
+      .map(person => ({ value: person.personId, label: person.name }));
   };
 
   const tagOptions = () => {
@@ -120,24 +126,35 @@ export const CreateForm = () => {
       .map(entry => availableTags().find(tag => tag.songTagId === entry.songTagId))
       .filter((tag): tag is SongTag => tag !== undefined);
 
-  const CreatorList = (props: { label: string; entries: () => CreatorEntry[]; setter: typeof setArrangers }) => (
+  const PersonSection = (props: { label: string; entries: () => PersonEntry[]; setter: typeof setLyricists; role: SongPersonRole }) => (
     <div class="mt-4">
       <div class="flex items-center gap-2">
         <span class="label">{props.label}</span>
-        <button type="button" class="btn btn-xs btn-outline" onclick={() => addEntry(props.setter)}>
+        <button type="button" class="btn btn-xs btn-outline" onclick={() => addEntry(props.setter, props.role)}>
           + 追加
         </button>
       </div>
       <For each={props.entries()}>
         {(entry, index) => (
-          <div class="mt-2 flex items-center gap-3">
+          <div class="mt-2 grid gap-3 md:grid-cols-[minmax(0,2fr)_96px_40px] md:items-center">
             <SearchableSelect
-              options={creatorOptions(props.entries(), index())}
-              value={entry.creatorId}
-              onChange={value => updateEntry(props.setter, index(), 'creatorId', value)}
-              placeholder="クリエイターを検索..."
+              options={personOptions(props.entries(), entry.personId)}
+              value={entry.personId}
+              onChange={value => updateEntry(props.setter, index(), 'personId', value)}
+              placeholder="人物を検索..."
               required
             />
+            <div class="flex items-center gap-2">
+              <label class="text-xs text-base-content/60">順</label>
+              <input
+                type="number"
+                class="input input-bordered w-16"
+                value={entry.orderNo}
+                onchange={e => updateEntry(props.setter, index(), 'orderNo', Number(e.currentTarget.value))}
+                required
+                min="1"
+              />
+            </div>
             <button
               type="button"
               class="btn btn-ghost btn-xs btn-square text-error"
@@ -161,6 +178,9 @@ export const CreateForm = () => {
           </div>
         )}
       </For>
+      <Show when={props.entries().length === 0}>
+        <p class="mt-3 text-sm text-base-content/60">{props.label}はまだ追加されていません。</p>
+      </Show>
     </div>
   );
 
@@ -282,9 +302,9 @@ export const CreateForm = () => {
 
         <fieldset class="fieldset bg-base-200 border-base-300 rounded-box border p-6">
           <legend class="px-2 text-sm font-semibold text-base-content/70">関係者</legend>
-          <CreatorList label="作詞者" entries={lyricists} setter={setLyricists} />
-          <CreatorList label="作曲者" entries={composers} setter={setComposers} />
-          <CreatorList label="編曲者" entries={arrangers} setter={setArrangers} />
+          <PersonSection label="作詞" entries={lyricists} setter={setLyricists} role={1} />
+          <PersonSection label="作曲" entries={composers} setter={setComposers} role={2} />
+          <PersonSection label="編曲" entries={arrangers} setter={setArrangers} role={3} />
         </fieldset>
 
         <div class="flex justify-end">

--- a/src/admin/src/components/song/EditableForm.tsx
+++ b/src/admin/src/components/song/EditableForm.tsx
@@ -1,5 +1,5 @@
 import { createEffect, createSignal, For, Show } from 'solid-js';
-import type { Arranger, Creator, Song, SongTag, SongType, SongTypeValue } from '../../generated';
+import type { Person, RequestSongPerson, Song, SongPerson, SongPersonRole, SongTag, SongType, SongTypeValue } from '../../generated';
 import { client } from '../../utils/client';
 import { createFormErrors } from '../../utils/form-error';
 import { createSubmitting } from '../../utils/use-submitting';
@@ -7,8 +7,9 @@ import { setFlash } from '../Flash';
 import { FormError } from '../FormError';
 import { SearchableSelect } from '../SearchableSelect';
 
-type CreatorEntry = {
-  creatorId: string;
+type PersonEntry = {
+  personId: string;
+  role: SongPersonRole;
   orderNo: number;
 };
 
@@ -17,7 +18,7 @@ type SongTagEntry = {
 };
 
 interface Props {
-  data?: { song: Song; creators: Creator[]; types: SongType[]; tags: SongTag[] };
+  data?: { song: Song; persons: Person[]; types: SongType[]; tags: SongTag[] };
   status: number;
 }
 
@@ -34,16 +35,17 @@ export const EditableForm = (props: Props) => {
   })();
   const listUrl = `/songs${listQuery}`;
 
-  const creators = props.data?.creators ?? [];
+  const persons = props.data?.persons ?? [];
   const types = props.data?.types ?? [];
   const availableTags = props.data?.tags ?? [];
 
-  const toEntries = (items: Arranger[] | undefined): CreatorEntry[] =>
-    (items ?? []).map(item => ({ creatorId: item.creatorId, orderNo: item.orderNo }));
+  const toEntries = (items: SongPerson[] | undefined): PersonEntry[] =>
+    (items ?? []).map(item => ({ personId: item.personId, role: item.role, orderNo: item.orderNo }));
 
-  const [lyricists, setLyricists] = createSignal<CreatorEntry[]>(toEntries(props.data?.song.lyricists));
-  const [composers, setComposers] = createSignal<CreatorEntry[]>(toEntries(props.data?.song.composers));
-  const [arrangers, setArrangers] = createSignal<CreatorEntry[]>(toEntries(props.data?.song.arrangers));
+  const initialEntries = toEntries(props.data?.song.persons);
+  const [lyricists, setLyricists] = createSignal<PersonEntry[]>(initialEntries.filter(entry => entry.role === 1));
+  const [composers, setComposers] = createSignal<PersonEntry[]>(initialEntries.filter(entry => entry.role === 2));
+  const [arrangers, setArrangers] = createSignal<PersonEntry[]>(initialEntries.filter(entry => entry.role === 3));
   const [tags, setTags] = createSignal<SongTagEntry[]>(
     (props.data?.song.tags ?? []).map(tag => ({ songTagId: tag.songTagId })),
   );
@@ -68,20 +70,17 @@ export const EditableForm = (props: Props) => {
     }
   });
 
-  const addEntry = (setter: typeof setArrangers) => {
-    setter(prev => [...prev, { creatorId: '', orderNo: prev.length + 1 }]);
+  const addEntry = (setter: typeof setLyricists, role: SongPersonRole) => {
+    setter(prev => [...prev, { personId: '', role, orderNo: prev.length + 1 }]);
   };
 
-  const removeEntry = (setter: typeof setArrangers, index: number) => {
-    setter(prev => prev.filter((_, i) => i !== index));
+  const removeEntry = (setter: typeof setLyricists, index: number) => {
+    setter(prev =>
+      prev.filter((_, i) => i !== index).map((entry, i) => ({ ...entry, orderNo: i + 1 })),
+    );
   };
 
-  const updateEntry = (
-    setter: typeof setArrangers,
-    index: number,
-    field: keyof CreatorEntry,
-    value: string | number,
-  ) => {
+  const updateEntry = (setter: typeof setLyricists, index: number, field: keyof PersonEntry, value: string | number) => {
     setter(prev => prev.map((entry, i) => (i === index ? { ...entry, [field]: value } : entry)));
   };
 
@@ -97,6 +96,8 @@ export const EditableForm = (props: Props) => {
     setTags(prev => (prev.some(entry => entry.songTagId === songTagId) ? prev : [...prev, { songTagId }]));
     setTagPickerValue('');
   };
+
+  const buildPersons = (): RequestSongPerson[] => [...lyricists(), ...composers(), ...arrangers()];
 
   const handleSubmit = async (e: Event) => {
     e.preventDefault();
@@ -148,9 +149,7 @@ export const EditableForm = (props: Props) => {
       typeValue: Number(formData.get('typeValue')) as SongTypeValue,
       isDisplay: formData.get('isDisplay') === 'true',
       orderNo: Number(formData.get('orderNo')),
-      arrangers: arrangers(),
-      composers: composers(),
-      lyricists: lyricists(),
+      persons: buildPersons(),
       tags: tags(),
     });
 
@@ -169,14 +168,16 @@ export const EditableForm = (props: Props) => {
     handleError(status, error);
   });
 
-  const creatorOptions = (entries: CreatorEntry[], currentIndex: number) => {
-    const selectedCreatorIds = new Set(
-      entries.filter((entry, index) => index !== currentIndex && entry.creatorId !== '').map(entry => entry.creatorId),
+  const personOptions = (entries: PersonEntry[], currentPersonId: string) => {
+    const selectedPersonIds = new Set(
+      entries
+        .filter(entry => entry.personId !== '' && entry.personId !== currentPersonId)
+        .map(entry => entry.personId),
     );
 
-    return creators
-      .filter(creator => !selectedCreatorIds.has(creator.creatorId) || creator.creatorId === entries[currentIndex]?.creatorId)
-      .map(creator => ({ value: creator.creatorId, label: creator.name }));
+    return persons
+      .filter(person => !selectedPersonIds.has(person.personId) || person.personId === currentPersonId)
+      .map(person => ({ value: person.personId, label: person.name }));
   };
 
   const tagOptions = () => {
@@ -192,22 +193,22 @@ export const EditableForm = (props: Props) => {
       .map(entry => availableTags.find(tag => tag.songTagId === entry.songTagId))
       .filter((tag): tag is SongTag => tag !== undefined);
 
-  const CreatorList = (listProps: { label: string; entries: () => CreatorEntry[]; setter: typeof setArrangers }) => (
+  const PersonSection = (props: { label: string; entries: () => PersonEntry[]; setter: typeof setLyricists; role: SongPersonRole }) => (
     <div class="mt-4">
       <div class="flex items-center gap-2">
-        <span class="label">{listProps.label}</span>
-        <button type="button" class="btn btn-xs btn-outline" onclick={() => addEntry(listProps.setter)}>
+        <span class="label">{props.label}</span>
+        <button type="button" class="btn btn-xs btn-outline" onclick={() => addEntry(props.setter, props.role)}>
           + 追加
         </button>
       </div>
-      <For each={listProps.entries()}>
+      <For each={props.entries()}>
         {(entry, index) => (
-          <div class="mt-2 flex items-center gap-3">
+          <div class="mt-2 grid gap-3 md:grid-cols-[minmax(0,2fr)_96px_40px] md:items-center">
             <SearchableSelect
-              options={creatorOptions(listProps.entries(), index())}
-              value={entry.creatorId}
-              onChange={value => updateEntry(listProps.setter, index(), 'creatorId', value)}
-              placeholder="クリエイターを検索..."
+              options={personOptions(props.entries(), entry.personId)}
+              value={entry.personId}
+              onChange={value => updateEntry(props.setter, index(), 'personId', value)}
+              placeholder="人物を検索..."
               required
             />
             <div class="flex items-center gap-2">
@@ -216,7 +217,7 @@ export const EditableForm = (props: Props) => {
                 type="number"
                 class="input input-bordered w-16"
                 value={entry.orderNo}
-                onchange={e => updateEntry(listProps.setter, index(), 'orderNo', Number(e.currentTarget.value))}
+                onchange={e => updateEntry(props.setter, index(), 'orderNo', Number(e.currentTarget.value))}
                 required
                 min="1"
               />
@@ -224,7 +225,7 @@ export const EditableForm = (props: Props) => {
             <button
               type="button"
               class="btn btn-ghost btn-xs btn-square text-error"
-              onclick={() => removeEntry(listProps.setter, index())}
+              onclick={() => removeEntry(props.setter, index())}
             >
               <svg
                 xmlns="http://www.w3.org/2000/svg"
@@ -244,6 +245,9 @@ export const EditableForm = (props: Props) => {
           </div>
         )}
       </For>
+      <Show when={props.entries().length === 0}>
+        <p class="mt-3 text-sm text-base-content/60">{props.label}はまだ追加されていません。</p>
+      </Show>
     </div>
   );
 
@@ -380,9 +384,9 @@ export const EditableForm = (props: Props) => {
 
           <fieldset class="fieldset bg-base-200 border-base-300 rounded-box border p-6">
             <legend class="px-2 text-sm font-semibold text-base-content/70">関係者</legend>
-            <CreatorList label="作詞者" entries={lyricists} setter={setLyricists} />
-            <CreatorList label="作曲者" entries={composers} setter={setComposers} />
-            <CreatorList label="編曲者" entries={arrangers} setter={setArrangers} />
+            <PersonSection label="作詞" entries={lyricists} setter={setLyricists} role={1} />
+            <PersonSection label="作曲" entries={composers} setter={setComposers} role={2} />
+            <PersonSection label="編曲" entries={arrangers} setter={setArrangers} role={3} />
           </fieldset>
 
           <div class="flex justify-end">

--- a/src/admin/src/pages/persons/[id].astro
+++ b/src/admin/src/pages/persons/[id].astro
@@ -1,0 +1,34 @@
+---
+import { EditableForm } from '../../components/person/EditableForm';
+import Layout from '../../layouts/Layout.astro';
+import { client } from '../../utils/client';
+
+export const prerender = false;
+
+interface Props {
+  id: string;
+}
+
+const { id } = Astro.params;
+
+if (typeof id !== 'string') {
+  throw new Error('URL が不正');
+}
+
+const { data, status } = await client.api.persons({ personId: id }).get({
+  headers: {
+    'x-csrf-token': Astro.cookies.get('csrf')?.value ?? '',
+    'cookie': Astro.request.headers.get('cookie') ?? '',
+  },
+});
+
+if (status === 401) {
+  return Astro.redirect('/auth/login');
+}
+---
+
+<Layout pageTitle="人物詳細">
+  <div>
+    <EditableForm data={data ?? undefined} status={status} client:only="solid-js" />
+  </div>
+</Layout>

--- a/src/admin/src/pages/persons/create/index.astro
+++ b/src/admin/src/pages/persons/create/index.astro
@@ -1,0 +1,10 @@
+---
+import { CreateForm } from '../../../components/person/CreateForm';
+import Layout from '../../../layouts/Layout.astro';
+
+export const prerender = false;
+---
+
+<Layout pageTitle="人物作成">
+  <CreateForm client:load />
+</Layout>

--- a/src/admin/src/pages/persons/index.astro
+++ b/src/admin/src/pages/persons/index.astro
@@ -1,0 +1,12 @@
+---
+import { FlashMessage } from '../../components/Flash';
+import { SearchList } from '../../components/person/SearchList';
+import Layout from '../../layouts/Layout.astro';
+
+export const prerender = false;
+---
+
+<Layout pageTitle="人物一覧">
+  <FlashMessage client:only="solid-js" />
+  <SearchList client:only="solid-js" />
+</Layout>

--- a/src/admin/src/server/index.ts
+++ b/src/admin/src/server/index.ts
@@ -4,6 +4,7 @@ import { adminUsers } from './routes/admin-users';
 import { auth } from './routes/auth';
 import { creators } from './routes/creators';
 import { performers } from './routes/performers';
+import { persons } from './routes/persons';
 import { songTags } from './routes/song-tags';
 import { songTypes } from './routes/song-types';
 import { songs } from './routes/songs';
@@ -18,6 +19,7 @@ export const app = new Elysia({ prefix: '/api' })
   .use(auth)
   .use(adminUsers)
   .use(creators)
+  .use(persons)
   .use(performers)
   .use(songTypes)
   .use(songTags)

--- a/src/admin/src/server/routes/persons.ts
+++ b/src/admin/src/server/routes/persons.ts
@@ -1,0 +1,99 @@
+import { Elysia, t } from 'elysia';
+import {
+  personServiceCreatePerson,
+  personServiceDeletePerson,
+  personServiceGetPerson,
+  personServiceSearchPersons,
+  personServiceUpdatePerson,
+} from '../../generated';
+import type { PerPage, PersonSearchSortBy, SortOrder } from '../../generated';
+import { withAuthRetry } from '../client';
+import { resolveApiResponse } from '../errors';
+import { authGuard } from '../middleware';
+
+export const persons = new Elysia({ prefix: '/persons' })
+  .use(authGuard)
+  .get(
+    '/search',
+    async ({ query, authSession }) => {
+      return withAuthRetry(authSession, async (client) => {
+        return resolveApiResponse(
+          await personServiceSearchPersons({
+            client,
+            query: {
+              name: query.name || undefined,
+              sort: (query.sort ?? 'order_no') as PersonSearchSortBy,
+              order: (query.order ?? 'asc') as SortOrder,
+              page: query.page ?? 1,
+              per_page: (query.per_page ?? 25) as PerPage,
+            },
+          }),
+        );
+      });
+    },
+    {
+      query: t.Object({
+        name: t.String(),
+        sort: t.Optional(t.Union([t.Literal('name'), t.Literal('order_no')])),
+        order: t.Optional(t.Union([t.Literal('asc'), t.Literal('desc')])),
+        page: t.Optional(t.Number()),
+        per_page: t.Optional(t.Number()),
+      }),
+    },
+  )
+  .get(
+    '/:personId',
+    async ({ params: { personId }, authSession }) => {
+      return withAuthRetry(authSession, async (client) => {
+        return resolveApiResponse(await personServiceGetPerson({ client, path: { personId } }));
+      });
+    },
+    {
+      params: t.Object({
+        personId: t.String(),
+      }),
+    },
+  )
+  .post(
+    '/',
+    async ({ body: { name }, authSession }) => {
+      return withAuthRetry(authSession, async (client) => {
+        return resolveApiResponse(await personServiceCreatePerson({ client, body: { name } }));
+      });
+    },
+    {
+      body: t.Object({
+        name: t.String(),
+      }),
+    },
+  )
+  .put(
+    '/:personId',
+    async ({ params: { personId }, body: { name, orderNo }, authSession }) => {
+      return withAuthRetry(authSession, async (client) => {
+        return resolveApiResponse(await personServiceUpdatePerson({ client, path: { personId }, body: { name, orderNo } }));
+      });
+    },
+    {
+      params: t.Object({
+        personId: t.String(),
+      }),
+      body: t.Object({
+        name: t.String(),
+        orderNo: t.Number(),
+      }),
+    },
+  )
+  .delete(
+    '/:personId',
+    async ({ params: { personId }, authSession }) => {
+      return withAuthRetry(authSession, async (client) => {
+        resolveApiResponse(await personServiceDeletePerson({ client, path: { personId } }));
+      });
+    },
+    {
+      params: t.Object({
+        personId: t.String(),
+      }),
+    },
+  );

--- a/src/admin/src/server/routes/songs.ts
+++ b/src/admin/src/server/routes/songs.ts
@@ -1,6 +1,6 @@
 import { Elysia, t } from 'elysia';
 import {
-  creatorServiceListCreators,
+  personServiceListPersons,
   songServiceCreateSong,
   songServiceDeleteSong,
   songServiceGetSong,
@@ -17,21 +17,21 @@ import { authGuard } from '../middleware';
 const SongTypeValueSchema = t.Union([t.Literal(1), t.Literal(2)]);
 const NullableStringSchema = t.Union([t.String(), t.Null()]);
 
-const CreatorRefSchema = t.Array(t.Object({ creatorId: t.String() }));
+const SongPersonRefSchema = t.Array(t.Object({ personId: t.String(), role: t.Union([t.Literal(1), t.Literal(2), t.Literal(3)]), orderNo: t.Number() }));
 const SongTagRefSchema = t.Array(t.Object({ songTagId: t.String() }));
 
 export const songs = new Elysia({ prefix: '/songs' })
   .use(authGuard)
   .get('/create-form', async ({ authSession }) => {
     return withAuthRetry(authSession, async (client) => {
-      const [creators, types, tags] = await Promise.all([
-        creatorServiceListCreators({ client }),
+      const [persons, types, tags] = await Promise.all([
+        personServiceListPersons({ client }),
         songTypeServiceListSongTypes({ client }),
         songTagServiceListSongTags({ client }),
       ]);
 
       return {
-        creators: resolveApiResponse(creators).creators,
+        persons: resolveApiResponse(persons).persons,
         types: resolveApiResponse(types).types,
         tags: resolveApiResponse(tags).tags,
       };
@@ -79,16 +79,16 @@ export const songs = new Elysia({ prefix: '/songs' })
     '/:songId/edit-form',
     async ({ params: { songId }, authSession }) => {
       return withAuthRetry(authSession, async (client) => {
-        const [song, creators, types, tags] = await Promise.all([
+        const [song, persons, types, tags] = await Promise.all([
           songServiceGetSong({ client, path: { songId } }),
-          creatorServiceListCreators({ client }),
+          personServiceListPersons({ client }),
           songTypeServiceListSongTypes({ client }),
           songTagServiceListSongTags({ client }),
         ]);
 
         return {
           ...resolveApiResponse(song),
-          creators: resolveApiResponse(creators).creators,
+          persons: resolveApiResponse(persons).persons,
           types: resolveApiResponse(types).types,
           tags: resolveApiResponse(tags).tags,
         };
@@ -115,19 +115,18 @@ export const songs = new Elysia({ prefix: '/songs' })
   )
   .post(
     '/',
-    async ({ body: { title, description, lyricsLink, typeValue, isDisplay, lyricists, composers, arrangers, tags }, authSession }) => {
+    async ({ body: { title, description, lyricsLink, typeValue, isDisplay, persons, tags }, authSession }) => {
       return withAuthRetry(authSession, async (client) => {
         return resolveApiResponse(
           await songServiceCreateSong({
             client,
             body: {
               title,
-              description, lyricsLink,
+              description,
+              lyricsLink,
               typeValue,
               isDisplay,
-              lyricists,
-              composers,
-              arrangers,
+              persons,
               tags,
             },
           }),
@@ -141,16 +140,14 @@ export const songs = new Elysia({ prefix: '/songs' })
         lyricsLink: NullableStringSchema,
         typeValue: SongTypeValueSchema,
         isDisplay: t.Boolean(),
-        lyricists: CreatorRefSchema,
-        composers: CreatorRefSchema,
-        arrangers: CreatorRefSchema,
+        persons: SongPersonRefSchema,
         tags: SongTagRefSchema,
       }),
     },
   )
   .put(
     '/:songId',
-    async ({ params: { songId }, body: { title, description, lyricsLink, typeValue, isDisplay, orderNo, composers, lyricists, arrangers, tags }, authSession }) => {
+    async ({ params: { songId }, body: { title, description, lyricsLink, typeValue, isDisplay, orderNo, persons, tags }, authSession }) => {
       return withAuthRetry(authSession, async (client) => {
         return resolveApiResponse(
           await songServiceUpdateSong({
@@ -158,13 +155,12 @@ export const songs = new Elysia({ prefix: '/songs' })
             path: { songId },
             body: {
               title,
-              description, lyricsLink,
+              description,
+              lyricsLink,
               typeValue,
               isDisplay,
               orderNo,
-              lyricists,
-              composers,
-              arrangers,
+              persons,
               tags,
             },
           }),
@@ -182,9 +178,7 @@ export const songs = new Elysia({ prefix: '/songs' })
         typeValue: SongTypeValueSchema,
         isDisplay: t.Boolean(),
         orderNo: t.Number(),
-        lyricists: CreatorRefSchema,
-        composers: CreatorRefSchema,
-        arrangers: CreatorRefSchema,
+        persons: SongPersonRefSchema,
         tags: SongTagRefSchema,
       }),
     },


### PR DESCRIPTION
## 概要
- `/persons` の一覧・作成・編集を行う admin BFF ルートと画面を追加
- サイドバーに人物導線を追加し、admin server に persons ルートを登録
- 楽曲の作成・編集フォームを `personId + role + orderNo` の payload に合わせて更新

## 確認
- `mise run admin:generate`
- `(cd src/admin && bunx tsc --noEmit)`

## 補足
- `bun --filter admin lint:check` は `eslint-plugin-import` 側で `sourceCode.getTokenOrCommentBefore is not a function` によりクラッシュするため、この PR では検証に使っていません。
