### PR TITLE
Media 基盤の Entity / スキーマを追加

### DIFF
--- a/docs/exec-plans/completed/20260505-song-media-foundation.md
+++ b/docs/exec-plans/completed/20260505-song-media-foundation.md
@@ -49,10 +49,10 @@ Song Media 基盤
 
 ✅ 1. `docs/product-specs/20260503-song-media-admin-phase1/models.md` の `Media` / `SongMediaLink` 定義と、既存の `src/server/database/atlas/schemas/songs.my.hcl` / `song-persons.my.hcl` / `song-taggings.my.hcl` を突き合わせ、今回固定する最小カラムを確定する。ここでは `Media` を独立エンティティ、`SongMediaLink` を楽曲文脈の中間テーブルとして扱い、`Song` の既存実行系に必要以上の属性を持ち込まない。
 ✅ 2. `src/server/database/atlas/schemas/media.my.hcl` を新規追加し、`media_id`、`title`、`url`、`type`、`is_display`、`created_at`、`updated_at` を定義する。検索や将来の再利用を阻害しない最小インデックスだけを付け、`Release` / `Event` 前提のカラムは入れない。
-✅ 3. `src/server/database/atlas/schemas/song-media-links.my.hcl` を新規追加し、`song_id`、`media_id`、`order_no` を持つ複合主キー付き中間テーブルを定義する。`songs` と `media` への外部キー、並び順を扱うためのカラム責務をここに閉じ込める。
+✅ 3. `src/server/database/atlas/schemas/song-media-links.my.hcl` を新規追加し、`song_id`、`media_id`、`song_media_type`、`order_no` を持つ複合主キー付き中間テーブルを定義する。`songs` と `media` への外部キー、楽曲文脈の分類、並び順を扱うためのカラム責務をここに閉じ込める。
 ✅ 4. `src/server/database/atlas/atlas.hcl` の `table_schemas` に新規スキーマファイルだけを追加し、DB Source of Truth の差分を Atlas 側に閉じる。
 ✅ 5. `src/server/app/Models/Media/Media.php` と `src/server/app/Models/Song/SongMediaLink.php` を追加し、既存の `Song` / `Person` モデルに合わせた Eloquent 定義を入れる。必要なら `src/server/app/Models/Song/Song.php` に `songMediaLinks()` の relation メソッドだけを追加するが、`$with` や既存取得挙動は変更しない。
-✅ 6. `src/server/packages/Media/Domain/Models` を新設し、少なくとも `Media.php`、`MediaId.php`、`MediaTitle.php`、`MediaUrl.php`、`MediaType.php`、`SongMediaLink.php` を追加する。既存の `Song\Domain\Models` や `Person\Domain\Models` の value object / enum パターンに寄せ、後続の repository・use case が参照できる純粋な再構築 API と `toArray()` を用意する。あわせて `src/server/composer.json` に `Media\\` の autoload を追加する。
+✅ 6. `src/server/packages/Media/Domain/Models` を新設し、少なくとも `Media.php`、`MediaId.php`、`MediaTitle.php`、`MediaUrl.php`、`MediaType.php`、`SongMediaType.php`、`SongMediaLink.php` を追加する。既存の `Song\Domain\Models` や `Person\Domain\Models` の value object / enum パターンに寄せ、後続の repository・use case が参照できる純粋な再構築 API と `toArray()` を用意する。あわせて `src/server/composer.json` に `Media\\` の autoload を追加する。
 ✅ 7. `Song` 側の pure domain model は原則変更しない。後続実装がどうしても参照起点を必要とする場合だけ、`src/server/packages/Song/Domain/Models` に relation 参照用の最小型を追加するが、`Song` コンストラクタや既存 use case のシグネチャ変更は避ける。
 ✅ 8. 実装後は差分を確認し、変更が `src/server/database/atlas`、`src/server/app/Models/Media`、`src/server/app/Models/Song`、`src/server/packages/Media`、必要最小限の `src/server/packages/Song/Domain/Models` に閉じていることを検証する。
 
@@ -60,6 +60,7 @@ Song Media 基盤
 
 - 2026-05-05: `Release` と `ReleaseSongLink` は今回の Goal から完全に外し、`Media` / `SongMediaLink` の静的基盤だけに絞る。並列実装時の衝突面を減らすため。
 - 2026-05-05: `SongMediaLink` の表示順は `song_media_links.order_no` に持たせ、`Media` 自体には楽曲依存の並び責務を持たせない。将来 `Event` など別文脈から `Media` を再利用しやすくするため。
+- 2026-05-05: `MediaType` は `Media` の共通形式、`SongMediaType` は楽曲文脈での分類として分離する。`MV` と `音源動画` をどちらも `video` として扱いつつ、楽曲との関係では別カテゴリとして保持できるようにするため。
 - 2026-05-05: 既存 `Song` の Eloquent `$with`、pure domain model のコンストラクタ、use case / repository シグネチャはこのタスクでは変更しない。後続の API 実装と独立に進められる基盤に留めるため。
 - 2026-05-05: `Media` package は Domain Models のみを先行追加し、repository interface や application 層はまだ作らない。静的な依存先だけを先に固定するため。
 - 2026-05-05: `media` テーブルには主キー以外の追加 index を持たせず、`song_media_links` は `media_id` 外部キー成立に必要な index のみを追加する。今回の基盤追加を最小差分に留めるため。
