### PR TITLE
Release 基盤を追加

### DIFF
--- a/docs/exec-plans/completed/20260508-release-foundation.md
+++ b/docs/exec-plans/completed/20260508-release-foundation.md
@@ -1,0 +1,80 @@
+# Title
+
+Release 基盤
+
+## Status
+
+completed
+
+## Background
+
+`docs/product-specs/20260503-song-media-admin-phase1/README.md` と `models.md` では、Phase 1 の対象として `Release` とその収録曲が定義されている。一方で、現行コードベースには `Media` と `SongMediaLink` の server 実装はあるが、`Release` は `src/viewer` のモック表示に留まり、`src/server` / `src/admin` / `src/contracts` に後続実装の共通依存先となる基盤がまだない。
+
+並列開発を始める前に、変更衝突が起きやすい API 契約や管理画面には入らず、server 側で静的な土台だけを先に固定する必要がある。
+
+## Goal
+
+`Release` と `TrackEntry` を表現するための最小限の server 基盤を追加し、後続の API、repository、admin 実装が並列で依存できる共通境界を整える。
+
+## Scope
+
+- `src/server/database/atlas/schemas` に `releases` / `release_track_entries` のテーブル定義を追加する
+- `src/server/database/atlas/atlas.hcl` に新規スキーマを登録する
+- `src/server/app/Models/Release` に、後続の永続化実装が依存できる Eloquent Model を追加する
+- `src/server/packages/Release/Domain/Models` を追加し、`Release` / `TrackEntry` の pure domain model を定義する
+- `src/server/composer.json` に `Release\\` の PSR-4 autoload を追加する
+
+## Non-Scope
+
+- `src/contracts` の TypeSpec 追加・更新
+- OpenAPI や generated code の更新
+- `src/server/packages/Release/Application` / `Infrastructures` / `Route` の実装
+- `src/server/app/Http` の controller / presenter / request 実装
+- `src/admin` の BFF、画面、フォーム実装
+- `src/viewer` のモック置換や表示改善
+- `Media` や `Song` の既存ユースケースの振る舞い変更
+- `src/server/app/Models/Song` への relation 追加
+- `src/server/packages/Song/Domain/Models/Song.php` に `Release` / `TrackEntry` を保持させる変更
+
+## Acceptance Criteria
+
+- `src/server/database/atlas/schemas` に `releases` と `release_track_entries` を表すファイルが追加され、`atlas.hcl` から参照されている
+- テーブル定義は `docs/product-specs/20260503-song-media-admin-phase1/models.md` の最小モデルに沿って、`Release` の基本属性と `TrackEntry` の関連・曲順だけを持つ
+- `src/server/app/Models/Release` と `src/server/packages/Release/Domain/Models` に、後続実装が参照できる `Release` / `TrackEntry` の型が追加されている
+- 既存の `src/contracts`、`src/admin`、`src/server/app/Http`、`src/server/packages/*/Application` には変更が入っていない
+- `src/server/app/Models/Song` には変更が入っていない
+- `src/server/packages/Song/Domain/Models/Song.php` は `Release` / `TrackEntry` を持たないままである
+- この基盤追加だけでは `Release` CRUD や画面導線はまだ提供されない
+
+## Steps
+
+1. ✅ `docs/product-specs/20260503-song-media-admin-phase1/models.md` の `Release` / 収録曲定義と、既存の `src/server/database/atlas/schemas/songs.my.hcl` / `song-media-links.my.hcl` / `src/server/app/Models/Media/Media.php` を突き合わせ、今回固定する最小カラムと relation 境界を確定する。ここでは `Song` は pure domain で `Release` も `TrackEntry` も持たず、関係は `Release` 側と read model 組み立て側に閉じる前提を計画の基準にする。
+2. ✅ `src/server/database/atlas/schemas/releases.my.hcl` を新規追加し、`release_id`、`title`、`type`、`distribution_type`、`released_on`、`description`、`is_display`、`created_at`、`updated_at` を定義する。`models.md` の最小モデルに合わせつつ、Phase 1 対象外のジャケット画像や版管理カラムは入れない。
+3. ✅ `src/server/database/atlas/schemas/release-track-entries.my.hcl` を新規追加し、`release_id`、`song_id`、`track_no` を持つ複合主キー付き中間テーブルを定義する。`releases` と `songs` への外部キー、曲順、同一楽曲の複数リリース所属をこのテーブル責務に閉じ込める。
+4. ✅ `src/server/database/atlas/atlas.hcl` の `table_schemas` に `releases.my.hcl` と `release-track-entries.my.hcl` を追加し、DB Source of Truth を Atlas に集約する。
+5. ✅ `src/server/app/Models/Release/Release.php` と `src/server/app/Models/Release/TrackEntry.php` を追加し、既存の `App\Models\Song` / `App\Models\Media` と同じ Eloquent パターンで primary key、casts、必要最小限の relation を定義する。`Song` 側には relation を追加せず、`TrackEntry` は `Release` 側からのみ参照できる形に留める。
+6. ✅ `src/server/packages/Release/Domain/Models` を新設し、少なくとも `Release.php`、`ReleaseId.php`、`ReleaseTitle.php`、`ReleaseType.php`、`ReleaseDistributionType.php`、`ReleasedOn.php`、`Description.php`、`TrackEntry.php`、`TrackEntries.php` を追加する。既存の `Media` / `Song` domain model に寄せて `reconstruct()` と `toArray()` を用意し、後続の repository・application 実装が依存できる pure domain の型を先に固定する。
+7. ✅ `src/server/composer.json` の PSR-4 autoload に `Release\\` を追加し、新規 package の namespace 解決を有効にする。必要であれば既存 package 名との衝突がないことも同時に確認する。
+8. ✅ 実装後は差分を確認し、変更が `src/server/database/atlas`、`src/server/app/Models/Release`、`src/server/packages/Release`、`src/server/composer.json` に閉じていること、`src/server/app/Models/Song` や application / contract / admin に差分がないことを検証する。
+
+## Decision Log
+
+- 2026-05-08: `Song` の pure domain model には `Release` も `TrackEntry` も持たせず、`Song` と `Release` の関係は `TrackEntry` テーブルと後続の read model 組み立てでのみ表現する。集約責務の混在を避けるため。
+- 2026-05-08: 今回の基盤追加では `src/server/app/Models/Song` に relation を追加しない。並列実装時に `Song` 取得系の競合を増やさず、静的な依存先だけを先に固定するため。
+- 2026-05-08: `Release` 側の Eloquent / domain model だけを先に追加し、repository・application・HTTP・admin は後続タスクに分離する。変更面を局所化し、API / UI 実装と独立に進められるようにするため。
+- 2026-05-08: `releases` テーブルは product spec の最小属性に留め、`distribution_type` と `released_on` を単数の属性として保持する。版違いは別 `Release` として登録し、ジャケット画像や版管理までは扱わないため。
+- 2026-05-08: `release_track_entries` は `release_id` / `song_id` / `track_no` のみを持つ単純な中間テーブルとし、将来の disc number などは今回入れない。後方互換を壊さずに拡張できる余地を残しつつ、初期基盤を最小に保つため。
+- 2026-05-08: 流通形態は複数値ではなく `ReleaseDistributionType` の単一 enum として扱う。版違いを別 `Release` に分ける運用の方針と整合し、後続の API / admin 実装も単純になるため。
+- 2026-05-08: `release_track_entries` では `release_id + track_no` を unique にして、同一リリース内で曲順が重複しないことを DB で保証する。後続の read model や UI が曖昧な並び順を扱わずに済むようにするため。
+- 2026-05-08: 発売日は `ReleaseDate` ではなく `ReleasedOn` と命名し、日付の意味を「いつ発売されたか」に固定する。後続で公開開始日や予約開始日など別の日付が増えても衝突しにくくするため。
+
+## Validation
+
+- `src/server/database/atlas/atlas.hcl` に `releases.my.hcl` と `release-track-entries.my.hcl` が追加され、`src/server/database/atlas/schemas` 側に対応ファイルが存在することを確認する。
+- `releases` テーブルが `release_id` / `title` / `type` / `distribution_type` / `released_on` / `description` / `is_display` / timestamp を持ち、`release_track_entries` テーブルが `release_id` / `song_id` / `track_no` と外部キーを持つことを確認する。
+- `release_track_entries` に `release_id + track_no` の unique index があり、同一リリース内で曲順重複を防げることを確認する。
+- `src/server/app/Models/Release/Release.php` と `src/server/app/Models/Release/TrackEntry.php`、`src/server/packages/Release/Domain/Models/*` が追加され、既存モデルと同等の namespace / reconstruct / `toArray()` パターンに沿っていることを確認する。
+- `src/server/composer.json` に `Release\\` の PSR-4 autoload が追加され、新規 domain model の namespace 解決ができる状態になっていることを確認する。
+- `src/server/app/Models/Song`、`src/contracts`、`src/server/app/Http`、`src/server/packages/*/Application`、`src/admin` に差分がないことを `git diff --name-only` で確認する。
+- `src/server/packages/Song/Domain/Models/Song.php` に差分がなく、`Song` が `Release` / `TrackEntry` を保持しない前提が維持されていることを確認する。
+- 必要に応じて `mise run api:phpstan` の対象を新規 package / model に絞って実行し、少なくとも追加した PHP ファイル群に静的解析エラーがないことを確認する。

