### PR TITLE
Media の RouteMap と文言を調整

### DIFF
--- a/src/admin/src/components/media/EditableForm.tsx
+++ b/src/admin/src/components/media/EditableForm.tsx
@@ -58,7 +58,7 @@ export const EditableForm = (props: Props) => {
     const mediaId = props.data?.media.mediaId;
 
     if (!mediaId) {
-      setFormError('更新対象のMedia IDを取得できませんでした');
+      setFormError('更新対象のメディアIDを取得できませんでした');
       return;
     }
 
@@ -97,7 +97,7 @@ export const EditableForm = (props: Props) => {
     const mediaId = props.data?.media.mediaId;
 
     if (!mediaId) {
-      setFormError('削除対象のMedia IDを取得できませんでした');
+      setFormError('削除対象のメディアIDを取得できませんでした');
       return;
     }
 
@@ -204,10 +204,10 @@ export const EditableForm = (props: Props) => {
 
         <fieldset class="rounded-box border border-error/20 bg-error/5 p-6">
           <legend class="px-2 text-sm font-semibold text-error">危険な操作</legend>
-          <p class="mt-1 text-sm text-base-content/60">この操作は取り消せません。楽曲に使用中のMediaは削除できません。</p>
+          <p class="mt-1 text-sm text-base-content/60">この操作は取り消せません。楽曲に使用中のメディアは削除できません。</p>
           <div class="mt-4">
             <button onClick={handleDelete} class="btn btn-outline btn-error btn-sm" disabled={isSubmitting()}>
-              {isSubmitting() ? '削除中...' : 'このMediaを削除する'}
+              {isSubmitting() ? '削除中...' : 'このメディアを削除する'}
             </button>
           </div>
         </fieldset>

--- a/src/admin/src/components/media/SearchList.tsx
+++ b/src/admin/src/components/media/SearchList.tsx
@@ -155,7 +155,7 @@ export const SearchList = () => {
             value={inputTitle()}
             onInput={e => setInputTitle(e.currentTarget.value)}
             class="input input-bordered input-sm"
-            placeholder="Media タイトルで検索"
+            placeholder="メディアタイトルで検索"
           />
         </fieldset>
         <fieldset class="fieldset">
@@ -247,7 +247,7 @@ export const SearchList = () => {
                 {message => <ListState state="error" colSpan={6} message={message()} onRetry={() => refetch()} />}
               </Match>
               <Match when={data() && data()!.media.length === 0}>
-                <ListState state="empty" colSpan={6} message="条件に一致する Media はありません。" />
+                <ListState state="empty" colSpan={6} message="条件に一致するメディアはありません。" />
               </Match>
               <Match when={data()}>
                 {result => (

--- a/src/admin/src/components/song/MediaSection.tsx
+++ b/src/admin/src/components/song/MediaSection.tsx
@@ -181,12 +181,12 @@ export const MediaSection = (props: Props) => {
 
   return (
     <fieldset class="fieldset bg-base-200 border-base-300 rounded-box border p-6">
-      <legend class="px-2 text-sm font-semibold text-base-content/70">Media</legend>
+      <legend class="px-2 text-sm font-semibold text-base-content/70">メディア</legend>
 
       <div class="grid gap-6 lg:grid-cols-[minmax(0,1.3fr)_minmax(0,1fr)]">
         <div class="space-y-4">
           <div>
-            <label class="label">既存 Media を検索</label>
+            <label class="label">既存メディアを検索</label>
             <div class="flex gap-2">
               <input
                 type="text"
@@ -231,7 +231,7 @@ export const MediaSection = (props: Props) => {
 
         <div class="space-y-3 rounded-box border border-base-300 bg-base-100 p-4">
           <div>
-            <label class="label">新規 Media 作成</label>
+            <label class="label">新規メディア作成</label>
             <input
               type="text"
               class="input input-bordered w-full"
@@ -288,10 +288,10 @@ export const MediaSection = (props: Props) => {
       </div>
 
       <div class="mt-6">
-        <label class="label">選択中の Media</label>
+        <label class="label">選択中のメディア</label>
         <Show
           when={props.entries().length > 0}
-          fallback={<p class="text-sm text-base-content/60">Media はまだ追加されていません。</p>}
+          fallback={<p class="text-sm text-base-content/60">メディアはまだ追加されていません。</p>}
         >
           <div class="space-y-3">
             <For each={props.entries()}>

--- a/src/admin/src/pages/media/[id].astro
+++ b/src/admin/src/pages/media/[id].astro
@@ -23,7 +23,7 @@ if (status === 401) {
 }
 ---
 
-<Layout pageTitle="Media詳細">
+<Layout pageTitle="メディア詳細">
   <div>
     <EditableForm data={data ?? undefined} status={status} client:only="solid-js" />
   </div>

--- a/src/admin/src/pages/media/index.astro
+++ b/src/admin/src/pages/media/index.astro
@@ -6,7 +6,7 @@ import Layout from '../../layouts/Layout.astro';
 export const prerender = false;
 ---
 
-<Layout pageTitle="Media一覧">
+<Layout pageTitle="メディア一覧">
   <FlashMessage client:only="solid-js" />
   <SearchList client:only="solid-js" />
 </Layout>

--- a/src/server/packages/AdminUser/Domain/Models/Permission.php
+++ b/src/server/packages/AdminUser/Domain/Models/Permission.php
@@ -31,8 +31,8 @@ enum Permission: string
             self::WritePerson => '人物編集',
             self::ReadSong => '楽曲閲覧',
             self::WriteSong => '楽曲編集',
-            self::ReadMedia => 'Media閲覧',
-            self::WriteMedia => 'Media編集',
+            self::ReadMedia => 'メディア閲覧',
+            self::WriteMedia => 'メディア編集',
         };
     }
 }

--- a/src/server/packages/Media/Application/UseCase/Delete/DeleteUseCase.php
+++ b/src/server/packages/Media/Application/UseCase/Delete/DeleteUseCase.php
@@ -41,7 +41,7 @@ readonly class DeleteUseCase
             ->mapErr(fn (): UseCaseError => new InvalidInputError(['mediaId' => ['IDが不正です']]))
             ->andThen(function (MediaId $mediaId): Result {
                 if ($this->repository->isUsed($mediaId)) {
-                    return new Err(new BusinessLogicError('このMediaは楽曲に使用されているため削除できません'));
+                    return new Err(new BusinessLogicError('このメディアは楽曲に使用されているため削除できません'));
                 }
 
                 $this->repository->delete($mediaId);

--- a/src/server/packages/Media/Route/MediaRouteMap.php
+++ b/src/server/packages/Media/Route/MediaRouteMap.php
@@ -8,5 +8,11 @@ enum MediaRouteMap: string
 {
     case Create = 'media.create';
 
+    case Get = 'media.get';
+
     case Search = 'media.search';
+
+    case Update = 'media.update';
+
+    case Delete = 'media.delete';
 }

--- a/src/server/routes/admin.php
+++ b/src/server/routes/admin.php
@@ -34,6 +34,7 @@ use App\Http\Middleware\OpenApiValidator;
 use Auth\Route\AuthRouteMap;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
+use Media\Route\MediaRouteMap;
 use Person\Route\PersonRouteMap;
 use Song\Route\SongRouteMap;
 use Song\Route\SongTypeRouteMap;
@@ -66,11 +67,11 @@ Route::middleware(OpenApiValidator::class)->group(function () {
                 });
 
                 Route::prefix('media')->group(function () {
-                    Route::post('/', [CreateMediaController::class, 'handle'])->name('media.create');
-                    Route::delete('/{mediaId}', [DeleteMediaController::class, 'handle'])->name('media.delete');
-                    Route::put('/{mediaId}', [UpdateMediaController::class, 'handle'])->name('media.update');
-                    Route::get('/search', [SearchMediaController::class, 'handle'])->name('media.search');
-                    Route::get('/{mediaId}', [GetMediaController::class, 'handle'])->name('media.get');
+                    Route::post('/', [CreateMediaController::class, 'handle'])->name(MediaRouteMap::Create);
+                    Route::delete('/{mediaId}', [DeleteMediaController::class, 'handle'])->name(MediaRouteMap::Delete);
+                    Route::put('/{mediaId}', [UpdateMediaController::class, 'handle'])->name(MediaRouteMap::Update);
+                    Route::get('/search', [SearchMediaController::class, 'handle'])->name(MediaRouteMap::Search);
+                    Route::get('/{mediaId}', [GetMediaController::class, 'handle'])->name(MediaRouteMap::Get);
                 });
 
                 Route::prefix('songs')->group(function () {

--- a/src/server/tests/Feature/Api/Media/CreateMediaTest.php
+++ b/src/server/tests/Feature/Api/Media/CreateMediaTest.php
@@ -7,6 +7,7 @@ namespace Tests\Feature\Api\Media;
 use Illuminate\Testing\Fluent\AssertableJson;
 use Media\Domain\Models\MediaFormat;
 use Media\Domain\Models\MediaType;
+use Media\Route\MediaRouteMap;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\Feature\Api\WithAuth;
 use Tests\Support\DatabaseTestCase;
@@ -19,7 +20,7 @@ class CreateMediaTest extends DatabaseTestCase
     public function canCreate(): void
     {
         $this->withAuth()
-            ->postJson(route('media.create'), [
+            ->postJson(route(MediaRouteMap::Create), [
                 'title' => '描き続けた君へ MV',
                 'url' => 'https://example.com/media',
                 'typeValue' => MediaType::Video->value,

--- a/src/server/tests/Feature/Api/Media/DeleteMediaTest.php
+++ b/src/server/tests/Feature/Api/Media/DeleteMediaTest.php
@@ -7,6 +7,7 @@ namespace Tests\Feature\Api\Media;
 use Media\Domain\Models\MediaFormat;
 use Media\Domain\Models\MediaType;
 use Media\Infrastructures\MediaRepository;
+use Media\Route\MediaRouteMap;
 use PHPUnit\Framework\Attributes\Test;
 use Song\Domain\Models\SongType;
 use Song\Infrastructures\SongRepository;
@@ -29,7 +30,7 @@ class DeleteMediaTest extends DatabaseTestCase
         $repository->save($media);
 
         $this->withAuth()
-            ->delete(route('media.delete', $uuid))
+            ->delete(route(MediaRouteMap::Delete, $uuid))
             ->assertStatus(204);
 
         $this->assertNull($repository->find($media->mediaId));
@@ -63,10 +64,10 @@ class DeleteMediaTest extends DatabaseTestCase
         );
 
         $this->withAuth()
-            ->delete(route('media.delete', $mediaId))
+            ->delete(route(MediaRouteMap::Delete, $mediaId))
             ->assertStatus(400)
             ->assertExactJson([
-                'message' => 'このMediaは楽曲に使用されているため削除できません',
+                'message' => 'このメディアは楽曲に使用されているため削除できません',
             ]);
 
         $this->assertNotNull($repository->find($media->mediaId));
@@ -76,7 +77,7 @@ class DeleteMediaTest extends DatabaseTestCase
     public function canDeleteEvenIfTargetDoesNotExist(): void
     {
         $this->withAuth()
-            ->delete(route('media.delete', 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'))
+            ->delete(route(MediaRouteMap::Delete, 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'))
             ->assertStatus(204);
     }
 }

--- a/src/server/tests/Feature/Api/Media/GetMediaTest.php
+++ b/src/server/tests/Feature/Api/Media/GetMediaTest.php
@@ -7,6 +7,7 @@ namespace Tests\Feature\Api\Media;
 use Media\Domain\Models\MediaFormat;
 use Media\Domain\Models\MediaType;
 use Media\Infrastructures\MediaRepository;
+use Media\Route\MediaRouteMap;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\Feature\Api\WithAuth;
 use Tests\Support\DatabaseTestCase;
@@ -35,7 +36,7 @@ class GetMediaTest extends DatabaseTestCase
         );
 
         $this->withAuth()
-            ->getJson(route('media.get', $uuid))
+            ->getJson(route(MediaRouteMap::Get, $uuid))
             ->assertStatus(200)
             ->assertExactJson([
                 'media' => [
@@ -59,7 +60,7 @@ class GetMediaTest extends DatabaseTestCase
     public function notFound(): void
     {
         $this->withAuth()
-            ->getJson(route('media.get', $this->generateUuid()))
+            ->getJson(route(MediaRouteMap::Get, $this->generateUuid()))
             ->assertStatus(404);
     }
 }

--- a/src/server/tests/Feature/Api/Media/SearchMediaTest.php
+++ b/src/server/tests/Feature/Api/Media/SearchMediaTest.php
@@ -7,6 +7,7 @@ namespace Tests\Feature\Api\Media;
 use Media\Domain\Models\MediaFormat;
 use Media\Domain\Models\MediaType;
 use Media\Infrastructures\MediaRepository;
+use Media\Route\MediaRouteMap;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\Feature\Api\WithAuth;
 use Tests\Support\DatabaseTestCase;
@@ -25,7 +26,7 @@ class SearchMediaTest extends DatabaseTestCase
         $repository->save($this->createMedia($this->generateUuid(), '別の動画', 'https://example.com/other', MediaType::Article, true, MediaFormat::Other));
 
         $this->withAuth()
-            ->getJson(route('media.search', ['title' => '描き続けた君へ']))
+            ->getJson(route(MediaRouteMap::Search, ['title' => '描き続けた君へ']))
             ->assertStatus(200)
             ->assertJsonCount(1, 'media')
             ->assertJsonPath('media.0.title', '描き続けた君へ MV')
@@ -39,7 +40,7 @@ class SearchMediaTest extends DatabaseTestCase
         $repository->save($this->createMedia($this->generateUuid(), '描き続けた君へ MV', 'https://example.com/mv', MediaType::Video, true, MediaFormat::Mv));
 
         $this->withAuth()
-            ->getJson(route('media.search', ['per_page' => 25]))
+            ->getJson(route(MediaRouteMap::Search, ['per_page' => 25]))
             ->assertStatus(200)
             ->assertJsonCount(1, 'media')
             ->assertJsonPath('media.0.title', '描き続けた君へ MV')
@@ -55,7 +56,7 @@ class SearchMediaTest extends DatabaseTestCase
         $repository->save($this->createMedia($this->generateUuid(), '記事', 'https://example.com/article', MediaType::Article, false, MediaFormat::Other));
 
         $this->withAuth()
-            ->getJson(route('media.search', [
+            ->getJson(route(MediaRouteMap::Search, [
                 'type' => MediaType::Video->value,
                 'format' => MediaFormat::LiveClip->value,
                 'is_display' => 'true',

--- a/src/server/tests/Feature/Api/Media/UpdateMediaTest.php
+++ b/src/server/tests/Feature/Api/Media/UpdateMediaTest.php
@@ -8,6 +8,7 @@ use Illuminate\Testing\Fluent\AssertableJson;
 use Media\Domain\Models\MediaFormat;
 use Media\Domain\Models\MediaType;
 use Media\Infrastructures\MediaRepository;
+use Media\Route\MediaRouteMap;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\Feature\Api\WithAuth;
 use Tests\Support\DatabaseTestCase;
@@ -36,7 +37,7 @@ class UpdateMediaTest extends DatabaseTestCase
         );
 
         $this->withAuth()
-            ->putJson(route('media.update', $uuid), [
+            ->putJson(route(MediaRouteMap::Update, $uuid), [
                 'title' => '描き続けた君へ 配信アーカイブ',
                 'url' => 'https://example.com/archive',
                 'typeValue' => MediaType::SocialPost->value,
@@ -80,7 +81,7 @@ class UpdateMediaTest extends DatabaseTestCase
         );
 
         $this->withAuth()
-            ->putJson(route('media.update', $routeMediaId), [
+            ->putJson(route(MediaRouteMap::Update, $routeMediaId), [
                 'mediaId' => $bodyMediaId,
                 'title' => '描き続けた君へ 配信アーカイブ',
                 'url' => 'https://example.com/archive',
@@ -109,7 +110,7 @@ class UpdateMediaTest extends DatabaseTestCase
         );
 
         $this->withAuth()
-            ->putJson(route('media.update', $uuid), [
+            ->putJson(route(MediaRouteMap::Update, $uuid), [
                 'title' => '',
                 'url' => '',
                 'typeValue' => 0,


### PR DESCRIPTION
## 概要
- Media の route 名を MediaRouteMap 経由に統一
- UI とエラーメッセージの Media 表記をメディアに統一

## 確認
- docker compose exec php php artisan test tests/Feature/Api/Media
- mise run admin:lint
- cd src/admin && bunx tsc --noEmit
- mise run api:phpstan