### PR TITLE
Person 削除時の使用中ガードを追加

### DIFF
--- a/src/server/app/Providers/Domain/SongServiceProvider.php
+++ b/src/server/app/Providers/Domain/SongServiceProvider.php
@@ -6,6 +6,7 @@ namespace App\Providers\Domain;
 
 use Illuminate\Http\Request;
 use Override;
+use Person\Domain\Services\PersonUsageCheckerInterface;
 use Song\Application\Query\SongQueryServiceInterface;
 use Song\Application\UseCase\Create\CreateInputData;
 use Song\Application\UseCase\Search\SearchInputData;
@@ -15,6 +16,7 @@ use Song\Application\UseCase\Tag\Update\UpdateInputData as UpdateTagInputData;
 use Song\Application\UseCase\Update\UpdateInputData;
 use Song\Domain\Models\SongRepositoryInterface;
 use Song\Domain\Models\Tag\SongTagRepositoryInterface;
+use Song\Infrastructures\PersonUsageChecker;
 use Song\Infrastructures\SongQueryService;
 use Song\Infrastructures\SongRepository;
 use Song\Infrastructures\Tag\SongTagRepository;
@@ -26,6 +28,7 @@ class SongServiceProvider extends EnvServiceProvider
     {
         $this->app->bind(SongRepositoryInterface::class, SongRepository::class);
         $this->app->bind(SongTagRepositoryInterface::class, SongTagRepository::class);
+        $this->app->bind(PersonUsageCheckerInterface::class, PersonUsageChecker::class);
 
         $this->app->bind(SongQueryServiceInterface::class, SongQueryService::class);
 

--- a/src/server/packages/Person/Application/UseCase/Delete/DeleteUseCase.php
+++ b/src/server/packages/Person/Application/UseCase/Delete/DeleteUseCase.php
@@ -7,10 +7,13 @@ namespace Person\Application\UseCase\Delete;
 use AdminUser\Domain\Models\Permission;
 use Person\Domain\Models\PersonId;
 use Person\Domain\Models\PersonRepositoryInterface;
+use ResultType\Err;
 use ResultType\Ok;
 use ResultType\Result;
+use Song\Domain\Models\SongRepositoryInterface;
 use Support\Domain\Error\EntityRuleViolationError;
 use Support\UseCase\Authorizer\UseCaseAuthorizer;
+use Support\UseCase\Error\BusinessLogicError;
 use Support\UseCase\Error\InvalidInputError;
 use Support\UseCase\Error\UseCaseError;
 
@@ -19,6 +22,7 @@ readonly class DeleteUseCase
     public function __construct(
         private UseCaseAuthorizer $authorizer,
         private PersonRepositoryInterface $repository,
+        private SongRepositoryInterface $songRepository,
     ) {
     }
 
@@ -39,6 +43,10 @@ readonly class DeleteUseCase
         return PersonId::create($inputData->personId)
             ->mapErr(fn (EntityRuleViolationError $e): UseCaseError => new InvalidInputError([$e->field => [$e->message]]))
             ->andThen(function (PersonId $personId): Result {
+                if ($this->songRepository->isPersonUsed($personId)) {
+                    return new Err(new BusinessLogicError('この人物は楽曲に使用されているため削除できません'));
+                }
+
                 $this->repository->delete($personId);
 
                 return new Ok(null);

--- a/src/server/packages/Person/Application/UseCase/Delete/DeleteUseCase.php
+++ b/src/server/packages/Person/Application/UseCase/Delete/DeleteUseCase.php
@@ -7,10 +7,10 @@ namespace Person\Application\UseCase\Delete;
 use AdminUser\Domain\Models\Permission;
 use Person\Domain\Models\PersonId;
 use Person\Domain\Models\PersonRepositoryInterface;
+use Person\Domain\Services\PersonUsageCheckerInterface;
 use ResultType\Err;
 use ResultType\Ok;
 use ResultType\Result;
-use Song\Domain\Models\SongRepositoryInterface;
 use Support\Domain\Error\EntityRuleViolationError;
 use Support\UseCase\Authorizer\UseCaseAuthorizer;
 use Support\UseCase\Error\BusinessLogicError;
@@ -22,7 +22,7 @@ readonly class DeleteUseCase
     public function __construct(
         private UseCaseAuthorizer $authorizer,
         private PersonRepositoryInterface $repository,
-        private SongRepositoryInterface $songRepository,
+        private PersonUsageCheckerInterface $usageChecker,
     ) {
     }
 
@@ -43,7 +43,7 @@ readonly class DeleteUseCase
         return PersonId::create($inputData->personId)
             ->mapErr(fn (EntityRuleViolationError $e): UseCaseError => new InvalidInputError([$e->field => [$e->message]]))
             ->andThen(function (PersonId $personId): Result {
-                if ($this->songRepository->isPersonUsed($personId)) {
+                if ($this->usageChecker->isUsed($personId)) {
                     return new Err(new BusinessLogicError('この人物は楽曲に使用されているため削除できません'));
                 }
 

--- a/src/server/packages/Person/Domain/Services/PersonUsageCheckerInterface.php
+++ b/src/server/packages/Person/Domain/Services/PersonUsageCheckerInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Person\Domain\Services;
+
+use Person\Domain\Models\PersonId;
+
+interface PersonUsageCheckerInterface
+{
+    public function isUsed(PersonId $personId): bool;
+}

--- a/src/server/packages/Song/Infrastructures/PersonUsageChecker.php
+++ b/src/server/packages/Song/Infrastructures/PersonUsageChecker.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Song\Infrastructures;
+
+use Override;
+use Person\Domain\Models\PersonId;
+use Person\Domain\Services\PersonUsageCheckerInterface;
+use Song\Domain\Models\SongRepositoryInterface;
+
+readonly class PersonUsageChecker implements PersonUsageCheckerInterface
+{
+    public function __construct(
+        private SongRepositoryInterface $repository,
+    ) {
+    }
+
+    #[Override]
+    public function isUsed(PersonId $personId): bool
+    {
+        return $this->repository->isPersonUsed($personId);
+    }
+}

--- a/src/server/tests/Feature/Api/Person/DeletePersonTest.php
+++ b/src/server/tests/Feature/Api/Person/DeletePersonTest.php
@@ -6,6 +6,7 @@ namespace Tests\Feature\Api\Person;
 
 use Person\Route\PersonRouteMap;
 use PHPUnit\Framework\Attributes\Test;
+use Song\Domain\Models\SongType;
 use Tests\Feature\Api\WithAuth;
 use Tests\Support\DatabaseTestCase;
 use Tests\Support\Domain\EntityFactory;
@@ -42,6 +43,31 @@ class DeletePersonTest extends DatabaseTestCase
                         'message' => '予期せぬエラー',
                     ],
                 ],
+            ]);
+    }
+
+    #[Test]
+    public function cannotDeleteWhenUsedInSong(): void
+    {
+        $personId = $this->generateUuid();
+
+        $this->storePersons($this->createPerson($personId, '人物', 1));
+        $this->storeSongs($this->createSong(
+            $this->generateUuid(),
+            '曲名',
+            '説明',
+            SongType::Original,
+            true,
+            1,
+            [],
+            [['personId' => $personId, 'role' => 1, 'orderNo' => 1]],
+        ));
+
+        $this->withAuth()
+            ->delete(route(PersonRouteMap::Delete, $personId))
+            ->assertStatus(400)
+            ->assertExactJson([
+                'message' => 'この人物は楽曲に使用されているため削除できません',
             ]);
     }
 }