--- a/src/server/app/Models/Release/Release.php
+++ b/src/server/app/Models/Release/Release.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\Release;
+
+use Carbon\CarbonImmutable;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Override;
+
+/**
+ * @property string          $release_id        リリースID
+ * @property string          $title             タイトル
+ * @property int             $type              種別
+ * @property int             $distribution_type 流通形態
+ * @property CarbonImmutable $released_on       発売日
+ * @property string          $description       説明
+ * @property bool            $is_display        表示フラグ
+ * @property CarbonImmutable $created_at        作成日時
+ * @property CarbonImmutable $updated_at        更新日時
+ * @property-read Collection<int, TrackEntry> $trackEntries
+ *
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Release newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Release newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Release query()
+ *
+ * @mixin \Eloquent
+ */
+class Release extends Model
+{
+    #[Override]
+    protected $table = 'releases';
+
+    #[Override]
+    protected $primaryKey = 'release_id';
+
+    #[Override]
+    protected $keyType = 'string';
+
+    #[Override]
+    protected function casts()
+    {
+        return [
+            'distribution_type' => 'integer',
+            'released_on' => 'immutable_date',
+            'is_display' => 'bool',
+            'created_at' => 'immutable_datetime',
+            'updated_at' => 'immutable_datetime',
+        ];
+    }
+
+    /**
+     * @return HasMany<TrackEntry, $this>
+     */
+    public function trackEntries(): HasMany
+    {
+        return $this->hasMany(TrackEntry::class, 'release_id', 'release_id')
+            ->orderBy('track_no');
+    }
+}

