### PR TITLE
CI で dump-autoload を実行

### DIFF
--- a/.github/workflows/server-qa.yaml
+++ b/.github/workflows/server-qa.yaml
@@ -90,6 +90,9 @@ jobs:
         if: steps.cache-composer.outputs.cache-hit != 'true'
         run: mise run api:composer:install
 
+      - name: Dump autoload
+        run: mise run api:composer:dump
+
       - name: Check generate code has diff
         run: mise run api:generate
 

--- a/mise.toml
+++ b/mise.toml
@@ -188,6 +188,10 @@ run = "docker compose exec php bash"
 description = "composer パッケージをインストールする"
 run = "docker compose run --rm php composer install"
 
+[tasks."api:composer:dump"]
+description = "autoloader を更新する"
+run = "docker compose exec -T php composer dump-autoload"
+
 [tasks."api:generate"]
 description = "OAS からサーバーのコードを生成する"
 run = '''


### PR DESCRIPTION
## 概要

名前空間を変えたときにエラーになることが多かったので対応
必ず autoloader を更新するようにした