--- a/src/server/tests/Integration/Person/Application/UseCase/Delete/DeleteUseCaseTest.php
+++ b/src/server/tests/Integration/Person/Application/UseCase/Delete/DeleteUseCaseTest.php
@@ -8,6 +8,7 @@ use App\Models\Person\Person as ModelsPerson;
 use Person\Application\UseCase\Delete\DeleteInputData;
 use Person\Application\UseCase\Delete\DeleteUseCase;
 use PHPUnit\Framework\Attributes\Test;
+use Song\Domain\Models\SongType;
 use Tests\Support\DatabaseTestCase;
 use Tests\Support\Domain\EntityFactory;
 use Tests\Support\Domain\EntityStore;
@@ -28,6 +29,30 @@ class DeleteUseCaseTest extends DatabaseTestCase
 
         $this->assertTrue($result->isOk());
         $this->assertCount(0, ModelsPerson::query()->get()->all());
+    }
+
+    #[Test]
+    public function cannotDeleteWhenUsedInSong(): void
+    {
+        $personId = $this->generateUuid();
+
+        $this->storePersons($this->createPerson($personId, '人物', 1));
+        $this->storeSongs($this->createSong(
+            $this->generateUuid(),
+            '曲名',
+            '説明',
+            SongType::Original,
+            true,
+            1,
+            [],
+            [['personId' => $personId, 'role' => 1, 'orderNo' => 1]],
+        ));
+
+        $result = $this->getInstance()->handle(new DeleteInputData($personId));
+
+        $this->assertTrue($result->isErr());
+        $this->assertSame('この人物は楽曲に使用されているため削除できません', $result->unwrapErr()->message);
+        $this->assertCount(1, ModelsPerson::query()->get()->all());
     }
 
     private function getInstance(): DeleteUseCase