--- a/src/server/app/Models/Release/TrackEntry.php
+++ b/src/server/app/Models/Release/TrackEntry.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\Release;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Override;
+
+/**
+ * @property string $release_id リリースID
+ * @property string $song_id    楽曲ID
+ * @property int    $track_no   曲順
+ * @property-read Release $release
+ *
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|TrackEntry newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|TrackEntry newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|TrackEntry query()
+ *
+ * @mixin \Eloquent
+ */
+class TrackEntry extends Model
+{
+    #[Override]
+    protected $table = 'release_track_entries';
+
+    // 複合主キーのため未設定
+    #[Override]
+    protected $primaryKey = '';
+
+    #[Override]
+    protected $keyType = 'string';
+
+    #[Override]
+    public $timestamps = false;
+
+    /**
+     * @return BelongsTo<Release, $this>
+     */
+    public function release(): BelongsTo
+    {
+        return $this->belongsTo(Release::class, 'release_id', 'release_id');
+    }
+}

--- a/src/server/composer.json
+++ b/src/server/composer.json
@@ -43,6 +43,7 @@
       "Support\\": "packages/Support/",
       "Song\\": "packages/Song/",
       "Media\\": "packages/Media/",
+      "Release\\": "packages/Release/",
       "Person\\": "packages/Person/",
       "AdminUser\\": "packages/AdminUser/",
       "Auth\\": "packages/Auth/",

