### PR TITLE
Media 一覧と検索フィルタを追加する

### DIFF
--- a/src/admin/src/components/Sidebar.tsx
+++ b/src/admin/src/components/Sidebar.tsx
@@ -69,6 +69,23 @@ const SwatchIcon = () => (
   </svg>
 );
 
+const PlayIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    class="size-5"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M5.25 5.653c0-1.427 1.529-2.33 2.779-1.643l11.54 6.347c1.295.713 1.295 2.573 0 3.286L8.03 19.99c-1.25.688-2.779-.216-2.779-1.643V5.653Z"
+    />
+  </svg>
+);
+
 const ShieldIcon = () => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
@@ -102,6 +119,7 @@ const navSections: NavSection[] = [
     title: '楽曲',
     items: [
       { href: '/songs', label: '楽曲', icon: MusicNoteIcon },
+      { href: '/media', label: 'Media', icon: PlayIcon },
       { href: '/song-types', label: '楽曲種別', icon: TagIcon },
       { href: '/song-tags', label: '楽曲タグ', icon: SwatchIcon },
     ],

--- a/src/admin/src/components/media/SearchList.tsx
+++ b/src/admin/src/components/media/SearchList.tsx
@@ -1,0 +1,303 @@
+import { For, Match, Show, Switch, createResource, createSignal } from 'solid-js';
+import type { MediaFormatValue, MediaTypeValue } from '../../generated';
+import { client } from '../../utils/client';
+import { ListState } from '../ListState';
+
+const PER_PAGE_OPTIONS = [25, 50, 100] as const;
+type PerPage = (typeof PER_PAGE_OPTIONS)[number];
+type DisplayFilter = '' | 'true' | 'false';
+
+const MEDIA_TYPE_OPTIONS: Array<{ value: '' | `${MediaTypeValue}`; label: string }> = [
+  { value: '', label: 'すべて' },
+  { value: '1', label: '動画' },
+  { value: '2', label: '記事' },
+  { value: '3', label: 'SNS投稿' },
+  { value: '4', label: '公式ページ' },
+  { value: '99', label: 'その他' },
+];
+
+const MEDIA_FORMAT_OPTIONS: Array<{ value: '' | `${MediaFormatValue}`; label: string }> = [
+  { value: '', label: 'すべて' },
+  { value: '1', label: 'MV' },
+  { value: '2', label: '音源動画' },
+  { value: '3', label: '配信アーカイブ' },
+  { value: '4', label: 'ショート動画' },
+  { value: '5', label: 'ライブ切り抜き' },
+  { value: '99', label: 'その他' },
+];
+
+const DEFAULT_PARAMS = {
+  title: '',
+  type: '' as '' | `${MediaTypeValue}`,
+  format: '' as '' | `${MediaFormatValue}`,
+  isDisplay: '' as DisplayFilter,
+  page: 1,
+  perPage: 25 as PerPage,
+};
+
+const getInitialParams = () => {
+  const params = new URLSearchParams(window.location.search);
+  const perPageRaw = Number(params.get('per_page'));
+
+  return {
+    title: params.get('title') ?? DEFAULT_PARAMS.title,
+    type: (params.get('type') ?? DEFAULT_PARAMS.type) as '' | `${MediaTypeValue}`,
+    format: (params.get('format') ?? DEFAULT_PARAMS.format) as '' | `${MediaFormatValue}`,
+    isDisplay: (params.get('is_display') ?? DEFAULT_PARAMS.isDisplay) as DisplayFilter,
+    page: Number(params.get('page') ?? String(DEFAULT_PARAMS.page)) || DEFAULT_PARAMS.page,
+    perPage: (PER_PAGE_OPTIONS.includes(perPageRaw as PerPage) ? perPageRaw : DEFAULT_PARAMS.perPage) as PerPage,
+  };
+};
+
+export const SearchList = () => {
+  const initial = getInitialParams();
+
+  const [title, setTitle] = createSignal(initial.title);
+  const [type, setType] = createSignal(initial.type);
+  const [format, setFormat] = createSignal(initial.format);
+  const [isDisplay, setIsDisplay] = createSignal<DisplayFilter>(initial.isDisplay);
+  const [page, setPage] = createSignal(initial.page);
+  const [perPage, setPerPage] = createSignal<PerPage>(initial.perPage);
+
+  const [inputTitle, setInputTitle] = createSignal(initial.title);
+  const [inputType, setInputType] = createSignal(initial.type);
+  const [inputFormat, setInputFormat] = createSignal(initial.format);
+  const [inputIsDisplay, setInputIsDisplay] = createSignal<DisplayFilter>(initial.isDisplay);
+  const [inputPerPage, setInputPerPage] = createSignal<PerPage>(initial.perPage);
+
+  const updateUrl = (params: { title: string; type: string; format: string; isDisplay: DisplayFilter; page: number; perPage: number }) => {
+    const searchParams = new URLSearchParams();
+    if (params.title) searchParams.set('title', params.title);
+    if (params.type) searchParams.set('type', params.type);
+    if (params.format) searchParams.set('format', params.format);
+    if (params.isDisplay) searchParams.set('is_display', params.isDisplay);
+    searchParams.set('page', String(params.page));
+    searchParams.set('per_page', String(params.perPage));
+    history.pushState(null, '', `?${searchParams.toString()}`);
+  };
+
+  const [fetchError, setFetchError] = createSignal<string | null>(null);
+
+  const [data, { refetch }] = createResource(
+    () => ({ title: title(), type: type(), format: format(), isDisplay: isDisplay(), page: page(), perPage: perPage() }),
+    async (params) => {
+      setFetchError(null);
+
+      const { data, status } = await client.api.media.search.get({
+        query: {
+          title: params.title,
+          type: params.type || undefined,
+          format: params.format || undefined,
+          is_display: params.isDisplay === '' ? undefined : params.isDisplay === 'true',
+          page: params.page,
+          per_page: params.perPage,
+        },
+      });
+
+      if (status === 401) {
+        window.location.href = '/auth/login';
+        return;
+      }
+
+      if (!data) {
+        setFetchError('データの取得に失敗しました。再度お試しください。');
+        return;
+      }
+
+      return data;
+    },
+  );
+
+  const handleSearch = (e: Event) => {
+    e.preventDefault();
+
+    const newPage = 1;
+    setTitle(inputTitle());
+    setType(inputType());
+    setFormat(inputFormat());
+    setIsDisplay(inputIsDisplay());
+    setPerPage(inputPerPage());
+    setPage(newPage);
+    updateUrl({ title: inputTitle(), type: inputType(), format: inputFormat(), isDisplay: inputIsDisplay(), page: newPage, perPage: inputPerPage() });
+  };
+
+  const handlePageChange = (nextPage: number) => {
+    setPage(nextPage);
+    updateUrl({ title: title(), type: type(), format: format(), isDisplay: isDisplay(), page: nextPage, perPage: perPage() });
+  };
+
+  const handleReset = () => {
+    setInputTitle(DEFAULT_PARAMS.title);
+    setInputType(DEFAULT_PARAMS.type);
+    setInputFormat(DEFAULT_PARAMS.format);
+    setInputIsDisplay(DEFAULT_PARAMS.isDisplay);
+    setInputPerPage(DEFAULT_PARAMS.perPage);
+    setTitle(DEFAULT_PARAMS.title);
+    setType(DEFAULT_PARAMS.type);
+    setFormat(DEFAULT_PARAMS.format);
+    setIsDisplay(DEFAULT_PARAMS.isDisplay);
+    setPage(DEFAULT_PARAMS.page);
+    setPerPage(DEFAULT_PARAMS.perPage);
+    updateUrl(DEFAULT_PARAMS);
+  };
+
+  return (
+    <>
+      <form onSubmit={handleSearch} class="mb-4 flex flex-wrap items-end gap-4">
+        <fieldset class="fieldset">
+          <label class="fieldset-label" for="title">
+            タイトル
+          </label>
+          <input
+            type="text"
+            id="title"
+            name="title"
+            value={inputTitle()}
+            onInput={e => setInputTitle(e.currentTarget.value)}
+            class="input input-bordered input-sm"
+            placeholder="Media タイトルで検索"
+          />
+        </fieldset>
+        <fieldset class="fieldset">
+          <label class="fieldset-label" for="type">
+            種別
+          </label>
+          <select
+            id="type"
+            name="type"
+            class="select select-bordered select-sm"
+            onChange={e => setInputType(e.currentTarget.value as '' | `${MediaTypeValue}`)}
+          >
+            <For each={MEDIA_TYPE_OPTIONS}>{option => <option value={option.value} selected={inputType() === option.value}>{option.label}</option>}</For>
+          </select>
+        </fieldset>
+        <fieldset class="fieldset">
+          <label class="fieldset-label" for="format">
+            形式
+          </label>
+          <select
+            id="format"
+            name="format"
+            class="select select-bordered select-sm"
+            onChange={e => setInputFormat(e.currentTarget.value as '' | `${MediaFormatValue}`)}
+          >
+            <For each={MEDIA_FORMAT_OPTIONS}>{option => <option value={option.value} selected={inputFormat() === option.value}>{option.label}</option>}</For>
+          </select>
+        </fieldset>
+        <fieldset class="fieldset">
+          <label class="fieldset-label" for="isDisplay">
+            表示設定
+          </label>
+          <select
+            id="isDisplay"
+            name="isDisplay"
+            class="select select-bordered select-sm"
+            onChange={e => setInputIsDisplay(e.currentTarget.value as DisplayFilter)}
+          >
+            <option value="" selected={inputIsDisplay() === ''}>すべて</option>
+            <option value="true" selected={inputIsDisplay() === 'true'}>表示する</option>
+            <option value="false" selected={inputIsDisplay() === 'false'}>表示しない</option>
+          </select>
+        </fieldset>
+        <fieldset class="fieldset">
+          <label class="fieldset-label" for="perPage">
+            表示件数
+          </label>
+          <select
+            id="perPage"
+            name="perPage"
+            class="select select-bordered select-sm"
+            onChange={e => setInputPerPage(Number(e.currentTarget.value) as PerPage)}
+          >
+            <For each={PER_PAGE_OPTIONS}>{n => <option value={n} selected={inputPerPage() === n}>{n}件</option>}</For>
+          </select>
+        </fieldset>
+        <button type="submit" class="btn btn-primary btn-sm mb-1">
+          検索
+        </button>
+        <button type="button" class="btn btn-ghost btn-sm mb-1" onClick={handleReset}>
+          リセット
+        </button>
+      </form>
+
+      <div class="mb-4 flex justify-end">
+        <button type="button" class="btn btn-primary btn-sm" disabled>
+          新規作成
+        </button>
+      </div>
+
+      <div class="overflow-x-auto rounded-box border border-base-300 bg-base-100">
+        <table class="table table-zebra">
+          <thead>
+            <tr>
+              <th>タイトル</th>
+              <th>種別</th>
+              <th>表示設定</th>
+              <th>形式</th>
+              <th>URL</th>
+              <th>操作</th>
+            </tr>
+          </thead>
+          <tbody>
+            <Switch>
+              <Match when={data.loading}>
+                <ListState state="loading" colSpan={6} />
+              </Match>
+              <Match when={fetchError()}>
+                {message => <ListState state="error" colSpan={6} message={message()} onRetry={() => refetch()} />}
+              </Match>
+              <Match when={data() && data()!.media.length === 0}>
+                <ListState state="empty" colSpan={6} message="条件に一致する Media はありません。" />
+              </Match>
+              <Match when={data()}>
+                {result => (
+                  <For each={result().media}>
+                    {media => (
+                      <tr class="transition-colors hover:bg-primary/30 focus-within:bg-primary/30">
+                        <td class="min-w-56">{media.title}</td>
+                        <td>{media.type.name}</td>
+                        <td>
+                          <span class={`badge badge-sm ${media.isDisplay ? 'badge-success badge-soft' : 'badge-ghost'}`}>
+                            {media.isDisplay ? '表示する' : '表示しない'}
+                          </span>
+                        </td>
+                        <td>{media.format.name}</td>
+                        <td class="max-w-xl">
+                          <a href={media.url} target="_blank" rel="noreferrer" class="link link-hover break-all text-sm">
+                            {media.url}
+                          </a>
+                        </td>
+                        <td>
+                          <button type="button" class="btn btn-ghost btn-xs" disabled>
+                            編集
+                          </button>
+                        </td>
+                      </tr>
+                    )}
+                  </For>
+                )}
+              </Match>
+            </Switch>
+          </tbody>
+        </table>
+      </div>
+
+      <Show when={!data.loading && !fetchError() && (data()?.maxPage ?? 0) > 1}>
+        <div class="mt-4 flex justify-center">
+          <div class="join">
+            <For each={Array.from({ length: data()!.maxPage }, (_, index) => index + 1)}>
+              {p => (
+                <button
+                  class={`join-item btn btn-sm${p === page() ? ' btn-active' : ''}`}
+                  onClick={() => handlePageChange(p)}
+                >
+                  {p}
+                </button>
+              )}
+            </For>
+          </div>
+        </div>
+      </Show>
+    </>
+  );
+};

--- a/src/admin/src/components/media/SearchList.tsx
+++ b/src/admin/src/components/media/SearchList.tsx
@@ -254,7 +254,9 @@ export const SearchList = () => {
                   <For each={result().media}>
                     {media => (
                       <tr class="transition-colors hover:bg-primary/30 focus-within:bg-primary/30">
-                        <td class="min-w-56">{media.title}</td>
+                        <td class="min-w-44 max-w-56">
+                          <p class="truncate">{media.title}</p>
+                        </td>
                         <td>{media.type.name}</td>
                         <td>
                           <span class={`badge badge-sm ${media.isDisplay ? 'badge-success badge-soft' : 'badge-ghost'}`}>

--- a/src/admin/src/generated/types.gen.ts
+++ b/src/admin/src/generated/types.gen.ts
@@ -652,6 +652,9 @@ export type MediaServiceSearchMediaData = {
     path?: never;
     query?: {
         title?: string;
+        type?: MediaTypeValue;
+        format?: MediaFormatValue;
+        is_display?: boolean;
         page?: Page;
         per_page?: PerPage;
     };

--- a/src/admin/src/pages/media/index.astro
+++ b/src/admin/src/pages/media/index.astro
@@ -1,0 +1,12 @@
+---
+import { FlashMessage } from '../../components/Flash';
+import { SearchList } from '../../components/media/SearchList';
+import Layout from '../../layouts/Layout.astro';
+
+export const prerender = false;
+---
+
+<Layout pageTitle="Media一覧">
+  <FlashMessage client:only="solid-js" />
+  <SearchList client:only="solid-js" />
+</Layout>

--- a/src/admin/src/server/routes/media.ts
+++ b/src/admin/src/server/routes/media.ts
@@ -18,6 +18,9 @@ export const media = new Elysia({ prefix: '/media' })
           client,
           query: {
             title: query.title || undefined,
+            type: query.type as MediaTypeValue | undefined,
+            format: query.format as MediaFormatValue | undefined,
+            is_display: query.is_display,
             page: query.page ?? 1,
             per_page: (query.per_page ?? 25) as PerPage,
           },
@@ -27,6 +30,9 @@ export const media = new Elysia({ prefix: '/media' })
     {
       query: t.Object({
         title: t.Optional(t.String()),
+        type: t.Optional(t.Union([t.Literal('1'), t.Literal('2'), t.Literal('3'), t.Literal('4'), t.Literal('99')])),
+        format: t.Optional(t.Union([t.Literal('1'), t.Literal('2'), t.Literal('3'), t.Literal('4'), t.Literal('5'), t.Literal('99')])),
+        is_display: t.Optional(t.Boolean()),
         page: t.Optional(t.Number()),
         per_page: t.Optional(t.Number()),
       }),

--- a/src/contracts/generated/oas/IsekaiObservatory.Admin.v1.yaml
+++ b/src/contracts/generated/oas/IsekaiObservatory.Admin.v1.yaml
@@ -166,6 +166,24 @@ paths:
           schema:
             type: string
           explode: false
+        - name: type
+          in: query
+          required: false
+          schema:
+            $ref: '#/components/schemas/MediaTypeValue'
+          explode: false
+        - name: format
+          in: query
+          required: false
+          schema:
+            $ref: '#/components/schemas/MediaFormatValue'
+          explode: false
+        - name: is_display
+          in: query
+          required: false
+          schema:
+            type: boolean
+          explode: false
         - name: page
           in: query
           required: false

--- a/src/contracts/src/admin/media/service.tsp
+++ b/src/contracts/src/admin/media/service.tsp
@@ -14,6 +14,9 @@ interface MediaService {
   @route("/search")
   searchMedia(
     @query title?: string,
+    @query type?: MediaTypeValue,
+    @query format?: MediaFormatValue,
+    @query("is_display") isDisplay?: boolean,
     @query page?: page = 1,
     @query("per_page") perPage?: PerPage = PerPage.twentyFive,
   ): Ok<MediaSearchResponse> | Unauthorized | Forbidden | ServerError;

--- a/src/server/Generated/lib/Api/MediaApi.php
+++ b/src/server/Generated/lib/Api/MediaApi.php
@@ -423,6 +423,9 @@ class MediaApi
      * Operation mediaServiceSearchMedia
      *
      * @param  string|null $title title (optional)
+     * @param  \OpenAPI\Client\Model\MediaTypeValue|null $type type (optional)
+     * @param  \OpenAPI\Client\Model\MediaFormatValue|null $format format (optional)
+     * @param  bool|null $is_display is_display (optional)
      * @param  Int|null $page page (optional)
      * @param  \OpenAPIClientModelPerPage|null $per_page per_page (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['mediaServiceSearchMedia'] to see the possible values for this operation
@@ -431,9 +434,9 @@ class MediaApi
      * @throws \InvalidArgumentException
      * @return \OpenAPI\Client\Model\MediaSearchResponse
      */
-    public function mediaServiceSearchMedia($title = null, $page = null, $per_page = null, string $contentType = self::contentTypes['mediaServiceSearchMedia'][0])
+    public function mediaServiceSearchMedia($title = null, $type = null, $format = null, $is_display = null, $page = null, $per_page = null, string $contentType = self::contentTypes['mediaServiceSearchMedia'][0])
     {
-        list($response) = $this->mediaServiceSearchMediaWithHttpInfo($title, $page, $per_page, $contentType);
+        list($response) = $this->mediaServiceSearchMediaWithHttpInfo($title, $type, $format, $is_display, $page, $per_page, $contentType);
         return $response;
     }
 
@@ -441,6 +444,9 @@ class MediaApi
      * Operation mediaServiceSearchMediaWithHttpInfo
      *
      * @param  string|null $title (optional)
+     * @param  \OpenAPI\Client\Model\MediaTypeValue|null $type (optional)
+     * @param  \OpenAPI\Client\Model\MediaFormatValue|null $format (optional)
+     * @param  bool|null $is_display (optional)
      * @param  Int|null $page (optional)
      * @param  \OpenAPIClientModelPerPage|null $per_page (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['mediaServiceSearchMedia'] to see the possible values for this operation
@@ -449,9 +455,9 @@ class MediaApi
      * @throws \InvalidArgumentException
      * @return array of \OpenAPI\Client\Model\MediaSearchResponse, HTTP status code, HTTP response headers (array of strings)
      */
-    public function mediaServiceSearchMediaWithHttpInfo($title = null, $page = null, $per_page = null, string $contentType = self::contentTypes['mediaServiceSearchMedia'][0])
+    public function mediaServiceSearchMediaWithHttpInfo($title = null, $type = null, $format = null, $is_display = null, $page = null, $per_page = null, string $contentType = self::contentTypes['mediaServiceSearchMedia'][0])
     {
-        $request = $this->mediaServiceSearchMediaRequest($title, $page, $per_page, $contentType);
+        $request = $this->mediaServiceSearchMediaRequest($title, $type, $format, $is_display, $page, $per_page, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -526,6 +532,9 @@ class MediaApi
      * Operation mediaServiceSearchMediaAsync
      *
      * @param  string|null $title (optional)
+     * @param  \OpenAPI\Client\Model\MediaTypeValue|null $type (optional)
+     * @param  \OpenAPI\Client\Model\MediaFormatValue|null $format (optional)
+     * @param  bool|null $is_display (optional)
      * @param  Int|null $page (optional)
      * @param  \OpenAPIClientModelPerPage|null $per_page (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['mediaServiceSearchMedia'] to see the possible values for this operation
@@ -533,9 +542,9 @@ class MediaApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function mediaServiceSearchMediaAsync($title = null, $page = null, $per_page = null, string $contentType = self::contentTypes['mediaServiceSearchMedia'][0])
+    public function mediaServiceSearchMediaAsync($title = null, $type = null, $format = null, $is_display = null, $page = null, $per_page = null, string $contentType = self::contentTypes['mediaServiceSearchMedia'][0])
     {
-        return $this->mediaServiceSearchMediaAsyncWithHttpInfo($title, $page, $per_page, $contentType)
+        return $this->mediaServiceSearchMediaAsyncWithHttpInfo($title, $type, $format, $is_display, $page, $per_page, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -547,6 +556,9 @@ class MediaApi
      * Operation mediaServiceSearchMediaAsyncWithHttpInfo
      *
      * @param  string|null $title (optional)
+     * @param  \OpenAPI\Client\Model\MediaTypeValue|null $type (optional)
+     * @param  \OpenAPI\Client\Model\MediaFormatValue|null $format (optional)
+     * @param  bool|null $is_display (optional)
      * @param  Int|null $page (optional)
      * @param  \OpenAPIClientModelPerPage|null $per_page (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['mediaServiceSearchMedia'] to see the possible values for this operation
@@ -554,10 +566,10 @@ class MediaApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function mediaServiceSearchMediaAsyncWithHttpInfo($title = null, $page = null, $per_page = null, string $contentType = self::contentTypes['mediaServiceSearchMedia'][0])
+    public function mediaServiceSearchMediaAsyncWithHttpInfo($title = null, $type = null, $format = null, $is_display = null, $page = null, $per_page = null, string $contentType = self::contentTypes['mediaServiceSearchMedia'][0])
     {
         $returnType = '\OpenAPI\Client\Model\MediaSearchResponse';
-        $request = $this->mediaServiceSearchMediaRequest($title, $page, $per_page, $contentType);
+        $request = $this->mediaServiceSearchMediaRequest($title, $type, $format, $is_display, $page, $per_page, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -599,6 +611,9 @@ class MediaApi
      * Create request for operation 'mediaServiceSearchMedia'
      *
      * @param  string|null $title (optional)
+     * @param  \OpenAPI\Client\Model\MediaTypeValue|null $type (optional)
+     * @param  \OpenAPI\Client\Model\MediaFormatValue|null $format (optional)
+     * @param  bool|null $is_display (optional)
      * @param  Int|null $page (optional)
      * @param  \OpenAPIClientModelPerPage|null $per_page (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['mediaServiceSearchMedia'] to see the possible values for this operation
@@ -606,8 +621,11 @@ class MediaApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function mediaServiceSearchMediaRequest($title = null, $page = null, $per_page = null, string $contentType = self::contentTypes['mediaServiceSearchMedia'][0])
+    public function mediaServiceSearchMediaRequest($title = null, $type = null, $format = null, $is_display = null, $page = null, $per_page = null, string $contentType = self::contentTypes['mediaServiceSearchMedia'][0])
     {
+
+
+
 
 
 
@@ -625,6 +643,33 @@ class MediaApi
             $title,
             'title', // param base name
             'string', // openApiType
+            'form', // style
+            false, // explode
+            false // required
+        ) ?? []);
+        // query params
+        $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
+            $type,
+            'type', // param base name
+            'MediaTypeValue', // openApiType
+            'form', // style
+            false, // explode
+            false // required
+        ) ?? []);
+        // query params
+        $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
+            $format,
+            'format', // param base name
+            'MediaFormatValue', // openApiType
+            'form', // style
+            false, // explode
+            false // required
+        ) ?? []);
+        // query params
+        $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
+            $is_display,
+            'is_display', // param base name
+            'boolean', // openApiType
             'form', // style
             false, // explode
             false // required

--- a/src/server/app/Providers/Domain/MediaServiceProvider.php
+++ b/src/server/app/Providers/Domain/MediaServiceProvider.php
@@ -28,8 +28,8 @@ class MediaServiceProvider extends EnvServiceProvider
             $isDisplay = $request->query('is_display');
 
             return new SearchInputData(
-                $request->has('title') && is_string($title) ? $title : Arg::Optional,
-                $request->has('type') && is_scalar($type) ? (int)$type : Arg::Optional,
+                $request->has('title')  && is_string($title) ? $title : Arg::Optional,
+                $request->has('type')   && is_scalar($type) ? (int)$type : Arg::Optional,
                 $request->has('format') && is_scalar($format) ? (int)$format : Arg::Optional,
                 $request->has('is_display')
                     ? filter_var($isDisplay, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? false

--- a/src/server/app/Providers/Domain/MediaServiceProvider.php
+++ b/src/server/app/Providers/Domain/MediaServiceProvider.php
@@ -23,9 +23,17 @@ class MediaServiceProvider extends EnvServiceProvider
         $this->app->bind(SearchInputData::class, function (): SearchInputData {
             $request = $this->app->make(Request::class);
             $title = $request->query('title', '');
+            $type = $request->query('type');
+            $format = $request->query('format');
+            $isDisplay = $request->query('is_display');
 
             return new SearchInputData(
                 $request->has('title') && is_string($title) ? $title : Arg::Optional,
+                $request->has('type') && is_scalar($type) ? (int)$type : Arg::Optional,
+                $request->has('format') && is_scalar($format) ? (int)$format : Arg::Optional,
+                $request->has('is_display')
+                    ? filter_var($isDisplay, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? false
+                    : Arg::Optional,
                 (int)$request->query('page', 1),
                 PerPage::from((int)$request->query('per_page', PerPage::TwentyFive->value)),
             );

--- a/src/server/packages/Media/Application/UseCase/Search/SearchInputData.php
+++ b/src/server/packages/Media/Application/UseCase/Search/SearchInputData.php
@@ -11,6 +11,9 @@ readonly class SearchInputData
 {
     public function __construct(
         public Arg|string $title = Arg::Optional,
+        public Arg|int $type = Arg::Optional,
+        public Arg|int $format = Arg::Optional,
+        public Arg|bool $isDisplay = Arg::Optional,
         public int $page = 1,
         public PerPage $perPage = PerPage::TwentyFive,
     ) {

--- a/src/server/packages/Media/Application/UseCase/Search/SearchUseCase.php
+++ b/src/server/packages/Media/Application/UseCase/Search/SearchUseCase.php
@@ -6,7 +6,9 @@ namespace Media\Application\UseCase\Search;
 
 use AdminUser\Domain\Models\Permission;
 use Media\Domain\Criteria\MediaSearchCriteria;
+use Media\Domain\Models\MediaFormat;
 use Media\Domain\Models\MediaRepositoryInterface;
+use Media\Domain\Models\MediaType;
 use ResultType\Ok;
 use ResultType\Result;
 use Support\Optional\Arg;
@@ -41,6 +43,15 @@ readonly class SearchUseCase
             $inputData->title === Arg::Optional
                 ? new None()
                 : new Some($inputData->title),
+            $inputData->type === Arg::Optional
+                ? new None()
+                : new Some(MediaType::from($inputData->type)),
+            $inputData->format === Arg::Optional
+                ? new None()
+                : new Some(MediaFormat::from($inputData->format)),
+            $inputData->isDisplay === Arg::Optional
+                ? new None()
+                : new Some($inputData->isDisplay),
             $inputData->page,
             $inputData->perPage,
         );

--- a/src/server/packages/Media/Domain/Criteria/MediaSearchCriteria.php
+++ b/src/server/packages/Media/Domain/Criteria/MediaSearchCriteria.php
@@ -12,10 +12,10 @@ use Support\Optional\Optional;
 readonly class MediaSearchCriteria
 {
     /**
-     * @param Optional<string>    $title
-     * @param Optional<MediaType> $type
+     * @param Optional<string>      $title
+     * @param Optional<MediaType>   $type
      * @param Optional<MediaFormat> $format
-     * @param Optional<bool>      $isDisplay
+     * @param Optional<bool>        $isDisplay
      */
     public function __construct(
         public Optional $title,

--- a/src/server/packages/Media/Domain/Criteria/MediaSearchCriteria.php
+++ b/src/server/packages/Media/Domain/Criteria/MediaSearchCriteria.php
@@ -4,16 +4,24 @@ declare(strict_types=1);
 
 namespace Media\Domain\Criteria;
 
+use Media\Domain\Models\MediaFormat;
+use Media\Domain\Models\MediaType;
 use Support\Domain\SearchCriteria\PerPage;
 use Support\Optional\Optional;
 
 readonly class MediaSearchCriteria
 {
     /**
-     * @param Optional<string> $title
+     * @param Optional<string>    $title
+     * @param Optional<MediaType> $type
+     * @param Optional<MediaFormat> $format
+     * @param Optional<bool>      $isDisplay
      */
     public function __construct(
         public Optional $title,
+        public Optional $type,
+        public Optional $format,
+        public Optional $isDisplay,
         public int $page = 1,
         public PerPage $perPage = PerPage::TwentyFive,
     ) {

--- a/src/server/packages/Media/Infrastructures/MediaRepository.php
+++ b/src/server/packages/Media/Infrastructures/MediaRepository.php
@@ -92,6 +92,18 @@ readonly class MediaRepository implements MediaRepositoryInterface
             $query = $query->whereLike('title', '%' . $keyword . '%');
         }
 
+        if ($criteria->type->isPresent()) {
+            $query = $query->where('type', $criteria->type->get()->value);
+        }
+
+        if ($criteria->format->isPresent()) {
+            $query = $query->where('format', $criteria->format->get()->value);
+        }
+
+        if ($criteria->isDisplay->isPresent()) {
+            $query = $query->where('is_display', $criteria->isDisplay->get());
+        }
+
         return $query;
     }
 

--- a/src/server/tests/Feature/Api/Media/SearchMediaTest.php
+++ b/src/server/tests/Feature/Api/Media/SearchMediaTest.php
@@ -45,4 +45,27 @@ class SearchMediaTest extends DatabaseTestCase
             ->assertJsonPath('media.0.title', '描き続けた君へ MV')
             ->assertJsonPath('maxPage', 1);
     }
+
+    #[Test]
+    public function canSearchByTypeFormatAndDisplay(): void
+    {
+        $repository = $this->app->make(MediaRepository::class);
+        $repository->save($this->createMedia($this->generateUuid(), 'MV', 'https://example.com/mv', MediaType::Video, true, MediaFormat::Mv));
+        $repository->save($this->createMedia($this->generateUuid(), '切り抜き', 'https://example.com/clip', MediaType::Video, true, MediaFormat::LiveClip));
+        $repository->save($this->createMedia($this->generateUuid(), '記事', 'https://example.com/article', MediaType::Article, false, MediaFormat::Other));
+
+        $this->withAuth()
+            ->getJson(route('media.search', [
+                'type' => MediaType::Video->value,
+                'format' => MediaFormat::LiveClip->value,
+                'is_display' => 'true',
+            ]))
+            ->assertStatus(200)
+            ->assertJsonCount(1, 'media')
+            ->assertJsonPath('media.0.title', '切り抜き')
+            ->assertJsonPath('media.0.type.value', MediaType::Video->value)
+            ->assertJsonPath('media.0.format.value', MediaFormat::LiveClip->value)
+            ->assertJsonPath('media.0.isDisplay', true)
+            ->assertJsonPath('maxPage', 1);
+    }
 }


### PR DESCRIPTION
## 概要
- admin に Media 一覧ページを追加
- Media 検索 API に種別・形式・表示設定フィルタを追加
- 一覧の見た目を楽曲一覧に寄せ、編集ボタンを配置

## 変更内容
- `/media` 一覧ページと `SearchList` コンポーネントを追加
- サイドバーに Media 導線を追加
- contracts の `MediaService.searchMedia` に `type` / `format` / `is_display` query を追加
- server 側の `MediaSearchCriteria` / `SearchInputData` / `SearchUseCase` / `MediaRepository` を拡張
- Media 検索の feature test を追加

## 確認
- `docker compose exec php php artisan test tests/Feature/Api/Media/SearchMediaTest.php`
- `mise run admin:lint`
- `cd src/admin && bunx tsc --noEmit`
- `mise run api:phpstan`
