### PR TITLE
Media の日付表示を正規化

### DIFF
--- a/src/admin/src/components/media/EditableForm.tsx
+++ b/src/admin/src/components/media/EditableForm.tsx
@@ -29,6 +29,24 @@ interface Props {
 }
 
 export const EditableForm = (props: Props) => {
+  const normalizeDateInputValue = (value: unknown): string => {
+    if (value instanceof Date) {
+      return Number.isNaN(value.getTime()) ? '' : value.toISOString().slice(0, 10);
+    }
+
+    if (typeof value !== 'string') {
+      return '';
+    }
+
+    if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+      return value;
+    }
+
+    const parsed = new Date(value);
+
+    return Number.isNaN(parsed.getTime()) ? '' : parsed.toISOString().slice(0, 10);
+  };
+
   const back = new URLSearchParams(window.location.search).get('back') ?? '';
   const listQuery = (() => {
     if (!back.startsWith('?')) return '';
@@ -160,7 +178,7 @@ export const EditableForm = (props: Props) => {
               type="date"
               class="input w-full"
               name="publishedAt"
-              value={props.data?.media.publishedAt}
+              value={normalizeDateInputValue(props.data?.media.publishedAt)}
               required
               classList={{ 'input-error': !!getFieldError('publishedAt') }}
             />

--- a/src/admin/src/components/media/SearchList.tsx
+++ b/src/admin/src/components/media/SearchList.tsx
@@ -50,6 +50,24 @@ const getInitialParams = () => {
 };
 
 export const SearchList = () => {
+  const normalizeDateDisplayValue = (value: unknown): string => {
+    if (value instanceof Date) {
+      return Number.isNaN(value.getTime()) ? '' : value.toISOString().slice(0, 10);
+    }
+
+    if (typeof value !== 'string') {
+      return '';
+    }
+
+    if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+      return value;
+    }
+
+    const parsed = new Date(value);
+
+    return Number.isNaN(parsed.getTime()) ? '' : parsed.toISOString().slice(0, 10);
+  };
+
   const initial = getInitialParams();
 
   const [title, setTitle] = createSignal(initial.title);
@@ -258,7 +276,7 @@ export const SearchList = () => {
                         <td class="min-w-44 max-w-56">
                           <p class="truncate">{media.title}</p>
                         </td>
-                        <td class="whitespace-nowrap text-sm">{media.publishedAt}</td>
+                        <td class="whitespace-nowrap text-sm">{normalizeDateDisplayValue(media.publishedAt)}</td>
                         <td>{media.type.name}</td>
                         <td>
                           <span class={`badge badge-sm ${media.isDisplay ? 'badge-success badge-soft' : 'badge-ghost'}`}>

--- a/src/admin/src/components/song/MediaSection.tsx
+++ b/src/admin/src/components/song/MediaSection.tsx
@@ -86,6 +86,7 @@ export const MediaSection = (props: Props) => {
 
   const [createTitle, setCreateTitle] = createSignal('');
   const [createUrl, setCreateUrl] = createSignal('');
+  const [createPublishedAt, setCreatePublishedAt] = createSignal('');
   const [createTypeValue, setCreateTypeValue] = createSignal<MediaTypeValue>(1);
   const [createFormatValue, setCreateFormatValue] = createSignal<MediaFormatValue>(1);
   const [createIsDisplay, setCreateIsDisplay] = createSignal(true);
@@ -213,6 +214,7 @@ export const MediaSection = (props: Props) => {
   const handleCreate = async () => {
     const title = createTitle().trim();
     const url = createUrl().trim();
+    const publishedAt = createPublishedAt();
 
     setCreateError(null);
 
@@ -226,6 +228,11 @@ export const MediaSection = (props: Props) => {
       return;
     }
 
+    if (publishedAt === '') {
+      setCreateError('公開日を入力してください');
+      return;
+    }
+
     if (hasExactUrlDuplicate()) {
       setCreateError('同じURLの既存メディアがあります。既存メディアの追加を検討してください');
       return;
@@ -236,6 +243,7 @@ export const MediaSection = (props: Props) => {
     const { data, error, status } = await client.api.media.post({
       title,
       url,
+      publishedAt,
       typeValue: createTypeValue(),
       formatValue: createFormatValue(),
       isDisplay: createIsDisplay(),
@@ -252,6 +260,7 @@ export const MediaSection = (props: Props) => {
     addEntry(data.media);
     setCreateTitle('');
     setCreateUrl('');
+    setCreatePublishedAt('');
     setCreateTypeValue(1);
     setCreateFormatValue(1);
     setCreateIsDisplay(true);
@@ -413,6 +422,15 @@ export const MediaSection = (props: Props) => {
               value={createUrl()}
               onInput={e => setCreateUrl(e.currentTarget.value)}
               placeholder="https://example.com/media"
+            />
+          </div>
+
+          <div>
+            <input
+              type="date"
+              class="input input-bordered w-full"
+              value={createPublishedAt()}
+              onInput={e => setCreatePublishedAt(e.currentTarget.value)}
             />
           </div>
 


### PR DESCRIPTION
## 概要
- Media 編集画面の公開日入力で、取得値を date input 向けに正規化
- Media 一覧画面の公開日表示でも同じ正規化を適用
- API から Date や ISO 文字列で返ってきても YYYY-MM-DD で表示できるように修正

## 確認
- bun run lint:check src/components/media/SearchList.tsx src/components/media/EditableForm.tsx

## 補足
- dump.sql は含めていません