### PR TITLE
media の監査ログ取得に対応

### DIFF
--- a/src/admin/src/components/audit-log/DetailView.tsx
+++ b/src/admin/src/components/audit-log/DetailView.tsx
@@ -12,6 +12,7 @@ const ACTION_LABEL: Record<string, string> = {
 
 const TARGET_TYPE_LABEL: Record<string, string> = {
   AdminUser: '管理ユーザー',
+  Media: 'メディア',
   Person: '人物',
   Song: '楽曲',
   SongTag: '楽曲タグ',

--- a/src/admin/src/components/audit-log/SearchList.tsx
+++ b/src/admin/src/components/audit-log/SearchList.tsx
@@ -14,7 +14,7 @@ type TargetType = AuditTargetType;
 // 型注釈で完全性を担保し、生成型に値が増減したらコンパイルエラーで気付ける形にする。
 const ACTION_OPTIONS = ['create', 'update', 'delete', 'login', 'refresh'] as const satisfies readonly Action[];
 
-const TARGET_TYPE_OPTIONS = ['AdminUser', 'Person', 'Song', 'SongTag'] as const satisfies readonly TargetType[];
+const TARGET_TYPE_OPTIONS = ['AdminUser', 'Media', 'Person', 'Song', 'SongTag'] as const satisfies readonly TargetType[];
 
 const ACTION_LABEL: Record<Action, string> = {
   create: '作成',
@@ -26,6 +26,7 @@ const ACTION_LABEL: Record<Action, string> = {
 
 const TARGET_TYPE_LABEL: Record<TargetType, string> = {
   AdminUser: '管理ユーザー',
+  Media: 'メディア',
   Person: '人物',
   Song: '楽曲',
   SongTag: '楽曲タグ',

--- a/src/admin/src/generated/types.gen.ts
+++ b/src/admin/src/generated/types.gen.ts
@@ -66,7 +66,7 @@ export type AuditLogSummary = {
 /**
  * 監査ログの対象種別
  */
-export type AuditTargetType = 'AdminUser' | 'Person' | 'Song' | 'SongTag';
+export type AuditTargetType = 'AdminUser' | 'Media' | 'Person' | 'Song' | 'SongTag';
 
 export type ErrorResponse = {
     message: string;

--- a/src/admin/src/server/routes/audit-logs.ts
+++ b/src/admin/src/server/routes/audit-logs.ts
@@ -18,6 +18,7 @@ const AuditActionSchema = t.Union([
 
 const AuditTargetTypeSchema = t.Union([
   t.Literal('AdminUser'),
+  t.Literal('Media'),
   t.Literal('Person'),
   t.Literal('Song'),
   t.Literal('SongTag'),

--- a/src/contracts/generated/oas/IsekaiObservatory.Admin.v1.yaml
+++ b/src/contracts/generated/oas/IsekaiObservatory.Admin.v1.yaml
@@ -1413,6 +1413,7 @@ components:
       type: string
       enum:
         - AdminUser
+        - Media
         - Person
         - Song
         - SongTag

--- a/src/contracts/src/admin/audit-logs/domain.tsp
+++ b/src/contracts/src/admin/audit-logs/domain.tsp
@@ -17,6 +17,7 @@ enum AuditAction {
 @doc("監査ログの対象種別")
 enum AuditTargetType {
   adminUser: "AdminUser",
+  media: "Media",
   person: "Person",
   song: "Song",
   songTag: "SongTag",

--- a/src/server/Generated/lib/Model/AuditTargetType.php
+++ b/src/server/Generated/lib/Model/AuditTargetType.php
@@ -45,6 +45,8 @@ enum AuditTargetType: string
      */
     case ADMIN_USER = 'AdminUser';
 
+    case MEDIA = 'Media';
+
     case PERSON = 'Person';
 
     case SONG = 'Song';

--- a/src/server/packages/Media/Application/UseCase/Create/CreateUseCase.php
+++ b/src/server/packages/Media/Application/UseCase/Create/CreateUseCase.php
@@ -15,6 +15,9 @@ use Support\Contracts\TransactionInterface;
 use Support\Domain\Error\DomainError;
 use Support\Domain\Error\DomainValidationError;
 use Support\Domain\Error\EntityRuleViolationError;
+use Support\UseCase\AuditLog\AuditAction;
+use Support\UseCase\AuditLog\AuditLogRecorderInterface;
+use Support\UseCase\AuditLog\AuditTargetType;
 use Support\UseCase\Authorizer\UseCaseAuthorizer;
 use Support\UseCase\Error\InvalidInputError;
 use Support\UseCase\Error\UseCaseError;
@@ -26,6 +29,7 @@ readonly class CreateUseCase
         private TransactionInterface $transaction,
         private MediaRepositoryInterface $repository,
         private MediaIntegrityService $service,
+        private AuditLogRecorderInterface $recorder,
     ) {
     }
 
@@ -57,6 +61,13 @@ readonly class CreateUseCase
             }
 
             $media = $this->repository->save($result->unwrap());
+
+            $this->recorder->record(
+                AuditAction::Create,
+                AuditTargetType::Media,
+                $media->mediaId,
+                $media->toArray(),
+            );
 
             return new Ok(new CreateOutputData($media));
         });

--- a/src/server/packages/Media/Application/UseCase/Delete/DeleteUseCase.php
+++ b/src/server/packages/Media/Application/UseCase/Delete/DeleteUseCase.php
@@ -10,6 +10,10 @@ use Media\Domain\Models\MediaRepositoryInterface;
 use ResultType\Err;
 use ResultType\Ok;
 use ResultType\Result;
+use Support\Contracts\TransactionInterface;
+use Support\UseCase\AuditLog\AuditAction;
+use Support\UseCase\AuditLog\AuditLogRecorderInterface;
+use Support\UseCase\AuditLog\AuditTargetType;
 use Support\UseCase\Authorizer\UseCaseAuthorizer;
 use Support\UseCase\Error\BusinessLogicError;
 use Support\UseCase\Error\InvalidInputError;
@@ -19,7 +23,9 @@ readonly class DeleteUseCase
 {
     public function __construct(
         private UseCaseAuthorizer $authorizer,
+        private TransactionInterface $transaction,
         private MediaRepositoryInterface $repository,
+        private AuditLogRecorderInterface $recorder,
     ) {
     }
 
@@ -39,14 +45,27 @@ readonly class DeleteUseCase
     {
         return MediaId::create($inputData->mediaId)
             ->mapErr(fn (): UseCaseError => new InvalidInputError(['mediaId' => ['IDが不正です']]))
-            ->andThen(function (MediaId $mediaId): Result {
+            ->andThen(fn (MediaId $mediaId): Result => $this->transaction->scope(function () use ($mediaId): Result {
+                $media = $this->repository->find($mediaId);
+
+                if (is_null($media)) {
+                    return new Ok(null);
+                }
+
                 if ($this->repository->isUsed($mediaId)) {
                     return new Err(new BusinessLogicError('このメディアは楽曲に使用されているため削除できません'));
                 }
 
                 $this->repository->delete($mediaId);
 
+                $this->recorder->record(
+                    AuditAction::Delete,
+                    AuditTargetType::Media,
+                    $media->mediaId,
+                    $media->toArray(),
+                );
+
                 return new Ok(null);
-            });
+            }));
     }
 }

--- a/src/server/packages/Media/Application/UseCase/Update/UpdateUseCase.php
+++ b/src/server/packages/Media/Application/UseCase/Update/UpdateUseCase.php
@@ -15,6 +15,9 @@ use Support\Contracts\TransactionInterface;
 use Support\Domain\Error\DomainError;
 use Support\Domain\Error\DomainValidationError;
 use Support\Domain\Error\EntityRuleViolationError;
+use Support\UseCase\AuditLog\AuditAction;
+use Support\UseCase\AuditLog\AuditLogRecorderInterface;
+use Support\UseCase\AuditLog\AuditTargetType;
 use Support\UseCase\Authorizer\UseCaseAuthorizer;
 use Support\UseCase\Error\InvalidInputError;
 use Support\UseCase\Error\UseCaseError;
@@ -26,6 +29,7 @@ readonly class UpdateUseCase
         private TransactionInterface $transaction,
         private MediaRepositoryInterface $repository,
         private MediaIntegrityService $service,
+        private AuditLogRecorderInterface $recorder,
     ) {
     }
 
@@ -58,6 +62,13 @@ readonly class UpdateUseCase
             }
 
             $media = $this->repository->save($result->unwrap());
+
+            $this->recorder->record(
+                AuditAction::Update,
+                AuditTargetType::Media,
+                $media->mediaId,
+                $media->toArray(),
+            );
 
             return new Ok(new UpdateOutputData($media));
         });

--- a/src/server/packages/Support/UseCase/AuditLog/AuditTargetType.php
+++ b/src/server/packages/Support/UseCase/AuditLog/AuditTargetType.php
@@ -8,6 +8,8 @@ enum AuditTargetType: string
 {
     case AdminUser = 'AdminUser';
 
+    case Media = 'Media';
+
     case Person = 'Person';
 
     case Song = 'Song';

--- a/src/server/tests/Integration/Media/Application/UseCase/CreateUseCaseTest.php
+++ b/src/server/tests/Integration/Media/Application/UseCase/CreateUseCaseTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Media\Application\UseCase;
+
+use App\Models\Media\Media as ModelsMedia;
+use Media\Application\UseCase\Create\CreateInputData;
+use Media\Application\UseCase\Create\CreateUseCase;
+use Media\Domain\Models\MediaFormat;
+use Media\Domain\Models\MediaType;
+use Mockery;
+use PHPUnit\Framework\Attributes\Test;
+use RuntimeException;
+use Support\UseCase\AuditLog\AuditAction;
+use Support\UseCase\AuditLog\AuditLogRecorderInterface;
+use Support\UseCase\AuditLog\AuditTargetType;
+use Tests\Support\Concerns\AssertsAuditLog;
+use Tests\Support\DatabaseTestCase;
+
+class CreateUseCaseTest extends DatabaseTestCase
+{
+    use AssertsAuditLog;
+
+    #[Test]
+    public function create(): void
+    {
+        $result = $this->getInstance()->handle(
+            new CreateInputData(
+                '描き続けた君へ MV',
+                'https://example.com/media',
+                MediaType::Video->value,
+                MediaFormat::Mv->value,
+                true,
+            ),
+        );
+
+        $this->assertTrue($result->isOk());
+
+        $media = ModelsMedia::query()->first();
+        $this->assertNotNull($media);
+        $this->assertSame('描き続けた君へ MV', $media->title);
+        $this->assertSame('https://example.com/media', $media->url);
+
+        $mediaId = $this->toUuid($media->media_id);
+        $this->assertAuditLogCount(1);
+        $log = $this->findAuditLog(AuditAction::Create, AuditTargetType::Media, $mediaId);
+        $this->assertSame('描き続けた君へ MV', $log['snapshot']['title']);
+        $this->assertSame(MediaType::Video->value, $log['snapshot']['type']);
+        $this->assertSame(MediaFormat::Mv->value, $log['snapshot']['format']);
+    }
+
+    #[Test]
+    public function rollsBackBusinessDataWhenAuditLogRecorderThrows(): void
+    {
+        $this->privilegedContext();
+
+        $recorder = Mockery::mock(AuditLogRecorderInterface::class);
+        $recorder->shouldReceive('record')->andThrow(new RuntimeException('audit log failure'));
+        $this->app->instance(AuditLogRecorderInterface::class, $recorder);
+
+        try {
+            $this->app->make(CreateUseCase::class)->handle(
+                new CreateInputData(
+                    'ロールバック対象',
+                    'https://example.com/rollback',
+                    MediaType::Video->value,
+                    MediaFormat::Mv->value,
+                    true,
+                ),
+            );
+            $this->fail('RuntimeException が送出されるはず');
+        } catch (RuntimeException $e) {
+            $this->assertSame('audit log failure', $e->getMessage());
+        }
+
+        $this->assertCount(0, ModelsMedia::query()->where('title', 'ロールバック対象')->get());
+        $this->assertAuditLogCount(0);
+    }
+
+    private function getInstance(): CreateUseCase
+    {
+        $this->privilegedContext();
+
+        return $this->app->make(CreateUseCase::class);
+    }
+}

--- a/src/server/tests/Integration/Media/Application/UseCase/DeleteUseCaseTest.php
+++ b/src/server/tests/Integration/Media/Application/UseCase/DeleteUseCaseTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Media\Application\UseCase;
+
+use App\Models\Media\Media as ModelsMedia;
+use Media\Application\UseCase\Delete\DeleteInputData;
+use Media\Application\UseCase\Delete\DeleteUseCase;
+use Media\Domain\Models\MediaFormat;
+use Media\Domain\Models\MediaType;
+use Mockery;
+use PHPUnit\Framework\Attributes\Test;
+use RuntimeException;
+use Song\Domain\Models\SongType;
+use Support\UseCase\AuditLog\AuditAction;
+use Support\UseCase\AuditLog\AuditLogRecorderInterface;
+use Support\UseCase\AuditLog\AuditTargetType;
+use Tests\Support\Concerns\AssertsAuditLog;
+use Tests\Support\DatabaseTestCase;
+use Tests\Support\Domain\EntityFactory;
+use Tests\Support\Domain\EntityStore;
+
+class DeleteUseCaseTest extends DatabaseTestCase
+{
+    use AssertsAuditLog;
+    use EntityFactory;
+    use EntityStore;
+
+    #[Test]
+    public function canDelete(): void
+    {
+        $mediaId = $this->generateUuid();
+
+        $this->storeMedia(
+            $this->createMedia(
+                $mediaId,
+                '描き続けた君へ MV',
+                'https://example.com/media',
+                MediaType::Video,
+                true,
+                MediaFormat::Mv,
+            ),
+        );
+
+        $result = $this->getInstance()->handle(new DeleteInputData($mediaId));
+
+        $this->assertTrue($result->isOk());
+        $this->assertCount(0, ModelsMedia::query()->get()->all());
+
+        $this->assertAuditLogCount(1);
+        $log = $this->findAuditLog(AuditAction::Delete, AuditTargetType::Media, $mediaId);
+        $this->assertSame('描き続けた君へ MV', $log['snapshot']['title']);
+    }
+
+    #[Test]
+    public function cannotDeleteWhenUsedInSong(): void
+    {
+        $mediaId = $this->generateUuid();
+
+        $this->storeMedia(
+            $this->createMedia(
+                $mediaId,
+                '描き続けた君へ MV',
+                'https://example.com/media',
+                MediaType::Video,
+                true,
+                MediaFormat::Mv,
+            ),
+        );
+        $this->storeSongs($this->createSong(
+            $this->generateUuid(),
+            '曲名',
+            '説明',
+            null,
+            SongType::Original,
+            true,
+            1,
+            [],
+            [],
+            [],
+            [
+                ['mediaId' => $mediaId, 'orderNo' => 1],
+            ],
+        ));
+
+        $result = $this->getInstance()->handle(new DeleteInputData($mediaId));
+
+        $this->assertTrue($result->isErr());
+        $this->assertSame('このメディアは楽曲に使用されているため削除できません', $result->unwrapErr()->message);
+        $this->assertCount(1, ModelsMedia::query()->get()->all());
+        $this->assertAuditLogCount(0);
+    }
+
+    #[Test]
+    public function rollsBackDeleteWhenAuditLogRecorderThrows(): void
+    {
+        $mediaId = $this->generateUuid();
+
+        $this->storeMedia(
+            $this->createMedia(
+                $mediaId,
+                'ロールバック対象',
+                'https://example.com/rollback',
+                MediaType::Video,
+                true,
+                MediaFormat::Mv,
+            ),
+        );
+
+        $this->privilegedContext();
+
+        $recorder = Mockery::mock(AuditLogRecorderInterface::class);
+        $recorder->shouldReceive('record')->andThrow(new RuntimeException('audit log failure'));
+        $this->app->instance(AuditLogRecorderInterface::class, $recorder);
+
+        try {
+            $this->app->make(DeleteUseCase::class)->handle(new DeleteInputData($mediaId));
+            $this->fail('RuntimeException が送出されるはず');
+        } catch (RuntimeException $e) {
+            $this->assertSame('audit log failure', $e->getMessage());
+        }
+
+        $this->assertCount(1, ModelsMedia::query()->where('title', 'ロールバック対象')->get());
+        $this->assertAuditLogCount(0);
+    }
+
+    private function getInstance(): DeleteUseCase
+    {
+        $this->privilegedContext();
+
+        return $this->app->make(DeleteUseCase::class);
+    }
+}

--- a/src/server/tests/Integration/Media/Application/UseCase/UpdateUseCaseTest.php
+++ b/src/server/tests/Integration/Media/Application/UseCase/UpdateUseCaseTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Media\Application\UseCase;
+
+use App\Models\Media\Media as ModelsMedia;
+use Media\Application\UseCase\Update\UpdateInputData;
+use Media\Application\UseCase\Update\UpdateUseCase;
+use Media\Domain\Models\MediaFormat;
+use Media\Domain\Models\MediaType;
+use PHPUnit\Framework\Attributes\Test;
+use Support\UseCase\AuditLog\AuditAction;
+use Support\UseCase\AuditLog\AuditTargetType;
+use Tests\Support\Concerns\AssertsAuditLog;
+use Tests\Support\DatabaseTestCase;
+use Tests\Support\Domain\EntityFactory;
+use Tests\Support\Domain\EntityStore;
+
+class UpdateUseCaseTest extends DatabaseTestCase
+{
+    use AssertsAuditLog;
+    use EntityFactory;
+    use EntityStore;
+
+    #[Test]
+    public function canUpdate(): void
+    {
+        $mediaId = $this->generateUuid();
+
+        $this->storeMedia(
+            $this->createMedia(
+                $mediaId,
+                '描き続けた君へ MV',
+                'https://example.com/media',
+                MediaType::Video,
+                true,
+                MediaFormat::Mv,
+            ),
+        );
+
+        $result = $this->getInstance()->handle(
+            new UpdateInputData(
+                $mediaId,
+                '描き続けた君へ 配信アーカイブ',
+                'https://example.com/archive',
+                MediaType::SocialPost->value,
+                MediaFormat::StreamArchive->value,
+                false,
+            ),
+        );
+
+        $this->assertTrue($result->isOk());
+
+        $media = ModelsMedia::query()->first();
+        $this->assertNotNull($media);
+        $this->assertSame('描き続けた君へ 配信アーカイブ', $media->title);
+        $this->assertSame('https://example.com/archive', $media->url);
+        $this->assertSame(MediaType::SocialPost->value, $media->type);
+        $this->assertSame(MediaFormat::StreamArchive->value, $media->format);
+        $this->assertFalse($media->is_display);
+
+        $this->assertAuditLogCount(1);
+        $log = $this->findAuditLog(AuditAction::Update, AuditTargetType::Media, $mediaId);
+        $this->assertSame('描き続けた君へ 配信アーカイブ', $log['snapshot']['title']);
+        $this->assertSame(MediaType::SocialPost->value, $log['snapshot']['type']);
+        $this->assertSame(MediaFormat::StreamArchive->value, $log['snapshot']['format']);
+        $this->assertFalse($log['snapshot']['is_display']);
+    }
+
+    private function getInstance(): UpdateUseCase
+    {
+        $this->privilegedContext();
+
+        return $this->app->make(UpdateUseCase::class);
+    }
+}

--- a/src/server/tests/Support/Domain/EntityStore.php
+++ b/src/server/tests/Support/Domain/EntityStore.php
@@ -9,6 +9,8 @@ use AdminUser\Domain\Models\AdminUserRepositoryInterface;
 use AdminUser\Domain\Models\HashedPassword;
 use Auth\Domain\Models\Token\RefreshToken\RefreshToken;
 use Auth\Domain\Models\Token\RefreshToken\RefreshTokenRepositoryInterface;
+use Media\Domain\Models\Media;
+use Media\Domain\Models\MediaRepositoryInterface;
 use Person\Domain\Models\Person;
 use Person\Domain\Models\PersonRepositoryInterface;
 use Song\Domain\Models\Song;
@@ -28,6 +30,12 @@ trait EntityStore
     {
         $repository = $this->makeRepository(SongRepositoryInterface::class);
         array_map(fn (Song $item) => $repository->save($item), $items);
+    }
+
+    protected function storeMedia(Media ...$items): void
+    {
+        $repository = $this->makeRepository(MediaRepositoryInterface::class);
+        array_map(fn (Media $item) => $repository->save($item), $items);
     }
 
     protected function storeSongTags(SongTag ...$items): void


### PR DESCRIPTION
## 概要
- Media の create / update / delete で監査ログを記録するよう追加
- 監査ログの target type に Media を追加し、契約と管理画面の表示・検索条件を更新
- Media 向けの監査ログ integration test を追加

## 動作確認
- mise run api:test tests/Integration/Media/Application/UseCase
- bunx tsc --noEmit
- mise run contract:compile:admin
- mise run api:generate
- mise run admin:generate