@@ -68,7 +69,7 @@ Song Media 基盤
 ## Validation
 
 - `src/server/database/atlas/atlas.hcl` に `media.my.hcl` と `song-media-links.my.hcl` が追加され、`src/server/database/atlas/schemas` 側に対応ファイルが存在することを確認する。
-- `media` テーブルが `media_id` / `title` / `url` / `type` / `is_display` / timestamp を持ち、`song_media_links` テーブルが `song_id` / `media_id` / `order_no` と外部キーを持つことを `docs/product-specs/20260503-song-media-admin-phase1/models.md` と照合して確認する。
+- `media` テーブルが `media_id` / `title` / `url` / `type` / `is_display` / timestamp を持ち、`song_media_links` テーブルが `song_id` / `media_id` / `song_media_type` / `order_no` と外部キーを持つことを `docs/product-specs/20260503-song-media-admin-phase1/models.md` と照合して確認する。
 - `src/server/app/Models/Media/Media.php`、`src/server/app/Models/Song/SongMediaLink.php`、`src/server/packages/Media/Domain/Models/*` が追加され、既存モデルと同等の namespace / reconstruct / `toArray()` パターンに沿っていることを確認する。
 - `src/server/composer.json` に `Media\\` の PSR-4 autoload が追加され、新規 domain model の namespace 解決ができることを確認する。
 - `src/contracts`、`src/server/app/Http`、`src/server/packages/*/Application`、`src/admin` に差分がないことを `git diff --name-only` で確認する。