--- a/src/server/database/atlas/atlas.hcl
+++ b/src/server/database/atlas/atlas.hcl
@@ -11,6 +11,8 @@ variable "table_schemas" {
     "file://schemas/song-taggings.my.hcl",
     "file://schemas/song-persons.my.hcl",
     "file://schemas/song-media-links.my.hcl",
+    "file://schemas/releases.my.hcl",
+    "file://schemas/release-track-entries.my.hcl",
     "file://schemas/refresh-tokens.my.hcl",
     "file://schemas/audit-logs.my.hcl",
   ]

--- a/src/server/database/atlas/schemas/release-track-entries.my.hcl
+++ b/src/server/database/atlas/schemas/release-track-entries.my.hcl
@@ -1,0 +1,45 @@
+table "release_track_entries" {
+  schema  = schema.db
+  comment = "リリース収録曲"
+
+  column "release_id" {
+    null    = false
+    type    = binary(16)
+    comment = "リリースID"
+  }
+  column "song_id" {
+    null    = false
+    type    = binary(16)
+    comment = "楽曲ID"
+  }
+  column "track_no" {
+    null     = false
+    type     = int
+    unsigned = true
+    comment  = "曲順"
+  }
+
+  primary_key {
+    columns = [column.release_id, column.song_id]
+  }
+
+  index "fk_release_track_entries_song_id" {
+    columns = [column.song_id]
+  }
+
+  index "release_track_entries_release_id_track_no_unique" {
+    unique  = true
+    columns = [column.release_id, column.track_no]
+  }
+
+  foreign_key "fk_release_track_entries_release_id" {
+    columns     = [column.release_id]
+    ref_columns = [table.releases.column.release_id]
+    on_delete   = CASCADE
+  }
+  foreign_key "fk_release_track_entries_song_id" {
+    columns     = [column.song_id]
+    ref_columns = [table.songs.column.song_id]
+    on_delete   = RESTRICT
+  }
+}

--- a/src/server/database/atlas/schemas/releases.my.hcl
+++ b/src/server/database/atlas/schemas/releases.my.hcl
@@ -1,0 +1,56 @@
+table "releases" {
+  schema  = schema.db
+  comment = "リリース"
+
+  column "release_id" {
+    null    = false
+    type    = binary(16)
+    comment = "リリースID"
+  }
+  column "title" {
+    null    = false
+    type    = varchar(255)
+    comment = "タイトル"
+  }
+  column "type" {
+    null     = false
+    type     = tinyint
+    unsigned = true
+    comment  = "種別"
+  }
+  column "distribution_type" {
+    null     = false
+    type     = tinyint
+    unsigned = true
+    comment  = "流通形態"
+  }
+  column "released_on" {
+    null    = false
+    type    = date
+    comment = "発売日"
+  }
+  column "description" {
+    null    = false
+    type    = text
+    comment = "説明"
+  }
+  column "is_display" {
+    null    = false
+    type    = bool
+    comment = "表示するか"
+  }
+  column "created_at" {
+    null    = false
+    type    = datetime
+    comment = "作成日時"
+  }
+  column "updated_at" {
+    null    = false
+    type    = datetime
+    comment = "更新日時"
+  }
+
+  primary_key {
+    columns = [column.release_id]
+  }
+}

