### PR TITLE
Song/Media のクエリ読み込みを整理

### DIFF
--- a/src/server/app/Models/Song/Song.php
+++ b/src/server/app/Models/Song/Song.php
@@ -45,7 +45,6 @@ class Song extends Model
     protected $with = [
         'persons',
         'taggings',
-        'songMediaLinks',
     ];
 
     #[Override]

--- a/src/server/packages/Media/Infrastructures/MediaDetailQueryService.php
+++ b/src/server/packages/Media/Infrastructures/MediaDetailQueryService.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace Media\Infrastructures;
 
-use App\Models\Song\SongMediaLink as ModelsSongMediaLink;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 use Media\Application\Query\MediaDetailQueryServiceInterface;
 use Media\Application\Query\MediaReferencedSong;
 use Media\Domain\Models\MediaId;
@@ -20,20 +21,26 @@ readonly class MediaDetailQueryService implements MediaDetailQueryServiceInterfa
     #[Override]
     public function findReferencedSongs(MediaId $mediaId): array
     {
+        /** @var Collection<int, object{song_id: string, title: string, song_order_no: int, media_order_no: int}> $rows */
+        $rows = DB::table('song_media_links')
+            ->join('songs', 'song_media_links.song_id', '=', 'songs.song_id')
+            ->where('media_id', $this->converter->toBin($mediaId->value))
+            ->orderBy('songs.order_no')
+            ->orderBy('song_media_links.order_no')
+            ->get([
+                'song_media_links.song_id',
+                'songs.title',
+                'songs.order_no as song_order_no',
+                'song_media_links.order_no as media_order_no',
+            ]);
+
         return array_values(
-            ModelsSongMediaLink::query()
-                ->with('song')
-                ->where('media_id', $this->converter->toBin($mediaId->value))
-                ->get()
-                ->sortBy([
-                    fn (ModelsSongMediaLink $link): int => $link->song->order_no,
-                    fn (ModelsSongMediaLink $link): int => $link->order_no,
-                ])
-                ->map(fn (ModelsSongMediaLink $link): MediaReferencedSong => new MediaReferencedSong(
-                    $this->converter->toUuid($link->song_id),
-                    $link->song->title,
-                    $link->song->order_no,
-                    $link->order_no,
+            $rows
+                ->map(fn (object $row): MediaReferencedSong => new MediaReferencedSong(
+                    $this->converter->toUuid($row->song_id),
+                    $row->title,
+                    $row->song_order_no,
+                    $row->media_order_no,
                 ))
                 ->all(),
         );

--- a/src/server/packages/Song/Infrastructures/SongRepository.php
+++ b/src/server/packages/Song/Infrastructures/SongRepository.php
@@ -30,6 +30,7 @@ readonly class SongRepository implements SongRepositoryInterface
     public function find(SongId $songId): ?Song
     {
         $found = ModelsSong::query()
+            ->with('songMediaLinks')
             ->where('song_id', $this->converter->toBin($songId->value))
             ->first();
 


### PR DESCRIPTION
## 概要
- Song 一覧/検索で不要な songMediaLinks の eager load を避けるように変更
- Song 詳細取得だけ songMediaLinks を明示 eager load するように変更
- Media 詳細の参照楽曲取得を SQL の join / order by に寄せ、PHP 側の sortBy() を削除

## 確認
- mise run api:phpstan packages/Media/Infrastructures/MediaDetailQueryService.php