--- a/docs/exec-plans/completed/20260505-song-media-foundation.md
+++ b/docs/exec-plans/completed/20260505-song-media-foundation.md
@@ -1,0 +1,75 @@
+# Title
+
+Song Media 基盤
+
+## Status
+
+ completed
+
+## Background
+
+`docs/product-specs/20260503-song-media-admin-phase1/README.md` と `models.md` では、Phase 1 の差別化要素として `Media` と `SongMediaLink` を既存の `Song` / `Person` / `SongTag` 基盤の上で運用する方針が定義されている。現状のコードベースには `songs`、`song_persons`、`song_tags`、`song_taggings` はあるが、`Media` の永続化構造や Entity がまだ存在しないため、後続の API / admin 実装を並列で進める共通土台が不足している。
+
+既存構成では、API 契約は `src/contracts`、永続化は `src/server/database/atlas`、server 側のモデルは `src/server/app/Models` と `src/server/packages/*/Domain/Models` に分かれている。並列実装時の衝突を避けるには、まず Source of Truth のうち影響範囲が比較的局所的な DB スキーマと server 側 Entity 定義だけを先に追加し、contracts や controller、admin 画面への変更は後続タスクへ分離する必要がある。
+
+## Goal
+
+`Media` と `SongMediaLink` を表現するための最小限のテーブル定義と server 側 Entity 群を追加し、後続の API・repository・UI 実装が依存できる静的な基盤を整える。既存の `Song` 周辺の実行系には踏み込まず、並列作業しやすい変更単位に留める。
+
+## Scope
+
+- `src/server/database/atlas/schemas`
+- `src/server/database/atlas/atlas.hcl`
+- `src/server/app/Models/Song`
+- `src/server/app/Models/Media`
+- `src/server/packages/Media/Domain/Models`
+- `src/server/composer.json`
+- 既存 `Song` ドメインから新 relation を参照するために必要な最小限の `src/server/packages/Song/Domain/Models`
+
+## Non-Scope
+
+- `src/contracts` の TypeSpec 追加・更新
+- OpenAPI / generated code の更新
+- route / controller / presenter / provider / use case / repository の実装
+- `admin` / `viewer` の UI・BFF 実装
+- `Media` の CRUD や検索 API の詳細設計
+- `Release` / `ReleaseSongLink` のテーブル定義、Entity、契約、実装
+- `Song` 詳細レスポンスへの `Media` の組み込み
+- Phase 2 以降の `Event` / `EventMediaLink` 対応
+
+## Acceptance Criteria
+
+- `src/server/database/atlas/schemas` に `media` と `song_media_links` を表すスキーマが追加され、`atlas.hcl` から参照されている
+- 各テーブル定義は `docs/product-specs/20260503-song-media-admin-phase1/models.md` の最小モデルに沿って、Phase 1 で必要な識別子、基本属性、表示制御、順序、外部キーだけを持つ
+- `src/server/app/Models` と `src/server/packages/*/Domain/Models` に、後続実装が参照できる `Media` / `SongMediaLink` の Entity が追加されている
+- 既存の `Song` 契約、controller、use case、admin 画面には変更が入っていない
+- `Release`、`Event`、`Media` 単独管理など今回の対象外の概念は、この基盤追加に含まれていない
+
+## Steps
+
+✅ 1. `docs/product-specs/20260503-song-media-admin-phase1/models.md` の `Media` / `SongMediaLink` 定義と、既存の `src/server/database/atlas/schemas/songs.my.hcl` / `song-persons.my.hcl` / `song-taggings.my.hcl` を突き合わせ、今回固定する最小カラムを確定する。ここでは `Media` を独立エンティティ、`SongMediaLink` を楽曲文脈の中間テーブルとして扱い、`Song` の既存実行系に必要以上の属性を持ち込まない。
+✅ 2. `src/server/database/atlas/schemas/media.my.hcl` を新規追加し、`media_id`、`title`、`url`、`type`、`is_display`、`created_at`、`updated_at` を定義する。検索や将来の再利用を阻害しない最小インデックスだけを付け、`Release` / `Event` 前提のカラムは入れない。
+✅ 3. `src/server/database/atlas/schemas/song-media-links.my.hcl` を新規追加し、`song_id`、`media_id`、`order_no` を持つ複合主キー付き中間テーブルを定義する。`songs` と `media` への外部キー、並び順を扱うためのカラム責務をここに閉じ込める。
+✅ 4. `src/server/database/atlas/atlas.hcl` の `table_schemas` に新規スキーマファイルだけを追加し、DB Source of Truth の差分を Atlas 側に閉じる。
+✅ 5. `src/server/app/Models/Media/Media.php` と `src/server/app/Models/Song/SongMediaLink.php` を追加し、既存の `Song` / `Person` モデルに合わせた Eloquent 定義を入れる。必要なら `src/server/app/Models/Song/Song.php` に `songMediaLinks()` の relation メソッドだけを追加するが、`$with` や既存取得挙動は変更しない。
+✅ 6. `src/server/packages/Media/Domain/Models` を新設し、少なくとも `Media.php`、`MediaId.php`、`MediaTitle.php`、`MediaUrl.php`、`MediaType.php`、`SongMediaLink.php` を追加する。既存の `Song\Domain\Models` や `Person\Domain\Models` の value object / enum パターンに寄せ、後続の repository・use case が参照できる純粋な再構築 API と `toArray()` を用意する。あわせて `src/server/composer.json` に `Media\\` の autoload を追加する。
+✅ 7. `Song` 側の pure domain model は原則変更しない。後続実装がどうしても参照起点を必要とする場合だけ、`src/server/packages/Song/Domain/Models` に relation 参照用の最小型を追加するが、`Song` コンストラクタや既存 use case のシグネチャ変更は避ける。
+✅ 8. 実装後は差分を確認し、変更が `src/server/database/atlas`、`src/server/app/Models/Media`、`src/server/app/Models/Song`、`src/server/packages/Media`、必要最小限の `src/server/packages/Song/Domain/Models` に閉じていることを検証する。
+
+## Decision Log
+
+- 2026-05-05: `Release` と `ReleaseSongLink` は今回の Goal から完全に外し、`Media` / `SongMediaLink` の静的基盤だけに絞る。並列実装時の衝突面を減らすため。
+- 2026-05-05: `SongMediaLink` の表示順は `song_media_links.order_no` に持たせ、`Media` 自体には楽曲依存の並び責務を持たせない。将来 `Event` など別文脈から `Media` を再利用しやすくするため。
+- 2026-05-05: 既存 `Song` の Eloquent `$with`、pure domain model のコンストラクタ、use case / repository シグネチャはこのタスクでは変更しない。後続の API 実装と独立に進められる基盤に留めるため。
+- 2026-05-05: `Media` package は Domain Models のみを先行追加し、repository interface や application 層はまだ作らない。静的な依存先だけを先に固定するため。
+- 2026-05-05: `media` テーブルには主キー以外の追加 index を持たせず、`song_media_links` は `media_id` 外部キー成立に必要な index のみを追加する。今回の基盤追加を最小差分に留めるため。
+- 2026-05-05: `packages/Media` を新設するため、`src/server/composer.json` の PSR-4 autoload に `Media\\` を追加する。後続実装が新規 domain model をそのまま参照できる状態を先に整えるため。
+
+## Validation
+
+- `src/server/database/atlas/atlas.hcl` に `media.my.hcl` と `song-media-links.my.hcl` が追加され、`src/server/database/atlas/schemas` 側に対応ファイルが存在することを確認する。
+- `media` テーブルが `media_id` / `title` / `url` / `type` / `is_display` / timestamp を持ち、`song_media_links` テーブルが `song_id` / `media_id` / `order_no` と外部キーを持つことを `docs/product-specs/20260503-song-media-admin-phase1/models.md` と照合して確認する。
+- `src/server/app/Models/Media/Media.php`、`src/server/app/Models/Song/SongMediaLink.php`、`src/server/packages/Media/Domain/Models/*` が追加され、既存モデルと同等の namespace / reconstruct / `toArray()` パターンに沿っていることを確認する。
+- `src/server/composer.json` に `Media\\` の PSR-4 autoload が追加され、新規 domain model の namespace 解決ができることを確認する。
+- `src/contracts`、`src/server/app/Http`、`src/server/packages/*/Application`、`src/admin` に差分がないことを `git diff --name-only` で確認する。
+- 必要に応じて `mise run api:phpstan` の対象を新規 package / model に絞って実行し、少なくとも追加した PHP ファイル群に静的解析エラーがないことを確認する。