--- a/src/server/packages/Release/Domain/Models/Description.php
+++ b/src/server/packages/Release/Domain/Models/Description.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Release\Domain\Models;
+
+use Support\Domain\ValueObjects\String\StringValueObject;
+
+readonly class Description extends StringValueObject
+{
+}

--- a/src/server/packages/Release/Domain/Models/Release.php
+++ b/src/server/packages/Release/Domain/Models/Release.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Release\Domain\Models;
+
+use DateType\ImmutableDate;
+
+readonly class Release
+{
+    public function __construct(
+        public ReleaseId $releaseId,
+        public ReleaseTitle $title,
+        public ReleaseType $type,
+        public ReleaseDistributionType $distributionType,
+        public ReleasedOn $releasedOn,
+        public Description $description,
+        public bool $isDisplay,
+        public TrackEntries $trackEntries,
+    ) {
+    }
+
+    /**
+     * @param list<array{songId: string, trackNo: int}> $trackEntries
+     */
+    public static function reconstruct(
+        string $releaseId,
+        string $title,
+        int $type,
+        int $distributionType,
+        ImmutableDate $releasedOn,
+        string $description,
+        bool $isDisplay,
+        array $trackEntries,
+    ): self {
+        return new self(
+            ReleaseId::reconstruct($releaseId),
+            ReleaseTitle::reconstruct($title),
+            ReleaseType::from($type),
+            ReleaseDistributionType::from($distributionType),
+            ReleasedOn::reconstruct($releasedOn),
+            Description::reconstruct($description),
+            $isDisplay,
+            TrackEntries::reconstruct($trackEntries),
+        );
+    }
+
+    /**
+     * @return array{release_id: string, title: string, type: value-of<ReleaseType>, distribution_type: value-of<ReleaseDistributionType>, released_on: string, description: string, is_display: bool, track_entries: list<array{song_id: string, track_no: int}>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'release_id' => $this->releaseId->value,
+            'title' => $this->title->value,
+            'type' => $this->type->value,
+            'distribution_type' => $this->distributionType->value,
+            'released_on' => $this->releasedOn->value->format('Y-m-d'),
+            'description' => $this->description->value,
+            'is_display' => $this->isDisplay,
+            'track_entries' => $this->trackEntries->toArray(),
+        ];
+    }
+
+    public function equals(self $other): bool
+    {
+        return $this->releaseId->equals($other->releaseId);
+    }
+}

--- a/src/server/packages/Release/Domain/Models/ReleaseDistributionType.php
+++ b/src/server/packages/Release/Domain/Models/ReleaseDistributionType.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Release\Domain\Models;
+
+enum ReleaseDistributionType: int
+{
+    case Digital = 1;
+
+    case Physical = 2;
+
+    case Other = 99;
+
+    public function getName(): string
+    {
+        return match ($this) {
+            self::Digital => '配信',
+            self::Physical => '物理',
+            self::Other => 'その他',
+        };
+    }
+
+    public function equals(self $other): bool
+    {
+        return $this === $other;
+    }
+}

--- a/src/server/packages/Release/Domain/Models/ReleaseId.php
+++ b/src/server/packages/Release/Domain/Models/ReleaseId.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Release\Domain\Models;
+
+use Support\Domain\ValueObjects\String\UuidValueObject;
+
+readonly class ReleaseId extends UuidValueObject
+{
+}

--- a/src/server/packages/Release/Domain/Models/ReleaseTitle.php
+++ b/src/server/packages/Release/Domain/Models/ReleaseTitle.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Release\Domain\Models;
+
+use Support\Domain\ValueObjects\String\StringValueObject;
+
+readonly class ReleaseTitle extends StringValueObject
+{
+}

--- a/src/server/packages/Release/Domain/Models/ReleaseType.php
+++ b/src/server/packages/Release/Domain/Models/ReleaseType.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Release\Domain\Models;
+
+enum ReleaseType: int
+{
+    case Single = 1;
+
+    case Album = 2;
+
+    case Ep = 3;
+
+    case Other = 99;
+
+    public function getName(): string
+    {
+        return match ($this) {
+            self::Single => 'シングル',
+            self::Album => 'アルバム',
+            self::Ep => 'EP',
+            self::Other => 'その他',
+        };
+    }
+
+    public function equals(self $other): bool
+    {
+        return $this === $other;
+    }
+}

--- a/src/server/packages/Release/Domain/Models/ReleasedOn.php
+++ b/src/server/packages/Release/Domain/Models/ReleasedOn.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Release\Domain\Models;
+
+use Support\Domain\ValueObjects\Date\ImmutableDateValueObject;
+
+readonly class ReleasedOn extends ImmutableDateValueObject
+{
+}

--- a/src/server/packages/Release/Domain/Models/TrackEntries.php
+++ b/src/server/packages/Release/Domain/Models/TrackEntries.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Release\Domain\Models;
+
+use Support\Collection\ImmutableCollection;
+
+/**
+ * @extends ImmutableCollection<int, TrackEntry>
+ */
+readonly class TrackEntries extends ImmutableCollection
+{
+    /**
+     * @param list<array{songId: string, trackNo: int}> $items
+     */
+    public static function reconstruct(array $items): self
+    {
+        return new self(array_map(
+            static fn (array $item): TrackEntry => TrackEntry::reconstruct(
+                $item['songId'],
+                $item['trackNo'],
+            ),
+            $items,
+        ));
+    }
+
+    /**
+     * @return list<array{song_id: string, track_no: int}>
+     */
+    public function toArray(): array
+    {
+        $items = [];
+
+        foreach ($this->toGeneric() as $item) {
+            $items[] = $item->toArray();
+        }
+
+        return $items;
+    }
+}

--- a/src/server/packages/Release/Domain/Models/TrackEntry.php
+++ b/src/server/packages/Release/Domain/Models/TrackEntry.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Release\Domain\Models;
+
+use Song\Domain\Models\SongId;
+use Support\Domain\ValueObjects\OrderNo;
+
+readonly class TrackEntry
+{
+    public function __construct(
+        public SongId $songId,
+        public OrderNo $trackNo,
+    ) {
+    }
+
+    public static function reconstruct(string $songId, int $trackNo): self
+    {
+        return new self(
+            SongId::reconstruct($songId),
+            OrderNo::reconstruct($trackNo),
+        );
+    }
+
+    /**
+     * @return array{song_id: string, track_no: int}
+     */
+    public function toArray(): array
+    {
+        return [
+            'song_id' => $this->songId->value,
+            'track_no' => $this->trackNo->value,
+        ];
+    }
+}


### PR DESCRIPTION
## 概要
- Release 集約の最小基盤を server 側へ追加
- 収録曲を TrackEntry として扱う schema / Eloquent / domain model を追加
- 流通形態を単一の ReleaseDistributionType、発売日を ReleasedOn として命名を整理

## 変更内容
- src/server/database/atlas に releases と release_track_entries の schema を追加
- src/server/app/Models/Release に Release と TrackEntry の Eloquent model を追加
- src/server/packages/Release/Domain/Models に Release の pure domain model 群を追加
- src/server/composer.json に Release 名前空間の PSR-4 autoload を追加
- exec plan を docs/exec-plans/completed/20260508-release-foundation.md に記録

## 設計上の意図
- Song は Release も TrackEntry も持たない
- 収録曲との関係は Release 側の TrackEntry に閉じる
- 流通形態は複数持たず、版違いは別 Release として登録する

## 確認
- mise run api:phpstan packages/Release app/Models/Release
