### PR TITLE
worktree:init で生成直後の環境変数を再読込する

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -112,11 +112,12 @@ run = "bun install"
 
 [tasks."worktree:init"]
 description = "worktree ごとのローカル実行設定を生成し、開発環境を起動する"
-run = [
-  "./tools/worktree/init.sh",
-  { task = "up" },
-  { tasks = ["api:composer:install", "bun:install"] },
-]
+run = '''
+./tools/worktree/init.sh
+mise run up
+mise run api:composer:install
+mise run bun:install
+'''
 
 [tasks."worktree:status"]
 description = "現在の worktree に割り当てられたポートと URL を表示する"


### PR DESCRIPTION
## 概要
- worktree:init 内の子タスク呼び出しをやめ、各段階を新しい mise run プロセスで実行するよう変更
- init.sh が生成した mise.local.toml を up と install 系が即座に再読込できるように修正
- 初回だけ Docker Compose が fallback の 6379 を使ってしまう問題を防止

## 確認
- mise run worktree:status