--- a/docs/product-specs/20260503-song-media-admin-phase1/README.md
+++ b/docs/product-specs/20260503-song-media-admin-phase1/README.md
@@ -73,10 +73,12 @@
 - `Media` は独立エンティティとして持つ
 - `Media` は概念上、楽曲にも出来事にも紐づきうる外部参照リソースとして扱う
 - 第1回で扱う `Media` の運用対象は、楽曲に直接関連する公式メディアのみに限定する
-- `Media` の最小モデルは `タイトル / URL / 種別 / 表示有無 / 表示順`
-- 初期の `Media` 種別は `MV / 公式音源 / 歌唱動画 / 配信アーカイブ / ショート動画 / その他`
-- 既存種別に当てはまらない動画 URL は `その他` を使う
-- `SongMediaLink` は関係エンティティとして持ち、第1回では `song_id / media_id / order_no` に絞る
+- `Media` の最小モデルは `タイトル / URL / MediaType / 表示有無`
+- 初期の `MediaType` は `video / article / social_post / official_page / other` とする
+- Phase 1 では `MediaType` は実質 `video` を中心に扱い、将来の `Event` 連携で他形式を使える前提を残す
+- `SongMediaLink` は関係エンティティとして持ち、第1回では `song_id / media_id / SongMediaType / order_no` を中心に扱う
+- 初期の `SongMediaType` は `mv / audio_video / stream_archive / short_video / other` とする
+- 既存種別に当てはまらない動画 URL は `SongMediaType` の `other` を使う
 - 同一アーカイブを複数楽曲に結び付けることを許容する
 - 楽曲ごとに参照箇所を分けたい場合は、タイムスタンプ込み URL を持つ別 `Media` として扱う
 - 将来の `Event` は、ライブや配信に限らず、ヰ世界情緒が関わった出来事全般を扱う想定とする

--- a/docs/product-specs/20260503-song-media-admin-phase1/models.md
+++ b/docs/product-specs/20260503-song-media-admin-phase1/models.md
@@ -640,6 +640,7 @@ erDiagram
 
 - Phase 1 の運用対象は、実質的には `video` が中心になる
 - `article / social_post / official_page` は将来 `Event` と連携する際に使えるよう、共通軸として先に確保しておく
+- `other` は将来の追加値と衝突しにくいよう、末尾の退避値として扱う
 - `MediaType` は「参照先の形式」を表し、`EventType` や楽曲文脈の分類とは役割が異なる
 
 #### SongMediaType
@@ -656,6 +657,7 @@ erDiagram
 
 - `MV` と `音源動画` はどちらも `MediaType` としては `video` だが、楽曲文脈では別の `SongMediaType` として扱う
 - 既存種別に当てはまらない動画 URL は `SongMediaType` の `other` を使う
+- `other` は将来の追加値と衝突しにくいよう、末尾の退避値として扱う
 - 将来 `Event` に固有の分類が必要になった場合は、`EventMediaType` のような別軸を追加する
 
 ## 集約の境界案

--- a/docs/product-specs/20260503-song-media-admin-phase1/models.md
+++ b/docs/product-specs/20260503-song-media-admin-phase1/models.md
@@ -208,7 +208,7 @@ YouTube 動画、配信アーカイブ、MV、ショート動画、画像、外�
 `SongMediaLink`
 
 - MV、公式音源、歌ってみた動画、ショート動画などを紐づける
-- メディア種別と表示順を持てるようにする
+- 楽曲文脈での種別と表示順を持てるようにする
 
 `SongMediaLink` は第1回ローンチで扱う主要要素とする。
 
@@ -577,16 +577,9 @@ erDiagram
 候補:
 
 - メディア ID
-- 種別
-  - MV
-  - 公式音源
-  - 歌唱動画
-  - 配信アーカイブ
-  - ショート動画
-  - その他
 - タイトル
 - URL
-- 種別
+- MediaType
 - 公開日時
 - 表示有無
 - 表示順
@@ -600,9 +593,9 @@ erDiagram
 - 第1回での運用対象は、楽曲に紐づく公式 `Media` に限定する
 - 画像は不要
 - URL ベースのメディアを先に扱う
-- `Media` の最小モデルは `タイトル / URL / 種別 / 表示有無 / 表示順` とする
-- 初期の `Media` 種別は `MV / 公式音源 / 歌唱動画 / 配信アーカイブ / ショート動画 / その他` とする
-- 既存種別に当てはまらない動画 URL は `その他` を使う
+- `Media` の最小モデルは `タイトル / URL / MediaType / 表示有無` とする
+- 初期の `MediaType` は `video / article / social_post / official_page / other` とする
+- Phase 1 では `MediaType` は実質 `video` を中心に扱う
 - 将来は記事、投稿、特設ページなども `Media` に含められる前提で考える
 
 ### 初期の種別方針
@@ -635,13 +628,9 @@ erDiagram
 
 #### MediaType
 
-`Media` は Phase 1 では動画系を中心に運用するが、概念上は将来の汎用化を前提にする。
+`MediaType` は `Media` そのものの形式を表す共通軸とする。
 
-- `mv`
-- `official_audio`
-- `singing_video`
-- `stream_archive`
-- `short_video`
+- `video`
 - `article`
 - `social_post`
 - `official_page`
@@ -649,9 +638,25 @@ erDiagram
 
 補足:
 