--- a/src/server/tests/Unit/Person/Application/UseCase/DeleteUseCaseTest.php
+++ b/src/server/tests/Unit/Person/Application/UseCase/DeleteUseCaseTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Person\Application\UseCase;
+
+use Mockery;
+use Mockery\MockInterface;
+use Override;
+use Person\Application\UseCase\Delete\DeleteInputData;
+use Person\Application\UseCase\Delete\DeleteUseCase;
+use Person\Domain\Models\PersonId;
+use Person\Domain\Models\PersonRepositoryInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Song\Domain\Models\SongRepositoryInterface;
+use Support\UseCase\Error\BusinessLogicError;
+use Support\UseCase\Error\InvalidInputError;
+use Tests\TestCase;
+
+class DeleteUseCaseTest extends TestCase
+{
+    private MockInterface&PersonRepositoryInterface $repository;
+
+    private MockInterface&SongRepositoryInterface $songRepository;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->repository = Mockery::mock(PersonRepositoryInterface::class);
+        $this->songRepository = Mockery::mock(SongRepositoryInterface::class);
+    }
+
+    #[Test]
+    public function deletePerson(): void
+    {
+        $this->songRepository->shouldReceive('isPersonUsed')
+            ->withArgs(fn (PersonId $arg): bool => $arg->value === 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA')
+            ->andReturn(false)
+            ->once();
+
+        $this->repository->shouldReceive('delete')
+            ->withArgs(fn (PersonId $arg): bool => $arg->value === 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA')
+            ->once();
+
+        $result = $this->getInstance()->handle(new DeleteInputData('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'));
+
+        $this->assertTrue($result->isOk());
+    }
+
+    #[Test]
+    public function cannotDeleteWhenUsedInSong(): void
+    {
+        $this->songRepository->shouldReceive('isPersonUsed')
+            ->withArgs(fn (PersonId $arg): bool => $arg->value === 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA')
+            ->andReturn(true)
+            ->once();
+
+        $this->repository->shouldNotReceive('delete');
+
+        $result = $this->getInstance()->handle(new DeleteInputData('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'));
+
+        $this->assertTrue($result->isErr());
+        $error = $result->unwrapErr();
+        $this->assertInstanceOf(BusinessLogicError::class, $error);
+        $this->assertSame('この人物は楽曲に使用されているため削除できません', $error->message);
+    }
+
+    #[Test]
+    public function invalidPersonId(): void
+    {
+        $this->songRepository->shouldNotReceive('isPersonUsed');
+        $this->repository->shouldNotReceive('delete');
+
+        $result = $this->getInstance()->handle(new DeleteInputData('invalid-id'));
+
+        $this->assertTrue($result->isErr());
+        $this->assertInstanceOf(InvalidInputError::class, $result->unwrapErr());
+    }
+
+    private function getInstance(): DeleteUseCase
+    {
+        return new DeleteUseCase(
+            $this->authorizer(),
+            $this->repository,
+            $this->songRepository,
+        );
+    }
+}

--- a/src/server/tests/Unit/Person/Application/UseCase/DeleteUseCaseTest.php
+++ b/src/server/tests/Unit/Person/Application/UseCase/DeleteUseCaseTest.php
@@ -11,8 +11,8 @@ use Person\Application\UseCase\Delete\DeleteInputData;
 use Person\Application\UseCase\Delete\DeleteUseCase;
 use Person\Domain\Models\PersonId;
 use Person\Domain\Models\PersonRepositoryInterface;
+use Person\Domain\Services\PersonUsageCheckerInterface;
 use PHPUnit\Framework\Attributes\Test;
-use Song\Domain\Models\SongRepositoryInterface;
 use Support\UseCase\Error\BusinessLogicError;
 use Support\UseCase\Error\InvalidInputError;
 use Tests\TestCase;
@@ -21,7 +21,7 @@ class DeleteUseCaseTest extends TestCase
 {
     private MockInterface&PersonRepositoryInterface $repository;
 
-    private MockInterface&SongRepositoryInterface $songRepository;
+    private MockInterface&PersonUsageCheckerInterface $usageChecker;
 
     #[Override]
     protected function setUp(): void
@@ -29,13 +29,13 @@ class DeleteUseCaseTest extends TestCase
         parent::setUp();
 
         $this->repository = Mockery::mock(PersonRepositoryInterface::class);
-        $this->songRepository = Mockery::mock(SongRepositoryInterface::class);
+        $this->usageChecker = Mockery::mock(PersonUsageCheckerInterface::class);
     }
 
     #[Test]
     public function deletePerson(): void
     {
-        $this->songRepository->shouldReceive('isPersonUsed')
+        $this->usageChecker->shouldReceive('isUsed')
             ->withArgs(fn (PersonId $arg): bool => $arg->value === 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA')
             ->andReturn(false)
             ->once();
@@ -52,7 +52,7 @@ class DeleteUseCaseTest extends TestCase
     #[Test]
     public function cannotDeleteWhenUsedInSong(): void
     {
-        $this->songRepository->shouldReceive('isPersonUsed')
+        $this->usageChecker->shouldReceive('isUsed')
             ->withArgs(fn (PersonId $arg): bool => $arg->value === 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA')
             ->andReturn(true)
             ->once();
@@ -70,7 +70,7 @@ class DeleteUseCaseTest extends TestCase
     #[Test]
     public function invalidPersonId(): void
     {
-        $this->songRepository->shouldNotReceive('isPersonUsed');
+        $this->usageChecker->shouldNotReceive('isUsed');
         $this->repository->shouldNotReceive('delete');
 
         $result = $this->getInstance()->handle(new DeleteInputData('invalid-id'));
@@ -84,7 +84,7 @@ class DeleteUseCaseTest extends TestCase
         return new DeleteUseCase(
             $this->authorizer(),
             $this->repository,
-            $this->songRepository,
+            $this->usageChecker,
         );
     }
 }


### PR DESCRIPTION
## 概要
- Person 削除時に、楽曲で使用中の人物は use case で削除拒否するよう変更
- 使用中の場合は `この人物は楽曲に使用されているため削除できません` を返す
- unit / integration / feature に使用中削除ガードのテストを追加

## 確認
- mise run api:test -- tests/Unit/Person/Application/UseCase/DeleteUseCaseTest.php
- mise run api:test -- tests/Integration/Person/Application/UseCase/Delete/DeleteUseCaseTest.php
- mise run api:test -- tests/Feature/Api/Person/DeletePersonTest.php

## 補足
- Feature テストは `isekai_observatory_testing_test_*` DB 未作成の環境要因で失敗しました
