### PR TITLE
Release 作成の収録楽曲追加と監査ログ修正

### DIFF
--- a/src/admin/src/components/audit-log/DetailView.tsx
+++ b/src/admin/src/components/audit-log/DetailView.tsx
@@ -14,6 +14,7 @@ const TARGET_TYPE_LABEL: Record<string, string> = {
   AdminUser: '管理ユーザー',
   Media: 'メディア',
   Person: '人物',
+  Release: 'リリース',
   Song: '楽曲',
   SongTag: '楽曲タグ',
 };

--- a/src/admin/src/components/audit-log/SearchList.tsx
+++ b/src/admin/src/components/audit-log/SearchList.tsx
@@ -14,7 +14,7 @@ type TargetType = AuditTargetType;
 // 型注釈で完全性を担保し、生成型に値が増減したらコンパイルエラーで気付ける形にする。
 const ACTION_OPTIONS = ['create', 'update', 'delete', 'login', 'refresh'] as const satisfies readonly Action[];
 
-const TARGET_TYPE_OPTIONS = ['AdminUser', 'Media', 'Person', 'Song', 'SongTag'] as const satisfies readonly TargetType[];
+const TARGET_TYPE_OPTIONS = ['AdminUser', 'Media', 'Person', 'Release', 'Song', 'SongTag'] as const satisfies readonly TargetType[];
 
 const ACTION_LABEL: Record<Action, string> = {
   create: '作成',
@@ -28,6 +28,7 @@ const TARGET_TYPE_LABEL: Record<TargetType, string> = {
   AdminUser: '管理ユーザー',
   Media: 'メディア',
   Person: '人物',
+  Release: 'リリース',
   Song: '楽曲',
   SongTag: '楽曲タグ',
 };

--- a/src/admin/src/components/release/CreateForm.tsx
+++ b/src/admin/src/components/release/CreateForm.tsx
@@ -126,7 +126,7 @@ export const CreateForm = () => {
       typeValue: typeValue(),
       distributionTypeValue: distributionTypeValue(),
       releasedOn: formData.get('releasedOn')?.toString() ?? '',
-      description: formData.get('description')?.toString() || undefined,
+      description: formData.get('description')?.toString() ?? '',
       isDisplay: isDisplay(),
       trackEntries: trackEntries().map((entry, index) => ({
         songId: entry.songId,

--- a/src/admin/src/components/release/CreateForm.tsx
+++ b/src/admin/src/components/release/CreateForm.tsx
@@ -1,5 +1,5 @@
-import { Show, createSignal } from 'solid-js';
-import type { ReleaseDistributionTypeValue, ReleaseTypeValue } from '../../generated';
+import { For, Show, createMemo, createSignal } from 'solid-js';
+import type { ReleaseDistributionTypeValue, ReleaseTypeValue, SongSummary } from '../../generated';
 import { client } from '../../utils/client';
 import { createFormErrors } from '../../utils/form-error';
 import { createSubmitting } from '../../utils/use-submitting';
@@ -19,11 +19,100 @@ const DISTRIBUTION_TYPE_OPTIONS: Array<{ value: ReleaseDistributionTypeValue; la
   { value: 99, label: 'その他' },
 ];
 
+type TrackEntryForm = {
+  songId: string;
+  title: string;
+};
+
 export const CreateForm = () => {
   const [typeValue, setTypeValue] = createSignal<ReleaseTypeValue>(1);
   const [distributionTypeValue, setDistributionTypeValue] = createSignal<ReleaseDistributionTypeValue>(1);
+  const [isDisplay, setIsDisplay] = createSignal(true);
+  const [trackEntries, setTrackEntries] = createSignal<TrackEntryForm[]>([]);
+  const [searchTitle, setSearchTitle] = createSignal('');
+  const [searchResults, setSearchResults] = createSignal<SongSummary[]>([]);
+  const [searchError, setSearchError] = createSignal<string | null>(null);
+  const [isSearching, setIsSearching] = createSignal(false);
+  const [hasSearched, setHasSearched] = createSignal(false);
+
   const { formError, getFieldError, clearErrors, handleError } = createFormErrors();
   const { isSubmitting, withSubmitting } = createSubmitting();
+
+  const selectedSongIds = createMemo(() => new Set(trackEntries().map(entry => entry.songId)));
+
+  const addTrackEntry = (song: SongSummary) => {
+    if (selectedSongIds().has(song.songId)) {
+      return;
+    }
+
+    setTrackEntries(prev => [...prev, { songId: song.songId, title: song.title }]);
+  };
+
+  const removeTrackEntry = (songId: string) => {
+    setTrackEntries(prev => prev.filter(entry => entry.songId !== songId));
+  };
+
+  const moveTrackEntry = (index: number, direction: -1 | 1) => {
+    setTrackEntries((prev) => {
+      const nextIndex = index + direction;
+      if (nextIndex < 0 || nextIndex >= prev.length) {
+        return prev;
+      }
+
+      const cloned = [...prev];
+      const [entry] = cloned.splice(index, 1);
+      if (!entry) {
+        return prev;
+      }
+      cloned.splice(nextIndex, 0, entry);
+
+      return cloned;
+    });
+  };
+
+  const handleSongSearch = async (e: Event) => {
+    e.preventDefault();
+    setSearchError(null);
+    setHasSearched(true);
+
+    if (searchTitle().trim() === '') {
+      setSearchResults([]);
+      setSearchError('楽曲名を入力してください');
+      return;
+    }
+
+    setIsSearching(true);
+
+    const { data, error, status } = await client.api.songs.search.get({
+      query: {
+        title: searchTitle().trim(),
+        sort: 'title',
+        order: 'asc',
+        page: 1,
+        per_page: 25,
+      },
+    });
+
+    setIsSearching(false);
+
+    if (status === 401) {
+      window.location.href = '/auth/login';
+      return;
+    }
+
+    if (!data) {
+      if (typeof error === 'object' && error !== null && 'value' in error) {
+        const body = (error as { value?: { message?: string } }).value;
+        setSearchError(body?.message ?? `検索に失敗しました (${status})`);
+      } else {
+        setSearchError(`検索に失敗しました (${status})`);
+      }
+      setSearchResults([]);
+      return;
+    }
+
+    setSearchResults(data.songs);
+  };
 
   const handleSubmit = withSubmitting(async (e: Event) => {
     e.preventDefault();
@@ -37,8 +126,12 @@ export const CreateForm = () => {
       typeValue: typeValue(),
       distributionTypeValue: distributionTypeValue(),
       releasedOn: formData.get('releasedOn')?.toString() ?? '',
-      description: formData.get('description')?.toString() ?? '',
-      isDisplay: formData.get('isDisplay') === 'true',
+      description: formData.get('description')?.toString() || undefined,
+      isDisplay: isDisplay(),
+      trackEntries: trackEntries().map((entry, index) => ({
+        songId: entry.songId,
+        trackNo: index + 1,
+      })),
     });
 
     if (data) {
@@ -51,12 +144,12 @@ export const CreateForm = () => {
   });
 
   return (
-    <form onsubmit={handleSubmit}>
+    <form onSubmit={handleSubmit}>
       <a href="/releases" class="btn btn-ghost btn-sm mb-4">
         ← 一覧に戻る
       </a>
       <FormError message={formError()} onClose={clearErrors} />
-      <div class="max-w-4xl space-y-6">
+      <div class="max-w-5xl space-y-6">
         <fieldset class="fieldset bg-base-200 border-base-300 rounded-box border p-6">
           <legend class="px-2 text-sm font-semibold text-base-content/70">基本情報</legend>
           <div class="grid gap-5 md:grid-cols-2">
@@ -92,9 +185,7 @@ export const CreateForm = () => {
                 value={String(typeValue())}
                 onChange={e => setTypeValue(Number(e.currentTarget.value) as ReleaseTypeValue)}
               >
-                {RELEASE_TYPE_OPTIONS.map(option => (
-                  <option value={option.value}>{option.label}</option>
-                ))}
+                <For each={RELEASE_TYPE_OPTIONS}>{option => <option value={option.value}>{option.label}</option>}</For>
               </select>
               <Show when={getFieldError('typeValue')}>{message => <p class="mt-1 text-xs text-error">{message()}</p>}</Show>
             </div>
@@ -107,9 +198,7 @@ export const CreateForm = () => {
                 value={String(distributionTypeValue())}
                 onChange={e => setDistributionTypeValue(Number(e.currentTarget.value) as ReleaseDistributionTypeValue)}
               >
-                {DISTRIBUTION_TYPE_OPTIONS.map(option => (
-                  <option value={option.value}>{option.label}</option>
-                ))}
+                <For each={DISTRIBUTION_TYPE_OPTIONS}>{option => <option value={option.value}>{option.label}</option>}</For>
               </select>
               <Show when={getFieldError('distributionTypeValue')}>
                 {message => <p class="mt-1 text-xs text-error">{message()}</p>}
@@ -121,7 +210,6 @@ export const CreateForm = () => {
               <textarea
                 class="textarea textarea-bordered min-h-32 w-full"
                 name="description"
-                required
                 classList={{ 'textarea-error': !!getFieldError('description') }}
               />
               <Show when={getFieldError('description')}>
@@ -131,25 +219,151 @@ export const CreateForm = () => {
 
             <div class="md:col-span-2">
               <label class="label">表示設定</label>
-              <div class="flex flex-wrap gap-4 rounded-box border border-base-300 bg-base-100 p-4">
-                <label class="label cursor-pointer justify-start gap-3">
-                  <input type="radio" class="radio radio-sm" name="isDisplay" value="true" checked />
-                  <span class="label-text">表示する</span>
-                </label>
-                <label class="label cursor-pointer justify-start gap-3">
-                  <input type="radio" class="radio radio-sm" name="isDisplay" value="false" />
-                  <span class="label-text">表示しない</span>
-                </label>
-              </div>
+              <select
+                class="select select-bordered w-full"
+                value={String(isDisplay())}
+                onChange={e => setIsDisplay(e.currentTarget.value === 'true')}
+                classList={{ 'select-error': !!getFieldError('isDisplay') }}
+              >
+                <option value="true">表示する</option>
+                <option value="false">表示しない</option>
+              </select>
+              <Show when={getFieldError('isDisplay')}>{message => <p class="mt-1 text-xs text-error">{message()}</p>}</Show>
             </div>
           </div>
+        </fieldset>
 
-          <div class="mt-6 flex justify-end">
-            <button class="btn btn-primary" disabled={isSubmitting()}>
-              {isSubmitting() ? '作成中...' : '作成'}
-            </button>
+        <fieldset class="rounded-box border border-base-300 bg-base-200 p-6">
+          <legend class="px-2 text-sm font-semibold text-base-content/70">収録楽曲</legend>
+          <Show when={getFieldError('trackEntries')}>{message => <p class="mb-4 text-sm text-error">{message()}</p>}</Show>
+          <div class="space-y-6">
+            <div>
+              <label class="label">現在の収録楽曲</label>
+              <Show
+                when={trackEntries().length > 0}
+                fallback={<p class="text-sm text-base-content/60">収録楽曲はまだ登録されていません。</p>}
+              >
+                <div class="overflow-x-auto rounded-box border border-base-300 bg-base-100">
+                  <table class="table table-sm">
+                    <thead>
+                      <tr>
+                        <th>曲順</th>
+                        <th>楽曲名</th>
+                        <th class="text-right">操作</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <For each={trackEntries()}>
+                        {(entry, index) => (
+                          <tr>
+                            <td>{index() + 1}</td>
+                            <td>{entry.title}</td>
+                            <td>
+                              <div class="flex justify-end gap-2">
+                                <button
+                                  type="button"
+                                  class="btn btn-ghost btn-xs"
+                                  disabled={index() === 0}
+                                  onClick={() => moveTrackEntry(index(), -1)}
+                                >
+                                  ↑
+                                </button>
+                                <button
+                                  type="button"
+                                  class="btn btn-ghost btn-xs"
+                                  disabled={index() === trackEntries().length - 1}
+                                  onClick={() => moveTrackEntry(index(), 1)}
+                                >
+                                  ↓
+                                </button>
+                                <a href={`/songs/${entry.songId}`} class="btn btn-ghost btn-xs">
+                                  楽曲を見る
+                                </a>
+                                <button type="button" class="btn btn-outline btn-error btn-xs" onClick={() => removeTrackEntry(entry.songId)}>
+                                  削除
+                                </button>
+                              </div>
+                            </td>
+                          </tr>
+                        )}
+                      </For>
+                    </tbody>
+                  </table>
+                </div>
+              </Show>
+            </div>
+
+            <div>
+              <label class="label">楽曲を追加</label>
+              <div class="flex flex-col gap-4 md:flex-row md:items-end">
+                <div class="flex-1">
+                  <label class="label">楽曲名</label>
+                  <input
+                    type="text"
+                    class="input input-bordered w-full"
+                    value={searchTitle()}
+                    onInput={e => setSearchTitle(e.currentTarget.value)}
+                    placeholder="楽曲名で検索"
+                  />
+                </div>
+                <button type="button" class="btn btn-primary" disabled={isSearching()} onClick={handleSongSearch}>
+                  {isSearching() ? '検索中...' : '検索'}
+                </button>
+              </div>
+
+              <Show when={searchError()}>
+                {message => <p class="mt-3 text-sm text-error">{message()}</p>}
+              </Show>
+
+              <Show when={hasSearched()}>
+                <div class="mt-4 overflow-x-auto rounded-box border border-base-300 bg-base-100">
+                  <table class="table table-sm">
+                    <thead>
+                      <tr>
+                        <th>楽曲名</th>
+                        <th>種別</th>
+                        <th>表示設定</th>
+                        <th class="text-right">操作</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <Show
+                        when={searchResults().length > 0}
+                        fallback={<tr><td colSpan={4} class="text-center text-sm text-base-content/60">条件に一致する楽曲はありません。</td></tr>}
+                      >
+                        <For each={searchResults()}>
+                          {song => (
+                            <tr>
+                              <td>{song.title}</td>
+                              <td>{song.type.name}</td>
+                              <td>{song.isDisplay ? '表示する' : '表示しない'}</td>
+                              <td class="text-right">
+                                <button
+                                  type="button"
+                                  class="btn btn-primary btn-xs"
+                                  disabled={selectedSongIds().has(song.songId)}
+                                  onClick={() => addTrackEntry(song)}
+                                >
+                                  {selectedSongIds().has(song.songId) ? '追加済み' : '追加'}
+                                </button>
+                              </td>
+                            </tr>
+                          )}
+                        </For>
+                      </Show>
+                    </tbody>
+                  </table>
+                </div>
+              </Show>
+            </div>
           </div>
         </fieldset>
+
+        <div class="flex justify-end">
+          <button class="btn btn-primary" disabled={isSubmitting()}>
+            {isSubmitting() ? '作成中...' : '作成'}
+          </button>
+        </div>
       </div>
     </form>
   );

--- a/src/admin/src/components/release/DetailView.tsx
+++ b/src/admin/src/components/release/DetailView.tsx
@@ -335,26 +335,16 @@ export const DetailView = (props: Props) => {
 
               <div class="md:col-span-2">
                 <label class="label">表示設定</label>
-                <div class="flex flex-wrap gap-4 rounded-box border border-base-300 bg-base-100 p-4">
-                  <label class="label cursor-pointer justify-start gap-3">
-                    <input
-                      type="radio"
-                      class="radio radio-sm"
-                      checked={isDisplay()}
-                      onChange={() => setIsDisplay(true)}
-                    />
-                    <span class="label-text">表示する</span>
-                  </label>
-                  <label class="label cursor-pointer justify-start gap-3">
-                    <input
-                      type="radio"
-                      class="radio radio-sm"
-                      checked={!isDisplay()}
-                      onChange={() => setIsDisplay(false)}
-                    />
-                    <span class="label-text">表示しない</span>
-                  </label>
-                </div>
+                <select
+                  class="select select-bordered w-full"
+                  value={String(isDisplay())}
+                  onChange={e => setIsDisplay(e.currentTarget.value === 'true')}
+                  classList={{ 'select-error': !!getFieldError('isDisplay') }}
+                >
+                  <option value="true">表示する</option>
+                  <option value="false">表示しない</option>
+                </select>
+                <Show when={getFieldError('isDisplay')}>{message => <p class="mt-1 text-xs text-error">{message()}</p>}</Show>
               </div>
             </div>
 
@@ -366,122 +356,130 @@ export const DetailView = (props: Props) => {
           </fieldset>
         </form>
 
-        <fieldset class="rounded-box border border-base-300 bg-base-100 p-6">
+        <fieldset class="rounded-box border border-base-300 bg-base-200 p-6">
           <legend class="px-2 text-sm font-semibold text-base-content/70">収録楽曲</legend>
           <Show when={getFieldError('trackEntries')}>{message => <p class="mb-4 text-sm text-error">{message()}</p>}</Show>
-          <Show
-            when={trackEntries().length > 0}
-            fallback={<p class="text-sm text-base-content/60">収録楽曲はまだ登録されていません。</p>}
-          >
-            <div class="overflow-x-auto">
-              <table class="table table-sm">
-                <thead>
-                  <tr>
-                    <th>曲順</th>
-                    <th>楽曲名</th>
-                    <th class="text-right">操作</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <For each={trackEntries()}>
-                    {(entry, index) => (
+          <div class="space-y-6">
+            <div>
+              <label class="label">現在の収録楽曲</label>
+              <Show
+                when={trackEntries().length > 0}
+                fallback={<p class="text-sm text-base-content/60">収録楽曲はまだ登録されていません。</p>}
+              >
+                <div class="overflow-x-auto rounded-box border border-base-300 bg-base-100">
+                  <table class="table table-sm">
+                    <thead>
                       <tr>
-                        <td>{index() + 1}</td>
-                        <td>{entry.title}</td>
-                        <td>
-                          <div class="flex justify-end gap-2">
-                            <button
-                              type="button"
-                              class="btn btn-ghost btn-xs"
-                              disabled={index() === 0}
-                              onClick={() => moveTrackEntry(index(), -1)}
-                            >
-                              ↑
-                            </button>
-                            <button
-                              type="button"
-                              class="btn btn-ghost btn-xs"
-                              disabled={index() === trackEntries().length - 1}
-                              onClick={() => moveTrackEntry(index(), 1)}
-                            >
-                              ↓
-                            </button>
-                            <a href={`/songs/${entry.songId}`} class="btn btn-ghost btn-xs">
-                              楽曲を見る
-                            </a>
-                            <button type="button" class="btn btn-outline btn-error btn-xs" onClick={() => removeTrackEntry(entry.songId)}>
-                              削除
-                            </button>
-                          </div>
-                        </td>
+                        <th>曲順</th>
+                        <th>楽曲名</th>
+                        <th class="text-right">操作</th>
                       </tr>
-                    )}
-                  </For>
-                </tbody>
-              </table>
+                    </thead>
+                    <tbody>
+                      <For each={trackEntries()}>
+                        {(entry, index) => (
+                          <tr>
+                            <td>{index() + 1}</td>
+                            <td>{entry.title}</td>
+                            <td>
+                              <div class="flex justify-end gap-2">
+                                <button
+                                  type="button"
+                                  class="btn btn-ghost btn-xs"
+                                  disabled={index() === 0}
+                                  onClick={() => moveTrackEntry(index(), -1)}
+                                >
+                                  ↑
+                                </button>
+                                <button
+                                  type="button"
+                                  class="btn btn-ghost btn-xs"
+                                  disabled={index() === trackEntries().length - 1}
+                                  onClick={() => moveTrackEntry(index(), 1)}
+                                >
+                                  ↓
+                                </button>
+                                <a href={`/songs/${entry.songId}`} class="btn btn-ghost btn-xs">
+                                  楽曲を見る
+                                </a>
+                                <button type="button" class="btn btn-outline btn-error btn-xs" onClick={() => removeTrackEntry(entry.songId)}>
+                                  削除
+                                </button>
+                              </div>
+                            </td>
+                          </tr>
+                        )}
+                      </For>
+                    </tbody>
+                  </table>
+                </div>
+              </Show>
             </div>
-          </Show>
-        </fieldset>
 
-        <fieldset class="rounded-box border border-base-300 bg-base-100 p-6">
-          <legend class="px-2 text-sm font-semibold text-base-content/70">楽曲を追加</legend>
-          <form onSubmit={handleSongSearch} class="flex flex-col gap-4 md:flex-row md:items-end">
-            <div class="flex-1">
-              <label class="label">楽曲名</label>
-              <input
-                type="text"
-                class="input input-bordered w-full"
-                value={searchTitle()}
-                onInput={e => setSearchTitle(e.currentTarget.value)}
-                placeholder="楽曲名で検索"
-              />
+            <div>
+              <label class="label">楽曲を追加</label>
+              <form onSubmit={handleSongSearch} class="flex flex-col gap-4 md:flex-row md:items-end">
+                <div class="flex-1">
+                  <label class="label">楽曲名</label>
+                  <input
+                    type="text"
+                    class="input input-bordered w-full"
+                    value={searchTitle()}
+                    onInput={e => setSearchTitle(e.currentTarget.value)}
+                    placeholder="楽曲名で検索"
+                  />
+                </div>
+                <button type="submit" class="btn btn-primary" disabled={isSearching()}>
+                  {isSearching() ? '検索中...' : '検索'}
+                </button>
+              </form>
+
+              <Show when={searchError()}>
+                {message => <p class="mt-3 text-sm text-error">{message()}</p>}
+              </Show>
+
+              <Show when={hasSearched()}>
+                <div class="mt-4 overflow-x-auto rounded-box border border-base-300 bg-base-100">
+                  <table class="table table-sm">
+                    <thead>
+                      <tr>
+                        <th>楽曲名</th>
+                        <th>種別</th>
+                        <th>表示設定</th>
+                        <th class="text-right">操作</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <Show
+                        when={searchResults().length > 0}
+                        fallback={<tr><td colSpan={4} class="text-center text-sm text-base-content/60">条件に一致する楽曲はありません。</td></tr>}
+                      >
+                        <For each={searchResults()}>
+                          {song => (
+                            <tr>
+                              <td>{song.title}</td>
+                              <td>{song.type.name}</td>
+                              <td>{song.isDisplay ? '表示する' : '表示しない'}</td>
+                              <td class="text-right">
+                                <button
+                                  type="button"
+                                  class="btn btn-primary btn-xs"
+                                  disabled={selectedSongIds().has(song.songId)}
+                                  onClick={() => addTrackEntry(song)}
+                                >
+                                  {selectedSongIds().has(song.songId) ? '追加済み' : '追加'}
+                                </button>
+                              </td>
+                            </tr>
+                          )}
+                        </For>
+                      </Show>
+                    </tbody>
+                  </table>
+                </div>
+              </Show>
             </div>
-            <button type="submit" class="btn btn-primary" disabled={isSearching()}>
-              {isSearching() ? '検索中...' : '検索'}
-            </button>
-          </form>
-
-          <Show when={searchError()}>
-            {message => <p class="mt-3 text-sm text-error">{message()}</p>}
-          </Show>
-
-          <Show when={hasSearched()}>
-            <div class="mt-4 overflow-x-auto">
-              <table class="table table-sm">
-                <thead>
-                  <tr>
-                    <th>楽曲名</th>
-                    <th>種別</th>
-                    <th>表示設定</th>
-                    <th class="text-right">操作</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <Show when={searchResults().length > 0} fallback={<tr><td colSpan={4} class="text-center text-sm text-base-content/60">条件に一致する楽曲はありません。</td></tr>}>
-                    <For each={searchResults()}>
-                      {song => (
-                        <tr>
-                          <td>{song.title}</td>
-                          <td>{song.type.name}</td>
-                          <td>{song.isDisplay ? '表示する' : '表示しない'}</td>
-                          <td class="text-right">
-                            <button
-                              type="button"
-                              class="btn btn-primary btn-xs"
-                              disabled={selectedSongIds().has(song.songId)}
-                              onClick={() => addTrackEntry(song)}
-                            >
-                              {selectedSongIds().has(song.songId) ? '追加済み' : '追加'}
-                            </button>
-                          </td>
-                        </tr>
-                      )}
-                    </For>
-                  </Show>
-                </tbody>
-              </table>
-            </div>
-          </Show>
+          </div>
         </fieldset>
 
         <fieldset class="rounded-box border border-error/20 bg-error/5 p-6">

--- a/src/admin/src/components/release/SearchList.tsx
+++ b/src/admin/src/components/release/SearchList.tsx
@@ -191,12 +191,6 @@ export const SearchList = () => {
 
   return (
     <>
-      <div class="mb-4 flex justify-end">
-        <a href="/releases/create" class="btn btn-primary btn-sm">
-          新規作成
-        </a>
-      </div>
-
       <form onSubmit={handleSearch} class="mb-4 flex flex-wrap items-end gap-4">
         <fieldset class="fieldset">
           <label class="fieldset-label" for="title">
@@ -276,6 +270,12 @@ export const SearchList = () => {
         </button>
       </form>
 
+      <div class="mb-4 flex justify-end">
+        <a href="/releases/create" class="btn btn-primary btn-sm">
+          新規作成
+        </a>
+      </div>
+
       <div class="overflow-x-auto rounded-box border border-base-300 bg-base-100">
         <table class="table table-zebra">
           <thead>
@@ -285,29 +285,26 @@ export const SearchList = () => {
               <th>流通形態</th>
               <th>発売日</th>
               <th>表示設定</th>
+              <th>操作</th>
             </tr>
           </thead>
           <tbody>
             <Switch>
               <Match when={data.loading}>
-                <ListState state="loading" colSpan={5} />
+                <ListState state="loading" colSpan={6} />
               </Match>
               <Match when={fetchError()}>
-                {message => <ListState state="error" colSpan={5} message={message()} onRetry={() => refetch()} />}
+                {message => <ListState state="error" colSpan={6} message={message()} onRetry={() => refetch()} />}
               </Match>
               <Match when={data() && data()!.releases.length === 0}>
-                <ListState state="empty" colSpan={5} message="条件に一致するリリースはありません。" />
+                <ListState state="empty" colSpan={6} message="条件に一致するリリースはありません。" />
               </Match>
               <Match when={data()}>
                 {result => (
                   <For each={result().releases}>
                     {release => (
                       <tr>
-                        <td class="min-w-56">
-                          <a href={buildDetailHref(release.releaseId)} class="link link-hover font-medium">
-                            {release.title}
-                          </a>
-                        </td>
+                        <td class="min-w-56 font-medium">{release.title}</td>
                         <td>{RELEASE_TYPE_OPTIONS.find(option => option.value === String(release.typeValue))?.label ?? '不明'}</td>
                         <td>{DISTRIBUTION_TYPE_OPTIONS.find(option => option.value === String(release.distributionTypeValue))?.label ?? '不明'}</td>
                         <td class="whitespace-nowrap text-sm">{normalizeDateDisplayValue(release.releasedOn)}</td>
@@ -315,6 +312,11 @@ export const SearchList = () => {
                           <span class={`badge badge-sm ${release.isDisplay ? 'badge-success badge-soft' : 'badge-ghost'}`}>
                             {release.isDisplay ? '表示する' : '表示しない'}
                           </span>
+                        </td>
+                        <td>
+                          <a href={buildDetailHref(release.releaseId)} class="btn btn-ghost btn-xs">
+                            編集
+                          </a>
                         </td>
                       </tr>
                     )}

--- a/src/admin/src/generated/types.gen.ts
+++ b/src/admin/src/generated/types.gen.ts
@@ -235,7 +235,7 @@ export type ReleaseCreateRequest = {
     typeValue: ReleaseTypeValue;
     distributionTypeValue: ReleaseDistributionTypeValue;
     releasedOn: ReleasedOn;
-    description?: string;
+    description: string;
     isDisplay: boolean;
     trackEntries: Array<TrackEntry>;
 };

--- a/src/admin/src/generated/types.gen.ts
+++ b/src/admin/src/generated/types.gen.ts
@@ -66,7 +66,7 @@ export type AuditLogSummary = {
 /**
  * 監査ログの対象種別
  */
-export type AuditTargetType = 'AdminUser' | 'Media' | 'Person' | 'Song' | 'SongTag';
+export type AuditTargetType = 'AdminUser' | 'Media' | 'Person' | 'Release' | 'Song' | 'SongTag';
 
 export type ErrorResponse = {
     message: string;
@@ -235,8 +235,9 @@ export type ReleaseCreateRequest = {
     typeValue: ReleaseTypeValue;
     distributionTypeValue: ReleaseDistributionTypeValue;
     releasedOn: ReleasedOn;
-    description: string;
+    description?: string;
     isDisplay: boolean;
+    trackEntries: Array<TrackEntry>;
 };
 
 export type ReleaseCreateResponse = {

--- a/src/admin/src/pages/releases/create/index.astro
+++ b/src/admin/src/pages/releases/create/index.astro
@@ -1,7 +1,7 @@
 ---
-import { FlashMessage } from '../../../../components/Flash';
-import { CreateForm } from '../../../../components/release/CreateForm';
-import Layout from '../../../../layouts/Layout.astro';
+import { FlashMessage } from '../../../components/Flash';
+import { CreateForm } from '../../../components/release/CreateForm';
+import Layout from '../../../layouts/Layout.astro';
 
 export const prerender = false;
 ---

--- a/src/admin/src/server/routes/audit-logs.ts
+++ b/src/admin/src/server/routes/audit-logs.ts
@@ -20,6 +20,7 @@ const AuditTargetTypeSchema = t.Union([
   t.Literal('AdminUser'),
   t.Literal('Media'),
   t.Literal('Person'),
+  t.Literal('Release'),
   t.Literal('Song'),
   t.Literal('SongTag'),
 ]);

--- a/src/admin/src/server/routes/releases.ts
+++ b/src/admin/src/server/routes/releases.ts
@@ -20,8 +20,12 @@ export const releases = new Elysia({ prefix: '/releases' })
         typeValue: t.Numeric(),
         distributionTypeValue: t.Numeric(),
         releasedOn: t.String(),
-        description: t.String(),
+        description: t.Optional(t.String()),
         isDisplay: t.Boolean(),
+        trackEntries: t.Array(t.Object({
+          songId: t.String(),
+          trackNo: t.Number(),
+        })),
       }),
     },
   )

--- a/src/admin/src/server/routes/releases.ts
+++ b/src/admin/src/server/routes/releases.ts
@@ -20,7 +20,7 @@ export const releases = new Elysia({ prefix: '/releases' })
         typeValue: t.Numeric(),
         distributionTypeValue: t.Numeric(),
         releasedOn: t.String(),
-        description: t.Optional(t.String()),
+        description: t.String(),
         isDisplay: t.Boolean(),
         trackEntries: t.Array(t.Object({
           songId: t.String(),

--- a/src/contracts/generated/oas/IsekaiObservatory.Admin.v1.yaml
+++ b/src/contracts/generated/oas/IsekaiObservatory.Admin.v1.yaml
@@ -1653,6 +1653,7 @@ components:
         - AdminUser
         - Media
         - Person
+        - Release
         - Song
         - SongTag
       description: 監査ログの対象種別
@@ -2031,8 +2032,8 @@ components:
         - typeValue
         - distributionTypeValue
         - releasedOn
-        - description
         - isDisplay
+        - trackEntries
       properties:
         title:
           $ref: '#/components/schemas/releaseTitle'
@@ -2046,6 +2047,10 @@ components:
           type: string
         isDisplay:
           type: boolean
+        trackEntries:
+          type: array
+          items:
+            $ref: '#/components/schemas/TrackEntry'
     ReleaseCreateResponse:
       type: object
       required:

--- a/src/contracts/generated/oas/IsekaiObservatory.Admin.v1.yaml
+++ b/src/contracts/generated/oas/IsekaiObservatory.Admin.v1.yaml
@@ -2032,6 +2032,7 @@ components:
         - typeValue
         - distributionTypeValue
         - releasedOn
+        - description
         - isDisplay
         - trackEntries
       properties:

--- a/src/contracts/src/admin/audit-logs/domain.tsp
+++ b/src/contracts/src/admin/audit-logs/domain.tsp
@@ -19,6 +19,7 @@ enum AuditTargetType {
   adminUser: "AdminUser",
   media: "Media",
   person: "Person",
+  release: "Release",
   song: "Song",
   songTag: "SongTag",
 }

--- a/src/contracts/src/admin/releases/transport.tsp
+++ b/src/contracts/src/admin/releases/transport.tsp
@@ -5,7 +5,7 @@ model ReleaseCreateRequest {
   typeValue: ReleaseTypeValue;
   distributionTypeValue: ReleaseDistributionTypeValue;
   releasedOn: releasedOn;
-  description?: string;
+  description: string;
   isDisplay: boolean;
   trackEntries: TrackEntry[];
 }

--- a/src/contracts/src/admin/releases/transport.tsp
+++ b/src/contracts/src/admin/releases/transport.tsp
@@ -5,8 +5,9 @@ model ReleaseCreateRequest {
   typeValue: ReleaseTypeValue;
   distributionTypeValue: ReleaseDistributionTypeValue;
   releasedOn: releasedOn;
-  description: string;
+  description?: string;
   isDisplay: boolean;
+  trackEntries: TrackEntry[];
 }
 
 model ReleaseCreateResponse {

--- a/src/server/Generated/lib/Model/AuditTargetType.php
+++ b/src/server/Generated/lib/Model/AuditTargetType.php
@@ -49,6 +49,8 @@ enum AuditTargetType: string
 
     case PERSON = 'Person';
 
+    case RELEASE = 'Release';
+
     case SONG = 'Song';
 
     case SONG_TAG = 'SongTag';

--- a/src/server/Generated/lib/Model/ReleaseCreateRequest.php
+++ b/src/server/Generated/lib/Model/ReleaseCreateRequest.php
@@ -62,7 +62,8 @@ class ReleaseCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
         'distribution_type_value' => '\OpenAPI\Client\Model\ReleaseDistributionTypeValue',
         'released_on' => '\DateTime',
         'description' => 'string',
-        'is_display' => 'bool'
+        'is_display' => 'bool',
+        'track_entries' => '\OpenAPI\Client\Model\TrackEntry[]'
     ];
 
     /**
@@ -78,7 +79,8 @@ class ReleaseCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
         'distribution_type_value' => null,
         'released_on' => 'date',
         'description' => null,
-        'is_display' => null
+        'is_display' => null,
+        'track_entries' => null
     ];
 
     /**
@@ -92,7 +94,8 @@ class ReleaseCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
         'distribution_type_value' => false,
         'released_on' => false,
         'description' => false,
-        'is_display' => false
+        'is_display' => false,
+        'track_entries' => false
     ];
 
     /**
@@ -186,7 +189,8 @@ class ReleaseCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
         'distribution_type_value' => 'distributionTypeValue',
         'released_on' => 'releasedOn',
         'description' => 'description',
-        'is_display' => 'isDisplay'
+        'is_display' => 'isDisplay',
+        'track_entries' => 'trackEntries'
     ];
 
     /**
@@ -200,7 +204,8 @@ class ReleaseCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
         'distribution_type_value' => 'setDistributionTypeValue',
         'released_on' => 'setReleasedOn',
         'description' => 'setDescription',
-        'is_display' => 'setIsDisplay'
+        'is_display' => 'setIsDisplay',
+        'track_entries' => 'setTrackEntries'
     ];
 
     /**
@@ -214,7 +219,8 @@ class ReleaseCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
         'distribution_type_value' => 'getDistributionTypeValue',
         'released_on' => 'getReleasedOn',
         'description' => 'getDescription',
-        'is_display' => 'getIsDisplay'
+        'is_display' => 'getIsDisplay',
+        'track_entries' => 'getTrackEntries'
     ];
 
     /**
@@ -280,6 +286,7 @@ class ReleaseCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
         $this->setIfExists('released_on', $data ?? [], null);
         $this->setIfExists('description', $data ?? [], null);
         $this->setIfExists('is_display', $data ?? [], null);
+        $this->setIfExists('track_entries', $data ?? [], null);
     }
 
     /**
@@ -325,11 +332,11 @@ class ReleaseCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
         if ($this->container['released_on'] === null) {
             $invalidProperties[] = "'released_on' can't be null";
         }
-        if ($this->container['description'] === null) {
-            $invalidProperties[] = "'description' can't be null";
-        }
         if ($this->container['is_display'] === null) {
             $invalidProperties[] = "'is_display' can't be null";
+        }
+        if ($this->container['track_entries'] === null) {
+            $invalidProperties[] = "'track_entries' can't be null";
         }
         return $invalidProperties;
     }
@@ -462,7 +469,7 @@ class ReleaseCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
     /**
      * Gets description
      *
-     * @return string
+     * @return string|null
      */
     public function getDescription()
     {
@@ -472,7 +479,7 @@ class ReleaseCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
     /**
      * Sets description
      *
-     * @param string $description description
+     * @param string|null $description description
      *
      * @return self
      */
@@ -509,6 +516,33 @@ class ReleaseCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
             throw new \InvalidArgumentException('non-nullable is_display cannot be null');
         }
         $this->container['is_display'] = $is_display;
+
+        return $this;
+    }
+
+    /**
+     * Gets track_entries
+     *
+     * @return \OpenAPI\Client\Model\TrackEntry[]
+     */
+    public function getTrackEntries()
+    {
+        return $this->container['track_entries'];
+    }
+
+    /**
+     * Sets track_entries
+     *
+     * @param \OpenAPI\Client\Model\TrackEntry[] $track_entries track_entries
+     *
+     * @return self
+     */
+    public function setTrackEntries($track_entries)
+    {
+        if (is_null($track_entries)) {
+            throw new \InvalidArgumentException('non-nullable track_entries cannot be null');
+        }
+        $this->container['track_entries'] = $track_entries;
 
         return $this;
     }

--- a/src/server/Generated/lib/Model/ReleaseCreateRequest.php
+++ b/src/server/Generated/lib/Model/ReleaseCreateRequest.php
@@ -332,6 +332,9 @@ class ReleaseCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
         if ($this->container['released_on'] === null) {
             $invalidProperties[] = "'released_on' can't be null";
         }
+        if ($this->container['description'] === null) {
+            $invalidProperties[] = "'description' can't be null";
+        }
         if ($this->container['is_display'] === null) {
             $invalidProperties[] = "'is_display' can't be null";
         }
@@ -469,7 +472,7 @@ class ReleaseCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
     /**
      * Gets description
      *
-     * @return string|null
+     * @return string
      */
     public function getDescription()
     {
@@ -479,7 +482,7 @@ class ReleaseCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
     /**
      * Sets description
      *
-     * @param string|null $description description
+     * @param string $description description
      *
      * @return self
      */

--- a/src/server/app/Http/Controllers/Api/Admin/V1/Release/CreateReleaseController.php
+++ b/src/server/app/Http/Controllers/Api/Admin/V1/Release/CreateReleaseController.php
@@ -23,20 +23,8 @@ class CreateReleaseController extends Controller
 
     public function handle(Request $request): JsonResponse
     {
-        return $this->buildInput($request)
+        return $this->mapper->map(CreateInputData::class, $request->all())
             |> $this->useCase->handle(...)
             |> $this->presenter->present(...);
-    }
-
-    private function buildInput(Request $request): CreateInputData
-    {
-        return $this->mapper->map(
-            CreateInputData::class,
-            [
-                ...$request->all(),
-                'description' => $request->string('description')->toString(),
-                'trackEntries' => $request->array('trackEntries'),
-            ],
-        );
     }
 }

--- a/src/server/app/Http/Controllers/Api/Admin/V1/Release/CreateReleaseController.php
+++ b/src/server/app/Http/Controllers/Api/Admin/V1/Release/CreateReleaseController.php
@@ -23,8 +23,20 @@ class CreateReleaseController extends Controller
 
     public function handle(Request $request): JsonResponse
     {
-        return $this->mapper->map(CreateInputData::class, $request->all())
+        return $this->buildInput($request)
             |> $this->useCase->handle(...)
             |> $this->presenter->present(...);
+    }
+
+    private function buildInput(Request $request): CreateInputData
+    {
+        return $this->mapper->map(
+            CreateInputData::class,
+            [
+                ...$request->all(),
+                'description' => $request->string('description')->toString(),
+                'trackEntries' => $request->array('trackEntries'),
+            ],
+        );
     }
 }

--- a/src/server/packages/Release/Application/Admin/UseCase/Create/CreateInputData.php
+++ b/src/server/packages/Release/Application/Admin/UseCase/Create/CreateInputData.php
@@ -14,8 +14,8 @@ readonly class CreateInputData
         public int $typeValue,
         public int $distributionTypeValue,
         public string $releasedOn,
-        public bool $isDisplay,
         public string $description,
+        public bool $isDisplay,
         public array $trackEntries,
     ) {
     }

--- a/src/server/packages/Release/Application/Admin/UseCase/Create/CreateInputData.php
+++ b/src/server/packages/Release/Application/Admin/UseCase/Create/CreateInputData.php
@@ -6,13 +6,17 @@ namespace Release\Application\Admin\UseCase\Create;
 
 readonly class CreateInputData
 {
+    /**
+     * @param list<array{songId: string, trackNo: int}> $trackEntries
+     */
     public function __construct(
         public string $title,
         public int $typeValue,
         public int $distributionTypeValue,
         public string $releasedOn,
-        public string $description,
         public bool $isDisplay,
+        public string $description,
+        public array $trackEntries,
     ) {
     }
 }

--- a/src/server/packages/Release/Application/Admin/UseCase/Create/CreateUseCase.php
+++ b/src/server/packages/Release/Application/Admin/UseCase/Create/CreateUseCase.php
@@ -55,6 +55,7 @@ readonly class CreateUseCase
                 $inputData->releasedOn,
                 $inputData->description,
                 $inputData->isDisplay,
+                $inputData->trackEntries,
             );
 
             if ($result->isErr()) {

--- a/src/server/packages/Release/Domain/Services/ReleaseIntegrityService.php
+++ b/src/server/packages/Release/Domain/Services/ReleaseIntegrityService.php
@@ -33,6 +33,8 @@ class ReleaseIntegrityService
     }
 
     /**
+     * @param list<array{songId: string, trackNo: int}> $trackEntries
+     *
      * @return Result<Release, DomainError>
      */
     public function prepareForCreate(
@@ -42,8 +44,9 @@ class ReleaseIntegrityService
         string $releasedOn,
         string $description,
         bool $isDisplay,
+        array $trackEntries,
     ): Result {
-        return $this->build(
+        $result = $this->build(
             $this->generator->generate(),
             $title,
             $typeValue,
@@ -51,8 +54,20 @@ class ReleaseIntegrityService
             $releasedOn,
             $description,
             $isDisplay,
-            [],
+            $trackEntries,
         );
+
+        if ($result->isErr()) {
+            return new Err($result->unwrapErr());
+        }
+
+        $release = $result->unwrap();
+
+        if (! $this->existsSongs($release->trackEntries)) {
+            return new Err(new BusinessRuleViolationError('指定された楽曲の一部が存在しません。'));
+        }
+
+        return new Ok($release);
     }
 
     /**

--- a/src/server/tests/Feature/Api/Admin/V1/AuditLog/GetAuditLogTest.php
+++ b/src/server/tests/Feature/Api/Admin/V1/AuditLog/GetAuditLogTest.php
@@ -51,7 +51,7 @@ class GetAuditLogTest extends DatabaseTestCase
             ->get(route(AuditLogRouteMap::Get, $auditLogId))
             ->assertStatus(200)
             ->json();
-
+        /** @var array{auditLog: array{auditLogId: string, adminUserId: string, adminUserName: string, action: string, targetType: string, targetId: string, createdAt: string, snapshot: array{title: string, tags: array<int, string>, meta: array{version: int, isDisplay: bool}}}} $response */
         $this->assertArrayHasKey('auditLog', $response);
         $this->assertSame($auditLogId, $response['auditLog']['auditLogId']);
         $this->assertSame($actorId, $response['auditLog']['adminUserId']);
@@ -64,6 +64,34 @@ class GetAuditLogTest extends DatabaseTestCase
         $this->assertSame(['オリジナル', '感動'], $response['auditLog']['snapshot']['tags']);
         $this->assertSame(3, $response['auditLog']['snapshot']['meta']['version']);
         $this->assertTrue($response['auditLog']['snapshot']['meta']['isDisplay']);
+    }
+
+    #[Test]
+    public function foundForRelease(): void
+    {
+        $actorId = $this->generateUuid();
+        $this->storeAdminUsers($this->createAdminUser($actorId, 'actor@example.com', Role::Privilege, name: '監査太郎'));
+
+        $auditLogId = $this->generateUuid();
+        $targetId = $this->generateUuid();
+
+        $this->insertAuditLog(
+            $auditLogId,
+            $actorId,
+            AuditAction::Update,
+            AuditTargetType::Release,
+            $targetId,
+            ['title' => '観測された春'],
+            new DateTimeImmutable('2026-04-02 10:00:00'),
+        );
+
+        $response = $this->withAuth()
+            ->get(route(AuditLogRouteMap::Get, $auditLogId))
+            ->assertStatus(200)
+            ->json();
+        /** @var array{auditLog: array{targetType: string, snapshot: array{title: string}}} $response */
+        $this->assertSame('Release', $response['auditLog']['targetType']);
+        $this->assertSame('観測された春', $response['auditLog']['snapshot']['title']);
     }
 
     #[Test]

--- a/src/server/tests/Feature/Api/Admin/V1/AuditLog/SearchAuditLogTest.php
+++ b/src/server/tests/Feature/Api/Admin/V1/AuditLog/SearchAuditLogTest.php
@@ -45,7 +45,7 @@ class SearchAuditLogTest extends DatabaseTestCase
             ->get(route(AuditLogRouteMap::Search))
             ->assertStatus(200)
             ->json();
-
+        /** @var array{maxPage: int, auditLogs: list<array{auditLogId: string, adminUserId: string, adminUserName: string, action: string, targetType: string, targetId: string}>} $response */
         $this->assertSame(1, $response['maxPage']);
         $this->assertCount(1, $response['auditLogs']);
         $this->assertSame($auditLogId, $response['auditLogs'][0]['auditLogId']);
@@ -54,6 +54,43 @@ class SearchAuditLogTest extends DatabaseTestCase
         $this->assertSame('update', $response['auditLogs'][0]['action']);
         $this->assertSame('Song', $response['auditLogs'][0]['targetType']);
         $this->assertSame($targetId, $response['auditLogs'][0]['targetId']);
+    }
+
+    #[Test]
+    public function canFilterReleaseTargetType(): void
+    {
+        $actorId = $this->generateUuid();
+        $this->storeAdminUsers($this->createAdminUser($actorId, 'actor@example.com', Role::Privilege, name: '監査太郎'));
+
+        $releaseAuditLogId = $this->generateUuid();
+
+        $this->insertAuditLog(
+            $releaseAuditLogId,
+            $actorId,
+            AuditAction::Update,
+            AuditTargetType::Release,
+            $this->generateUuid(),
+            ['title' => '観測された春'],
+            new DateTimeImmutable('2026-04-02 10:00:00'),
+        );
+        $this->insertAuditLog(
+            $this->generateUuid(),
+            $actorId,
+            AuditAction::Update,
+            AuditTargetType::Song,
+            $this->generateUuid(),
+            ['title' => '描き続けた君へ'],
+            new DateTimeImmutable('2026-04-03 10:00:00'),
+        );
+
+        $response = $this->withAuth()
+            ->get(route(AuditLogRouteMap::Search, ['target_type' => 'Release']))
+            ->assertStatus(200)
+            ->json();
+        /** @var array{auditLogs: list<array{auditLogId: string, targetType: string}>} $response */
+        $this->assertCount(1, $response['auditLogs']);
+        $this->assertSame($releaseAuditLogId, $response['auditLogs'][0]['auditLogId']);
+        $this->assertSame('Release', $response['auditLogs'][0]['targetType']);
     }
 
     #[Test]
@@ -89,7 +126,7 @@ class SearchAuditLogTest extends DatabaseTestCase
             ->get(route(AuditLogRouteMap::Search, ['admin_user_name' => '監査']))
             ->assertStatus(200)
             ->json();
-
+        /** @var array{auditLogs: list<array{adminUserName: string}>} $response */
         $this->assertCount(1, $response['auditLogs']);
         $this->assertSame('監査太郎', $response['auditLogs'][0]['adminUserName']);
     }

--- a/src/server/tests/Feature/Api/Admin/V1/Release/CreateReleaseTest.php
+++ b/src/server/tests/Feature/Api/Admin/V1/Release/CreateReleaseTest.php
@@ -7,24 +7,37 @@ namespace Tests\Feature\Api\Admin\V1\Release;
 use Illuminate\Testing\Fluent\AssertableJson;
 use PHPUnit\Framework\Attributes\Test;
 use Release\Route\ReleaseRouteMap;
+use Song\Domain\Models\SongType;
 use Tests\Feature\Api\Admin\WithAuth;
 use Tests\Support\DatabaseTestCase;
+use Tests\Support\Domain\EntityFactory;
+use Tests\Support\Domain\EntityStore;
 
 class CreateReleaseTest extends DatabaseTestCase
 {
+    use EntityFactory;
+    use EntityStore;
     use WithAuth;
 
     #[Test]
     public function canCreate(): void
     {
+        $songId = $this->generateUuid();
+
+        $this->storeSongs(
+            $this->createSong($songId, '一曲目', '説明', SongType::Original, true, 1),
+        );
+
         $this->withAuth()
             ->postJson(route(ReleaseRouteMap::Create), [
                 'title' => '観測された春',
                 'typeValue' => 2,
                 'distributionTypeValue' => 1,
                 'releasedOn' => '2026-05-09',
-                'description' => '説明',
                 'isDisplay' => true,
+                'trackEntries' => [
+                    ['songId' => $songId, 'trackNo' => 1],
+                ],
             ])->assertStatus(200)
             ->assertJson(
                 fn (AssertableJson $json) => $json
@@ -36,9 +49,10 @@ class CreateReleaseTest extends DatabaseTestCase
                             ->where('typeValue', 2)
                             ->where('distributionTypeValue', 1)
                             ->where('releasedOn', '2026-05-09')
-                            ->where('description', '説明')
+                            ->where('description', '')
                             ->where('isDisplay', true)
-                            ->where('trackEntries', []),
+                            ->where('trackEntries.0.songId', $songId)
+                            ->where('trackEntries.0.trackNo', 1),
                     ),
             );
     }
@@ -54,6 +68,7 @@ class CreateReleaseTest extends DatabaseTestCase
                 'releasedOn' => 'invalid-date',
                 'description' => '説明',
                 'isDisplay' => true,
+                'trackEntries' => [],
             ])->assertStatus(422)
             ->assertJson(
                 fn (AssertableJson $json) => $json

--- a/src/server/tests/Feature/Api/Admin/V1/Release/CreateReleaseTest.php
+++ b/src/server/tests/Feature/Api/Admin/V1/Release/CreateReleaseTest.php
@@ -34,6 +34,7 @@ class CreateReleaseTest extends DatabaseTestCase
                 'typeValue' => 2,
                 'distributionTypeValue' => 1,
                 'releasedOn' => '2026-05-09',
+                'description' => '',
                 'isDisplay' => true,
                 'trackEntries' => [
                     ['songId' => $songId, 'trackNo' => 1],

--- a/src/server/tests/Integration/Release/Application/Admin/UseCase/Create/CreateUseCaseTest.php
+++ b/src/server/tests/Integration/Release/Application/Admin/UseCase/Create/CreateUseCaseTest.php
@@ -5,39 +5,56 @@ declare(strict_types=1);
 namespace Tests\Integration\Release\Application\Admin\UseCase\Create;
 
 use App\Models\Release\Release as ModelsRelease;
+use App\Models\Release\TrackEntry as ModelsTrackEntry;
 use PHPUnit\Framework\Attributes\Test;
 use Release\Application\Admin\UseCase\Create\CreateInputData;
 use Release\Application\Admin\UseCase\Create\CreateUseCase;
 use Release\Domain\Models\ReleaseDistributionType;
 use Release\Domain\Models\ReleaseType;
+use Song\Domain\Models\SongType;
 use Support\UseCase\Error\InvalidInputError;
 use Tests\Support\DatabaseTestCase;
+use Tests\Support\Domain\EntityFactory;
+use Tests\Support\Domain\EntityStore;
 
 class CreateUseCaseTest extends DatabaseTestCase
 {
+    use EntityFactory;
+    use EntityStore;
+
     #[Test]
     public function canCreate(): void
     {
+        $songId = $this->generateUuid();
+
+        $this->storeSongs(
+            $this->createSong($songId, '一曲目', '説明', SongType::Original, true, 1),
+        );
+
         $result = $this->getInstance()->handle(new CreateInputData(
             title: '観測された春',
             typeValue: ReleaseType::Album->value,
             distributionTypeValue: ReleaseDistributionType::Digital->value,
             releasedOn: '2026-05-09',
-            description: '説明',
+            description: '',
             isDisplay: true,
+            trackEntries: [
+                ['songId' => $songId, 'trackNo' => 1],
+            ],
         ));
 
         $this->assertTrue($result->isOk());
         $this->assertSame('観測された春', $result->unwrap()->release->title->value);
-        $this->assertCount(0, $result->unwrap()->release->trackEntries->toGeneric());
+        $this->assertCount(1, $result->unwrap()->release->trackEntries->toGeneric());
 
         $this->assertDatabaseHas(ModelsRelease::class, [
             'title' => '観測された春',
             'type' => ReleaseType::Album->value,
             'distribution_type' => ReleaseDistributionType::Digital->value,
-            'description' => '説明',
+            'description' => '',
             'is_display' => true,
         ]);
+        $this->assertDatabaseCount(ModelsTrackEntry::class, 1);
     }
 
     #[Test]
@@ -50,6 +67,7 @@ class CreateUseCaseTest extends DatabaseTestCase
             releasedOn: 'invalid-date',
             description: '説明',
             isDisplay: true,
+            trackEntries: [],
         ));
 
         $this->assertTrue($result->isErr());


### PR DESCRIPTION
## 概要

Release 作成で説明を任意にしつつ収録楽曲を追加できるようにし、あわせて Release を含む監査ログが閲覧できない問題を修正します。

## やったこと

- Release 作成 API の request を拡張し、description の任意化と trackEntries 追加に対応
- Release 作成画面に楽曲検索・追加・削除・並び替え UI を追加し、一覧や詳細の導線・見た目も調整
- AuditTargetType に Release を追加し、監査ログの一覧・詳細・BFF・回帰テストを修正

## やってないこと

- Release 更新時の既知の contract ずれ修正
- 監査ログのデザイン刷新

## 関連

- 特になし