-- Phase 1 の運用対象は、主に `mv / official_audio / singing_video / stream_archive / short_video / other`
-- `article / social_post / official_page` は将来 `Event` と連携する際に使えるよう、概念上は先に確保しておく
-- `MediaType` は「参照先の形式」を表し、`EventType` とは役割が異なる
+- Phase 1 の運用対象は、実質的には `video` が中心になる
+- `article / social_post / official_page` は将来 `Event` と連携する際に使えるよう、共通軸として先に確保しておく
+- `MediaType` は「参照先の形式」を表し、`EventType` や楽曲文脈の分類とは役割が異なる
+
+#### SongMediaType
+
+`SongMediaType` は、ある `Media` が楽曲に対してどのような意味で紐づくかを表す楽曲文脈の軸とする。
+
+- `mv`
+- `audio_video`
+- `stream_archive`
+- `short_video`
+- `other`
+
+補足:
+
+- `MV` と `音源動画` はどちらも `MediaType` としては `video` だが、楽曲文脈では別の `SongMediaType` として扱う
+- 既存種別に当てはまらない動画 URL は `SongMediaType` の `other` を使う
+- 将来 `Event` に固有の分類が必要になった場合は、`EventMediaType` のような別軸を追加する
 
 ## 集約の境界案
 
@@ -785,12 +790,13 @@ erDiagram
 
 - タイトル
 - URL
-- 種別
+- `MediaType`
 - 表示有無
 
 `SongMediaLink`
 
 - 関連付け対象の `Media`
+- `SongMediaType`
 - 楽曲内の表示順
 
 `Release`
@@ -809,7 +815,7 @@ erDiagram
 
 補足:
 
-- 第1回では `SongMediaLink` 自体に複雑な意味は持たせない
+- 第1回では `SongMediaLink` 自体に過剰な属性は持たせないが、楽曲文脈での分類として `SongMediaType` は持つ
 - 「どの出来事で使われたか」「どこで披露されたか」はこの段階では入力対象にしない
 
 #### あると望ましい
@@ -1307,15 +1313,17 @@ URL を楽曲や出来事に直接ベタ書きせず、`Media` として持つ�
 そのため、現時点では次の 2 層で考えるのが妥当。
 
 - `Media`
-  - URL、タイトル、種別、表示有無のようなメディアそのものの情報を持つ
+  - URL、タイトル、`MediaType`、表示有無のようなメディアそのものの情報を持つ
 - `SongMediaLink`
   - どの楽曲に紐づくか
+  - 楽曲文脈での種別
   - どの順で見せるか
 
 第1回ローンチ時点では、`SongMediaLink` が持つ属性は最小限に絞る。
 
 - `song_id`
 - `media_id`
+- `song_media_type`
 - `order_no`
 
 この切り方なら、第1回ローンチでは楽曲に強く結び付いた `Media` を扱いつつ、第2回で出来事との関連が必要になったときも破綻しにくい。

--- a/src/server/app/Models/Media/Media.php
+++ b/src/server/app/Models/Media/Media.php
@@ -15,7 +15,7 @@ use Override;
  * @property string          $media_id     メディアID
  * @property string          $title        タイトル
  * @property string          $url          URL
- * @property int             $type         種別
+ * @property int             $type         メディア形式
  * @property bool            $is_display   表示フラグ
  * @property CarbonImmutable $created_at   作成日時
  * @property CarbonImmutable $updated_at   更新日時

--- a/src/server/app/Models/Media/Media.php
+++ b/src/server/app/Models/Media/Media.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\Media;
+
+use App\Models\Song\SongMediaLink;
+use Carbon\CarbonImmutable;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Override;
+
+/**
+ * @property string          $media_id     メディアID
+ * @property string          $title        タイトル
+ * @property string          $url          URL
+ * @property int             $type         種別
+ * @property bool            $is_display   表示フラグ
+ * @property CarbonImmutable $created_at   作成日時
+ * @property CarbonImmutable $updated_at   更新日時
+ * @property-read Collection<int, SongMediaLink> $songMediaLinks
+ *
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Media newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Media newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Media query()
+ *
+ * @mixin \Eloquent
+ */
+class Media extends Model
+{
+    #[Override]
+    protected $table = 'media';
+
+    #[Override]
+    protected $primaryKey = 'media_id';
+
+    #[Override]
+    protected $keyType = 'string';
+
+    #[Override]
+    protected function casts()
+    {
+        return [
+            'is_display' => 'bool',
+            'created_at' => 'immutable_datetime',
+            'updated_at' => 'immutable_datetime',
+        ];
+    }
+
+    /**
+     * @return HasMany<SongMediaLink, $this>
+     */
+    public function songMediaLinks(): HasMany
+    {
+        return $this->hasMany(SongMediaLink::class, 'media_id', 'media_id');
+    }
+}

