### PR TITLE
楽曲フォームのメディア選択導線を強化

### DIFF
--- a/src/admin/src/components/song/MediaSection.tsx
+++ b/src/admin/src/components/song/MediaSection.tsx
@@ -19,6 +19,7 @@ interface Props {
 }
 
 type DisplayFilter = '' | 'true' | 'false';
+type PerPage = 25 | 50 | 100;
 
 const mediaFormatOptions: Array<{ value: MediaFormatValue; label: string }> = [
   { value: 1, label: 'MV' },
@@ -36,6 +37,8 @@ const mediaTypeOptions: Array<{ value: MediaTypeValue; label: string }> = [
   { value: 4, label: '公式ページ' },
   { value: 99, label: 'その他' },
 ];
+
+const perPageOptions: PerPage[] = [25, 50, 100];
 
 const mergeMedia = (current: Media[], incoming: Media[]): Media[] => {
   const map = new Map(current.map(item => [item.mediaId, item]));
@@ -73,6 +76,9 @@ export const MediaSection = (props: Props) => {
   const [searchTypeValue, setSearchTypeValue] = createSignal<'' | `${MediaTypeValue}`>('');
   const [searchFormatValue, setSearchFormatValue] = createSignal<'' | `${MediaFormatValue}`>('');
   const [searchIsDisplay, setSearchIsDisplay] = createSignal<DisplayFilter>('');
+  const [searchPage, setSearchPage] = createSignal(1);
+  const [searchPerPage, setSearchPerPage] = createSignal<PerPage>(50);
+  const [searchMaxPage, setSearchMaxPage] = createSignal(1);
   const [searching, setSearching] = createSignal(false);
   const [searchResults, setSearchResults] = createSignal<Media[]>([]);
   const [searchError, setSearchError] = createSignal<string | null>(null);
@@ -87,6 +93,49 @@ export const MediaSection = (props: Props) => {
   const [createError, setCreateError] = createSignal<string | null>(null);
 
   const selectedIds = () => new Set(props.entries().map(entry => entry.mediaId));
+  const allKnownMedia = () => mergeMedia(props.availableMedia(), searchResults());
+
+  const normalize = (value: string) => value.trim().toLocaleLowerCase('ja');
+
+  const buildMediaDetailUrl = (mediaId: string) => `/media/${mediaId}`;
+
+  const duplicateCandidates = () => {
+    const title = normalize(createTitle());
+    const url = normalize(createUrl());
+
+    if (title === '' && url === '') {
+      return [];
+    }
+
+    return allKnownMedia()
+      .map((item) => {
+        const itemTitle = normalize(item.title);
+        const itemUrl = normalize(item.url);
+        const reasons: string[] = [];
+
+        if (url !== '' && itemUrl === url) {
+          reasons.push('同じURL');
+        }
+
+        if (title.length >= 3 && itemTitle !== '') {
+          if (itemTitle === title) {
+            reasons.push('同じタイトル');
+          } else if (itemTitle.includes(title) || title.includes(itemTitle)) {
+            reasons.push('類似タイトル');
+          }
+        }
+
+        if (reasons.length === 0) {
+          return null;
+        }
+
+        return { item, reasons };
+      })
+      .filter((entry): entry is { item: Media; reasons: string[] } => entry !== null)
+      .slice(0, 5);
+  };
+
+  const hasExactUrlDuplicate = () => duplicateCandidates().some(entry => entry.reasons.includes('同じURL'));
 
   const addEntry = (media: Media) => {
     if (selectedIds().has(media.mediaId)) {
@@ -119,10 +168,11 @@ export const MediaSection = (props: Props) => {
     });
   };
 
-  const handleSearch = async () => {
+  const handleSearch = async (page = 1) => {
     setSearchError(null);
     setSearching(true);
     setHasSearched(true);
+    setSearchPage(page);
 
     const { data, error, status } = await client.api.media.search.get({
       query: {
@@ -130,7 +180,8 @@ export const MediaSection = (props: Props) => {
         type: searchTypeValue() || undefined,
         format: searchFormatValue() || undefined,
         is_display: searchIsDisplay() === '' ? undefined : searchIsDisplay() === 'true',
-        per_page: 25,
+        page,
+        per_page: searchPerPage(),
       },
     });
 
@@ -142,6 +193,7 @@ export const MediaSection = (props: Props) => {
     }
 
     setSearchResults(data.media);
+    setSearchMaxPage(data.maxPage);
     props.setAvailableMedia(prev => mergeMedia(prev, data.media));
   };
 
@@ -150,6 +202,9 @@ export const MediaSection = (props: Props) => {
     setSearchTypeValue('');
     setSearchFormatValue('');
     setSearchIsDisplay('');
+    setSearchPage(1);
+    setSearchPerPage(50);
+    setSearchMaxPage(1);
     setSearchError(null);
     setHasSearched(false);
     setSearchResults([]);
@@ -168,6 +223,11 @@ export const MediaSection = (props: Props) => {
 
     if (url === '') {
       setCreateError('URLを入力してください');
+      return;
+    }
+
+    if (hasExactUrlDuplicate()) {
+      setCreateError('同じURLの既存メディアがあります。既存メディアの追加を検討してください');
       return;
     }
 
@@ -243,10 +303,18 @@ export const MediaSection = (props: Props) => {
                 <option value="true">表示する</option>
                 <option value="false">表示しない</option>
               </select>
+
+              <select
+                class="select select-bordered w-full"
+                value={searchPerPage()}
+                onChange={e => setSearchPerPage(Number(e.currentTarget.value) as PerPage)}
+              >
+                <For each={perPageOptions}>{option => <option value={option}>{option}件表示</option>}</For>
+              </select>
             </div>
 
             <div class="mt-3 flex gap-2">
-              <button type="button" class="btn btn-outline" disabled={searching()} onClick={handleSearch}>
+              <button type="button" class="btn btn-outline" disabled={searching()} onClick={() => void handleSearch()}>
                 {searching() ? '検索中...' : '検索'}
               </button>
               <button type="button" class="btn btn-ghost" disabled={searching()} onClick={handleResetSearch}>
@@ -261,6 +329,29 @@ export const MediaSection = (props: Props) => {
               when={candidateResults().length > 0}
               fallback={<p class="text-sm text-base-content/60">{hasSearched() ? '条件に一致するメディアはありません。' : '候補のメディアはまだありません。'}</p>}
             >
+              <div class="mb-2 flex items-center justify-between text-xs text-base-content/60">
+                <p>{hasSearched() ? `${searchPage()} / ${searchMaxPage()} ページ` : `${candidateResults().length} 件の候補を表示中`}</p>
+                <Show when={hasSearched() && searchMaxPage() > 1}>
+                  <div class="flex gap-2">
+                    <button
+                      type="button"
+                      class="btn btn-ghost btn-xs"
+                      disabled={searching() || searchPage() <= 1}
+                      onClick={() => void handleSearch(searchPage() - 1)}
+                    >
+                      前へ
+                    </button>
+                    <button
+                      type="button"
+                      class="btn btn-ghost btn-xs"
+                      disabled={searching() || searchPage() >= searchMaxPage()}
+                      onClick={() => void handleSearch(searchPage() + 1)}
+                    >
+                      次へ
+                    </button>
+                  </div>
+                </Show>
+              </div>
               <For each={candidateResults()}>
                 {item => (
                   <div class="rounded-box border border-base-300 bg-base-100 p-3">
@@ -277,14 +368,24 @@ export const MediaSection = (props: Props) => {
                           {item.url}
                         </a>
                       </div>
-                      <button
-                        type="button"
-                        class="btn btn-xs btn-primary"
-                        disabled={selectedIds().has(item.mediaId)}
-                        onClick={() => addEntry(item)}
-                      >
-                        {selectedIds().has(item.mediaId) ? '追加済み' : '追加'}
-                      </button>
+                      <div class="flex flex-col items-end gap-2">
+                        <a
+                          href={buildMediaDetailUrl(item.mediaId)}
+                          target="_blank"
+                          rel="noreferrer"
+                          class="btn btn-ghost btn-xs"
+                        >
+                          詳細
+                        </a>
+                        <button
+                          type="button"
+                          class="btn btn-xs btn-primary"
+                          disabled={selectedIds().has(item.mediaId)}
+                          onClick={() => addEntry(item)}
+                        >
+                          {selectedIds().has(item.mediaId) ? '追加済み' : '追加'}
+                        </button>
+                      </div>
                     </div>
                   </div>
                 )}
@@ -314,6 +415,47 @@ export const MediaSection = (props: Props) => {
               placeholder="https://example.com/media"
             />
           </div>
+
+          <Show when={duplicateCandidates().length > 0}>
+            <div class="rounded-box border border-warning/40 bg-warning/10 p-3">
+              <p class="text-sm font-medium text-warning-content">重複候補があります</p>
+              <div class="mt-2 space-y-2">
+                <For each={duplicateCandidates()}>
+                  {candidate => (
+                    <div class="rounded-box bg-base-100 p-3">
+                      <div class="flex items-start justify-between gap-3">
+                        <div class="min-w-0">
+                          <div class="flex items-center gap-2">
+                            <p class="truncate text-sm font-medium">{candidate.item.title}</p>
+                            <For each={candidate.reasons}>
+                              {reason => <span class="badge badge-warning badge-sm badge-outline">{reason}</span>}
+                            </For>
+                          </div>
+                          <p class="text-xs text-base-content/60">{candidate.item.type.name} / {candidate.item.format.name}</p>
+                          <a href={candidate.item.url} target="_blank" rel="noreferrer" class="link link-hover break-all text-xs">
+                            {candidate.item.url}
+                          </a>
+                        </div>
+                        <div class="flex flex-col items-end gap-2">
+                          <a
+                            href={buildMediaDetailUrl(candidate.item.mediaId)}
+                            target="_blank"
+                            rel="noreferrer"
+                            class="btn btn-ghost btn-xs"
+                          >
+                            詳細
+                          </a>
+                          <button type="button" class="btn btn-primary btn-xs" disabled={selectedIds().has(candidate.item.mediaId)} onClick={() => addEntry(candidate.item)}>
+                            {selectedIds().has(candidate.item.mediaId) ? '追加済み' : '既存を追加'}
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  )}
+                </For>
+              </div>
+            </div>
+          </Show>
 
           <div class="grid gap-3 md:grid-cols-2">
             <select
@@ -371,6 +513,14 @@ export const MediaSection = (props: Props) => {
                     </div>
 
                     <div class="flex items-center gap-2">
+                      <a
+                        href={buildMediaDetailUrl(entry.mediaId)}
+                        target="_blank"
+                        rel="noreferrer"
+                        class="btn btn-ghost btn-xs"
+                      >
+                        詳細
+                      </a>
                       <button type="button" class="btn btn-ghost btn-xs" onClick={() => moveEntry(index(), -1)} disabled={index() === 0}>
                         ↑
                       </button>

--- a/src/admin/src/server/routes/songs.ts
+++ b/src/admin/src/server/routes/songs.ts
@@ -30,7 +30,7 @@ export const songs = new Elysia({ prefix: '/songs' })
         personServiceListPersons({ client }),
         songTypeServiceListSongTypes({ client }),
         songTagServiceListSongTags({ client }),
-        mediaServiceSearchMedia({ client, query: { per_page: 25 } }),
+        mediaServiceSearchMedia({ client, query: { per_page: 50 } }),
       ]);
 
       return {
@@ -88,7 +88,7 @@ export const songs = new Elysia({ prefix: '/songs' })
           personServiceListPersons({ client }),
           songTypeServiceListSongTypes({ client }),
           songTagServiceListSongTags({ client }),
-          mediaServiceSearchMedia({ client, query: { per_page: 25 } }),
+          mediaServiceSearchMedia({ client, query: { per_page: 50 } }),
         ]);
 
         return {


### PR DESCRIPTION
## 概要
- 楽曲フォームのメディア検索に表示件数とページ移動を追加
- メディア候補と選択中メディアから詳細画面へ移動できるように変更
- 新規メディア作成前に URL とタイトルの重複候補を表示
- 同じ URL の既存メディアがある場合は新規作成を止めて既存利用を促す
- create/edit フォームの初期メディア preload 件数を 50 件に増加

## 確認
- mise run admin:lint
- cd src/admin && bunx tsc --noEmit