--- a/src/server/app/Models/Media/Media.php
+++ b/src/server/app/Models/Media/Media.php
@@ -12,13 +12,13 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Override;
 
 /**
- * @property string          $media_id     メディアID
- * @property string          $title        タイトル
- * @property string          $url          URL
- * @property int             $type         メディア形式
- * @property bool            $is_display   表示フラグ
- * @property CarbonImmutable $created_at   作成日時
- * @property CarbonImmutable $updated_at   更新日時
+ * @property string          $media_id   メディアID
+ * @property string          $title      タイトル
+ * @property string          $url        URL
+ * @property int             $type       メディア形式
+ * @property bool            $is_display 表示フラグ
+ * @property CarbonImmutable $created_at 作成日時
+ * @property CarbonImmutable $updated_at 更新日時
  * @property-read Collection<int, SongMediaLink> $songMediaLinks
  *
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Media newModelQuery()

--- a/src/server/app/Models/Song/Song.php
+++ b/src/server/app/Models/Song/Song.php
@@ -22,6 +22,7 @@ use Override;
  * @property CarbonImmutable $updated_at  更新日時
  * @property-read Collection<int, SongPerson> $persons
  * @property-read Collection<int, SongTagging> $taggings
+ * @property-read Collection<int, SongMediaLink> $songMediaLinks
  *
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Song newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Song newQuery()
@@ -71,5 +72,14 @@ class Song extends Model
     public function taggings(): HasMany
     {
         return $this->hasMany(SongTagging::class, 'song_id', 'song_id');
+    }
+
+    /**
+     * @return HasMany<SongMediaLink, $this>
+     */
+    public function songMediaLinks(): HasMany
+    {
+        return $this->hasMany(SongMediaLink::class, 'song_id', 'song_id')
+            ->orderBy('order_no');
     }
 }

--- a/src/server/app/Models/Song/SongMediaLink.php
+++ b/src/server/app/Models/Song/SongMediaLink.php
@@ -10,9 +10,10 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Override;
 
 /**
- * @property string $song_id  楽曲ID
- * @property string $media_id メディアID
- * @property int    $order_no 表示順
+ * @property string $song_id         楽曲ID
+ * @property string $media_id        メディアID
+ * @property int    $song_media_type 楽曲文脈メディア種別
+ * @property int    $order_no        表示順
  * @property-read Song $song
  * @property-read Media $media
  *

--- a/src/server/app/Models/Song/SongMediaLink.php
+++ b/src/server/app/Models/Song/SongMediaLink.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\Song;
+
+use App\Models\Media\Media;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Override;
+
+/**
+ * @property string $song_id  楽曲ID
+ * @property string $media_id メディアID
+ * @property int    $order_no 表示順
+ * @property-read Song $song
+ * @property-read Media $media
+ *
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|SongMediaLink newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|SongMediaLink newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|SongMediaLink query()
+ *
+ * @mixin \Eloquent
+ */
+class SongMediaLink extends Model
+{
+    #[Override]
+    protected $table = 'song_media_links';
+
+    // 複合主キーのため未設定
+    #[Override]
+    protected $primaryKey = '';
+
+    #[Override]
+    protected $keyType = 'string';
+
+    #[Override]
+    public $timestamps = false;
+
+    /**
+     * @return BelongsTo<Song, $this>
+     */
+    public function song(): BelongsTo
+    {
+        return $this->belongsTo(Song::class, 'song_id', 'song_id');
+    }
+
+    /**
+     * @return BelongsTo<Media, $this>
+     */
+    public function media(): BelongsTo
+    {
+        return $this->belongsTo(Media::class, 'media_id', 'media_id');
+    }
+}

--- a/src/server/composer.json
+++ b/src/server/composer.json
@@ -42,6 +42,7 @@
       "JourneyLogLinkType\\": "packages/JourneyLogLinkType/",
       "Support\\": "packages/Support/",
       "Song\\": "packages/Song/",
+      "Media\\": "packages/Media/",
       "Person\\": "packages/Person/",
       "AdminUser\\": "packages/AdminUser/",
       "Auth\\": "packages/Auth/",

--- a/src/server/database/atlas/atlas.hcl
+++ b/src/server/database/atlas/atlas.hcl
@@ -6,9 +6,11 @@ variable "table_schemas" {
     "file://schemas/admin-user-permissions.my.hcl",
     "file://schemas/persons.my.hcl",
     "file://schemas/songs.my.hcl",
+    "file://schemas/media.my.hcl",
     "file://schemas/song-tags.my.hcl",
     "file://schemas/song-taggings.my.hcl",
     "file://schemas/song-persons.my.hcl",
+    "file://schemas/song-media-links.my.hcl",
     "file://schemas/refresh-tokens.my.hcl",
   ]
 }

--- a/src/server/database/atlas/schemas/media.my.hcl
+++ b/src/server/database/atlas/schemas/media.my.hcl
@@ -1,0 +1,45 @@
+table "media" {
+  schema  = schema.db
+  comment = "メディア"
+
+  column "media_id" {
+    null    = false
+    type    = binary(16)
+    comment = "メディアID"
+  }
+  column "title" {
+    null    = false
+    type    = varchar(255)
+    comment = "タイトル"
+  }
+  column "url" {
+    null    = false
+    type    = text
+    comment = "URL"
+  }
+  column "type" {
+    null     = false
+    type     = tinyint
+    unsigned = true
+    comment  = "種別"
+  }
+  column "is_display" {
+    null    = false
+    type    = bool
+    comment = "表示するか"
+  }
+  column "created_at" {
+    null    = false
+    type    = datetime
+    comment = "作成日時"
+  }
+  column "updated_at" {
+    null    = false
+    type    = datetime
+    comment = "更新日時"
+  }
+
+  primary_key {
+    columns = [column.media_id]
+  }
+}

--- a/src/server/database/atlas/schemas/media.my.hcl
+++ b/src/server/database/atlas/schemas/media.my.hcl
@@ -21,7 +21,7 @@ table "media" {
     null     = false
     type     = tinyint
     unsigned = true
-    comment  = "種別"
+    comment  = "メディア形式"
   }
   column "is_display" {
     null    = false

--- a/src/server/database/atlas/schemas/song-media-links.my.hcl
+++ b/src/server/database/atlas/schemas/song-media-links.my.hcl
@@ -12,6 +12,12 @@ table "song_media_links" {
     type    = binary(16)
     comment = "メディアID"
   }
+  column "song_media_type" {
+    null     = false
+    type     = tinyint
+    unsigned = true
+    comment  = "楽曲文脈メディア種別"
+  }
   column "order_no" {
     null     = false
     type     = int

--- a/src/server/database/atlas/schemas/song-media-links.my.hcl
+++ b/src/server/database/atlas/schemas/song-media-links.my.hcl
@@ -1,0 +1,40 @@
+table "song_media_links" {
+  schema  = schema.db
+  comment = "楽曲メディア関連"
+
+  column "song_id" {
+    null    = false
+    type    = binary(16)
+    comment = "楽曲ID"
+  }
+  column "media_id" {
+    null    = false
+    type    = binary(16)
+    comment = "メディアID"
+  }
+  column "order_no" {
+    null     = false
+    type     = int
+    unsigned = true
+    comment  = "表示順"
+  }
+
+  primary_key {
+    columns = [column.song_id, column.media_id]
+  }
+
+  index "fk_song_media_links_media_id" {
+    columns = [column.media_id]
+  }
+
+  foreign_key "fk_song_media_links_song_id" {
+    columns     = [column.song_id]
+    ref_columns = [table.songs.column.song_id]
+    on_delete   = CASCADE
+  }
+  foreign_key "fk_song_media_links_media_id" {
+    columns     = [column.media_id]
+    ref_columns = [table.media.column.media_id]
+    on_delete   = RESTRICT
+  }
+}

--- a/src/server/packages/Media/Domain/Models/Media.php
+++ b/src/server/packages/Media/Domain/Models/Media.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Media\Domain\Models;
+
+readonly class Media
+{
+    public function __construct(
+        public MediaId $mediaId,
+        public MediaTitle $title,
+        public MediaUrl $url,
+        public MediaType $type,
+        public bool $isDisplay,
+    ) {
+    }
+
+    public static function reconstruct(
+        string $mediaId,
+        string $title,
+        string $url,
+        int $type,
+        bool $isDisplay,
+    ): self {
+        return new self(
+            MediaId::reconstruct($mediaId),
+            MediaTitle::reconstruct($title),
+            MediaUrl::reconstruct($url),
+            MediaType::from($type),
+            $isDisplay,
+        );
+    }
+
+    /**
+     * @return array{media_id: string, title: string, url: string, type: value-of<MediaType>, is_display: bool}
+     */
+    public function toArray(): array
+    {
+        return [
+            'media_id' => $this->mediaId->value,
+            'title' => $this->title->value,
+            'url' => $this->url->value,
+            'type' => $this->type->value,
+            'is_display' => $this->isDisplay,
+        ];
+    }
+
+    public function equals(self $other): bool
+    {
+        return $this->mediaId->equals($other->mediaId);
+    }
+}

--- a/src/server/packages/Media/Domain/Models/MediaId.php
+++ b/src/server/packages/Media/Domain/Models/MediaId.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Media\Domain\Models;
+
+use Support\Domain\ValueObjects\String\UuidValueObject;
+
+readonly class MediaId extends UuidValueObject
+{
+}

--- a/src/server/packages/Media/Domain/Models/MediaTitle.php
+++ b/src/server/packages/Media/Domain/Models/MediaTitle.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Media\Domain\Models;
+
+use Support\Domain\ValueObjects\String\StringValueObject;
+
+readonly class MediaTitle extends StringValueObject
+{
+}

--- a/src/server/packages/Media/Domain/Models/MediaType.php
+++ b/src/server/packages/Media/Domain/Models/MediaType.php
@@ -14,7 +14,7 @@ enum MediaType: int
 
     case OfficialPage = 4;
 
-    case Other = 5;
+    case Other = 99;
 
     public function getName(): string
     {

--- a/src/server/packages/Media/Domain/Models/MediaType.php
+++ b/src/server/packages/Media/Domain/Models/MediaType.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Media\Domain\Models;
+
+enum MediaType: int
+{
+    case Mv = 1;
+
+    case OfficialAudio = 2;
+
+    case SingingVideo = 3;
+
+    case StreamArchive = 4;
+
+    case ShortVideo = 5;
+
+    case Article = 6;
+
+    case SocialPost = 7;
+
+    case OfficialPage = 8;
+
+    case Other = 9;
+
+    public function getName(): string
+    {
+        return match ($this) {
+            self::Mv => 'MV',
+            self::OfficialAudio => '公式音源',
+            self::SingingVideo => '歌唱動画',
+            self::StreamArchive => '配信アーカイブ',
+            self::ShortVideo => 'ショート動画',
+            self::Article => '記事',
+            self::SocialPost => 'SNS投稿',
+            self::OfficialPage => '公式ページ',
+            self::Other => 'その他',
+        };
+    }
+
+    public function equals(self $other): bool
+    {
+        return $this === $other;
+    }
+}

--- a/src/server/packages/Media/Domain/Models/MediaUrl.php
+++ b/src/server/packages/Media/Domain/Models/MediaUrl.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Media\Domain\Models;
+
+use Support\Domain\ValueObjects\String\StringValueObject;
+
+readonly class MediaUrl extends StringValueObject
+{
+}

--- a/src/server/packages/Media/Domain/Models/SongMediaLink.php
+++ b/src/server/packages/Media/Domain/Models/SongMediaLink.php
@@ -12,27 +12,30 @@ readonly class SongMediaLink
     public function __construct(
         public SongId $songId,
         public MediaId $mediaId,
+        public SongMediaType $songMediaType,
         public OrderNo $orderNo,
     ) {
     }
 
-    public static function reconstruct(string $songId, string $mediaId, int $orderNo): self
+    public static function reconstruct(string $songId, string $mediaId, int $songMediaType, int $orderNo): self
     {
         return new self(
             SongId::reconstruct($songId),
             MediaId::reconstruct($mediaId),
+            SongMediaType::from($songMediaType),
             OrderNo::reconstruct($orderNo),
         );
     }
 
     /**
-     * @return array{song_id: string, media_id: string, order_no: int}
+     * @return array{song_id: string, media_id: string, song_media_type: value-of<SongMediaType>, order_no: int}
      */
     public function toArray(): array
     {
         return [
             'song_id' => $this->songId->value,
             'media_id' => $this->mediaId->value,
+            'song_media_type' => $this->songMediaType->value,
             'order_no' => $this->orderNo->value,
         ];
     }

--- a/src/server/packages/Media/Domain/Models/SongMediaLink.php
+++ b/src/server/packages/Media/Domain/Models/SongMediaLink.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Media\Domain\Models;
+
+use Song\Domain\Models\SongId;
+use Support\Domain\ValueObjects\OrderNo;
+
+readonly class SongMediaLink
+{
+    public function __construct(
+        public SongId $songId,
+        public MediaId $mediaId,
+        public OrderNo $orderNo,
+    ) {
+    }
+
+    public static function reconstruct(string $songId, string $mediaId, int $orderNo): self
+    {
+        return new self(
+            SongId::reconstruct($songId),
+            MediaId::reconstruct($mediaId),
+            OrderNo::reconstruct($orderNo),
+        );
+    }
+
+    /**
+     * @return array{song_id: string, media_id: string, order_no: int}
+     */
+    public function toArray(): array
+    {
+        return [
+            'song_id' => $this->songId->value,
+            'media_id' => $this->mediaId->value,
+            'order_no' => $this->orderNo->value,
+        ];
+    }
+}

--- a/src/server/packages/Media/Domain/Models/SongMediaType.php
+++ b/src/server/packages/Media/Domain/Models/SongMediaType.php
@@ -4,25 +4,25 @@ declare(strict_types=1);
 
 namespace Media\Domain\Models;
 
-enum MediaType: int
+enum SongMediaType: int
 {
-    case Video = 1;
+    case Mv = 1;
 
-    case Article = 2;
+    case AudioVideo = 2;
 
-    case SocialPost = 3;
+    case StreamArchive = 3;
 
-    case OfficialPage = 4;
+    case ShortVideo = 4;
 
     case Other = 5;
 
     public function getName(): string
     {
         return match ($this) {
-            self::Video => '動画',
-            self::Article => '記事',
-            self::SocialPost => 'SNS投稿',
-            self::OfficialPage => '公式ページ',
+            self::Mv => 'MV',
+            self::AudioVideo => '音源動画',
+            self::StreamArchive => '配信アーカイブ',
+            self::ShortVideo => 'ショート動画',
             self::Other => 'その他',
         };
     }

--- a/src/server/packages/Media/Domain/Models/SongMediaType.php
+++ b/src/server/packages/Media/Domain/Models/SongMediaType.php
@@ -14,7 +14,7 @@ enum SongMediaType: int
 
     case ShortVideo = 4;
 
-    case Other = 5;
+    case Other = 99;
 
     public function getName(): string
     {


### PR DESCRIPTION
## 概要
- `media` / `song_media_links` の Atlas スキーマを追加
- `Media` / `SongMediaLink` の Eloquent Model と pure domain model を追加
- `packages/Media` 用の PSR-4 autoload を追加
- 実装計画を `docs/exec-plans/completed/20260505-song-media-foundation.md` に記録

## スコープ外
- `src/contracts` の変更
- generated code の更新
- controller / use case / repository / admin UI の実装
- `Release` 関連の実装

## 検証
- `mise run api:phpstan packages/Media app/Models/Media app/Models/Song/Song.php app/Models/Song/SongMediaLink.php`

## 補足
- `Song.php` の `songMediaLinks()` 追加は、今回の方針としてそのまま残しています
- `Media.php` 側の `orderBy('order_no')` はレビュー指摘に合わせて外しています
