### PR TITLE
Viewer 楽曲一覧に人物配列とリリース件数を追加

### DIFF
--- a/src/contracts/generated/oas/IsekaiObservatory.Viewer.v1.yaml
+++ b/src/contracts/generated/oas/IsekaiObservatory.Viewer.v1.yaml
@@ -47,6 +47,9 @@ components:
         - description
         - type
         - counts
+        - lyricists
+        - composers
+        - arrangers
       properties:
         songId:
           $ref: '#/components/schemas/songId'
@@ -58,6 +61,18 @@ components:
           $ref: '#/components/schemas/SongType'
         counts:
           $ref: '#/components/schemas/SongRelationCounts'
+        lyricists:
+          type: array
+          items:
+            type: string
+        composers:
+          type: array
+          items:
+            type: string
+        arrangers:
+          type: array
+          items:
+            type: string
       examples:
         - songId: 3cd42c09-ff3c-4cd2-913f-a279c4ea89b4
           title: 描き続けた君へ
@@ -66,7 +81,14 @@ components:
             name: オリジナル曲
             value: 1
           counts:
+            releaseCount: 1
             mediaCount: 3
+          lyricists:
+            - 作詞者
+          composers:
+            - 作曲者
+          arrangers:
+            - 編曲者
     SongListResponse:
       type: object
       required:
@@ -89,13 +111,25 @@ components:
                 name: オリジナル曲
                 value: 1
               counts:
+                releaseCount: 1
                 mediaCount: 3
+              lyricists:
+                - 作詞者
+              composers:
+                - 作曲者
+              arrangers:
+                - 編曲者
           nextCursor: eyJvcmRlck5vIjoxLCJzb25nSWQiOiIzY2Q0MmMwOS1mZjNjLTRjZDItOTEzZi1hMjc5YzRlYTg5YjQifQ==
     SongRelationCounts:
       type: object
       required:
+        - releaseCount
         - mediaCount
       properties:
+        releaseCount:
+          type: integer
+          format: int32
+          description: 関連リリース数
         mediaCount:
           type: integer
           format: int32

--- a/src/contracts/src/viewer/songs/domain.tsp
+++ b/src/contracts/src/viewer/songs/domain.tsp
@@ -28,6 +28,9 @@ model SongType {
 }
 
 model SongRelationCounts {
+  @doc("関連リリース数")
+  releaseCount: int32;
+
   @doc("関連メディア数")
   mediaCount: int32;
 }
@@ -37,7 +40,10 @@ model SongRelationCounts {
   title: "描き続けた君へ",
   description: "楽曲説明",
   type: #{ name: "オリジナル曲", value: SongTypeValue.original },
-  counts: #{ mediaCount: 3 },
+  counts: #{ releaseCount: 1, mediaCount: 3 },
+  lyricists: #["作詞者"],
+  composers: #["作曲者"],
+  arrangers: #["編曲者"],
 })
 model SongListItem {
   songId: songId;
@@ -45,4 +51,7 @@ model SongListItem {
   description: description;
   type: SongType;
   counts: SongRelationCounts;
+  lyricists: string[];
+  composers: string[];
+  arrangers: string[];
 }

--- a/src/contracts/src/viewer/songs/transport.tsp
+++ b/src/contracts/src/viewer/songs/transport.tsp
@@ -18,7 +18,10 @@ scalar limit extends int32;
       title: "描き続けた君へ",
       description: "楽曲説明",
       type: #{ name: "オリジナル曲", value: SongTypeValue.original },
-      counts: #{ mediaCount: 3 },
+      counts: #{ releaseCount: 1, mediaCount: 3 },
+      lyricists: #["作詞者"],
+      composers: #["作曲者"],
+      arrangers: #["編曲者"],
     }
   ],
   nextCursor: "eyJvcmRlck5vIjoxLCJzb25nSWQiOiIzY2Q0MmMwOS1mZjNjLTRjZDItOTEzZi1hMjc5YzRlYTg5YjQifQ==",

--- a/src/server/app/Http/Presenters/Api/Viewer/V1/Song/ListPresenter.php
+++ b/src/server/app/Http/Presenters/Api/Viewer/V1/Song/ListPresenter.php
@@ -35,7 +35,7 @@ class ListPresenter
     }
 
     /**
-     * @return array{songId: string, title: string, type: array{name: string, value: 1|2}, description: string, counts: array{mediaCount: int}}
+     * @return array{songId: string, title: string, type: array{name: string, value: 1|2}, description: string, lyricists: array<string>, composers: array<string>, arrangers: array<string>, counts: array{releaseCount: int, mediaCount: int}}
      */
     private function toArray(SongListItem $song): array
     {
@@ -47,7 +47,11 @@ class ListPresenter
                 'value' => $song->type->value,
             ],
             'description' => $song->description,
+            'lyricists' => $song->lyricists,
+            'composers' => $song->composers,
+            'arrangers' => $song->arrangers,
             'counts' => [
+                'releaseCount' => $song->releaseCount,
                 'mediaCount' => $song->mediaCount,
             ],
         ];

--- a/src/server/app/Models/Song/Song.php
+++ b/src/server/app/Models/Song/Song.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace App\Models\Song;
 
+use App\Models\Release\Release;
 use Carbon\CarbonImmutable;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Override;
 
@@ -23,6 +25,7 @@ use Override;
  * @property-read Collection<int, SongPerson> $persons
  * @property-read Collection<int, SongTagging> $taggings
  * @property-read Collection<int, SongMediaLink> $songMediaLinks
+ * @property-read Collection<int, Release> $releases
  *
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Song newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Song newQuery()
@@ -81,5 +84,20 @@ class Song extends Model
     {
         return $this->hasMany(SongMediaLink::class, 'song_id', 'song_id')
             ->orderBy('order_no');
+    }
+
+    /**
+     * @return BelongsToMany<Release, $this>
+     */
+    public function releases(): BelongsToMany
+    {
+        return $this->belongsToMany(
+            Release::class,
+            'release_track_entries',
+            'song_id',
+            'release_id',
+            'song_id',
+            'release_id',
+        )->withPivot('track_no');
     }
 }

--- a/src/server/app/Models/Song/SongPerson.php
+++ b/src/server/app/Models/Song/SongPerson.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Models\Song;
 
+use App\Models\Person\Person;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Override;
 
 /**
@@ -12,6 +14,7 @@ use Override;
  * @property string $person_id 人物ID
  * @property string $role      役割
  * @property int    $order_no  表示順
+ * @property-read Person $person
  *
  * @method static \Illuminate\Database\Eloquent\Builder<static>|SongPerson newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|SongPerson newQuery()
@@ -32,4 +35,12 @@ class SongPerson extends Model
 
     #[Override]
     public $timestamps = false;
+
+    /**
+     * @return BelongsTo<Person, $this>
+     */
+    public function person(): BelongsTo
+    {
+        return $this->belongsTo(Person::class, 'person_id', 'person_id');
+    }
 }

--- a/src/server/packages/Song/Application/Viewer/Query/SongListItem.php
+++ b/src/server/packages/Song/Application/Viewer/Query/SongListItem.php
@@ -8,11 +8,20 @@ use Song\Domain\Models\SongType;
 
 readonly class SongListItem
 {
+    /**
+     * @param array<string> $lyricists
+     * @param array<string> $composers
+     * @param array<string> $arrangers
+     */
     public function __construct(
         public string $songId,
         public string $title,
         public SongType $type,
         public string $description,
+        public array $lyricists,
+        public array $composers,
+        public array $arrangers,
+        public int $releaseCount,
         public int $mediaCount,
         public int $orderNo,
     ) {

--- a/src/server/packages/Song/Infrastructures/Viewer/SongQueryService.php
+++ b/src/server/packages/Song/Infrastructures/Viewer/SongQueryService.php
@@ -5,12 +5,16 @@ declare(strict_types=1);
 namespace Song\Infrastructures\Viewer;
 
 use App\Models\Song\Song;
+use App\Models\Song\SongPerson;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Override;
 use Song\Application\Viewer\Query\SongListCursor;
 use Song\Application\Viewer\Query\SongListItem;
 use Song\Application\Viewer\Query\SongListPage;
 use Song\Application\Viewer\Query\SongQueryServiceInterface;
+use Song\Domain\Models\Persons\SongPersonRole;
 use Song\Domain\Models\SongType;
 use Support\Contracts\Uuid\UuidConverterInterface;
 
@@ -26,9 +30,20 @@ readonly class SongQueryService implements SongQueryServiceInterface
         $query = Song::query()
             ->select(['song_id', 'title', 'description', 'type', 'order_no'])
             ->where('is_display', true)
+            // 将来的に Eloquent やめるので黙らせる
+            // @phpstan-ignore-next-line
+            ->with([
+                'persons' => fn (HasMany $query) => $query
+                    ->select(['song_id', 'person_id', 'role', 'order_no'])
+                    ->orderBy('order_no'),
+                'persons.person' => fn (BelongsTo $query) => $query
+                    ->select(['person_id', 'name']),
+            ])
             ->withCount([
                 'songMediaLinks as media_count' => fn (Builder $query) => $query
                     ->whereHas('media', fn (Builder $mediaQuery) => $mediaQuery->where('is_display', true)),
+                'releases as release_count' => fn (Builder $query) => $query
+                    ->where('is_display', true),
             ])
             ->orderBy('order_no')
             ->orderBy('song_id');
@@ -51,6 +66,7 @@ readonly class SongQueryService implements SongQueryServiceInterface
             ->map(function (Song $song): SongListItem {
                 // 直接 $song から取得しようとすると静的解析でエラーになるため回避策として getAttribute を呼び出している
                 // 将来的に Eloquent をやめてこの回避策をしなくてもいいようにする
+                $releaseCount = $song->getAttribute('release_count');
                 $mediaCount = $song->getAttribute('media_count');
 
                 return new SongListItem(
@@ -58,6 +74,10 @@ readonly class SongQueryService implements SongQueryServiceInterface
                     $song->title,
                     SongType::from($song->type),
                     $song->description,
+                    $this->personNamesByRole($song, SongPersonRole::Lyricist),
+                    $this->personNamesByRole($song, SongPersonRole::Composer),
+                    $this->personNamesByRole($song, SongPersonRole::Arranger),
+                    is_numeric($releaseCount) ? (int)$releaseCount : 0,
                     is_numeric($mediaCount) ? (int)$mediaCount : 0,
                     $song->order_no,
                 );
@@ -72,5 +92,18 @@ readonly class SongQueryService implements SongQueryServiceInterface
             : SongListCursor::encode($lastSong->orderNo, $lastSong->songId);
 
         return new SongListPage($currentSongs->all(), $nextCursor);
+    }
+
+    /**
+     * @return array<string>
+     */
+    private function personNamesByRole(Song $song, SongPersonRole $role): array
+    {
+        return $song->persons
+            ->toBase()
+            ->filter(fn (SongPerson $person): bool => (int)$person->role === $role->value)
+            ->map(fn (SongPerson $person): string => $person->person->name)
+            ->values()
+            ->all();
     }
 }

--- a/src/server/tests/Feature/Api/Viewer/V1/Song/ListSongTest.php
+++ b/src/server/tests/Feature/Api/Viewer/V1/Song/ListSongTest.php
@@ -7,6 +7,9 @@ namespace Tests\Feature\Api\Viewer\V1\Song;
 use Media\Domain\Models\MediaFormat;
 use Media\Domain\Models\MediaType;
 use PHPUnit\Framework\Attributes\Test;
+use Release\Domain\Models\ReleaseDistributionType;
+use Release\Domain\Models\ReleaseType;
+use Song\Domain\Models\Persons\SongPersonRole;
 use Song\Domain\Models\SongType;
 use Song\Route\ViewerSongRouteMap;
 use Tests\Support\DatabaseTestCase;
@@ -26,6 +29,17 @@ class ListSongTest extends DatabaseTestCase
         $hiddenSongId = $this->generateUuid();
         $visibleMediaId = $this->generateUuid();
         $hiddenMediaId = $this->generateUuid();
+        $visibleReleaseId = $this->generateUuid();
+        $hiddenReleaseId = $this->generateUuid();
+        $lyricistId = $this->generateUuid();
+        $composerId = $this->generateUuid();
+        $arrangerId = $this->generateUuid();
+
+        $this->storePersons(
+            $this->createPerson($lyricistId, '作詞太郎', 1),
+            $this->createPerson($composerId, '作曲花子', 2),
+            $this->createPerson($arrangerId, '編曲次郎', 3),
+        );
 
         $this->storeMedia(
             $this->createMedia($visibleMediaId, '公開 MV', 'https://example.com/public', MediaType::Video, true, MediaFormat::Mv),
@@ -41,7 +55,11 @@ class ListSongTest extends DatabaseTestCase
                 true,
                 1,
                 [],
-                [],
+                [
+                    ['personId' => $lyricistId, 'role' => SongPersonRole::Lyricist->value, 'orderNo' => 1],
+                    ['personId' => $composerId, 'role' => SongPersonRole::Composer->value, 'orderNo' => 2],
+                    ['personId' => $arrangerId, 'role' => SongPersonRole::Arranger->value, 'orderNo' => 3],
+                ],
                 [],
                 [],
                 [],
@@ -57,7 +75,6 @@ class ListSongTest extends DatabaseTestCase
                 SongType::Cover,
                 true,
                 2,
-                [],
                 [],
                 [],
                 [],
@@ -78,7 +95,31 @@ class ListSongTest extends DatabaseTestCase
                 [],
                 [],
                 [],
-                [],
+            ),
+        );
+
+        $this->storeReleases(
+            $this->createRelease(
+                $visibleReleaseId,
+                '公開リリース',
+                ReleaseType::Single,
+                ReleaseDistributionType::Digital,
+                true,
+                description: '公開リリース',
+                trackEntries: [
+                    ['songId' => $visibleSongId, 'trackNo' => 1],
+                ],
+            ),
+            $this->createRelease(
+                $hiddenReleaseId,
+                '非公開リリース',
+                ReleaseType::Album,
+                ReleaseDistributionType::Physical,
+                false,
+                description: '非公開リリース',
+                trackEntries: [
+                    ['songId' => $visibleSongId, 'trackNo' => 1],
+                ],
             ),
         );
 
@@ -94,7 +135,11 @@ class ListSongTest extends DatabaseTestCase
                             'value' => 1,
                         ],
                         'description' => 'Viewer の一覧表示向けに集約された楽曲説明',
+                        'lyricists' => ['作詞太郎'],
+                        'composers' => ['作曲花子'],
+                        'arrangers' => ['編曲次郎'],
                         'counts' => [
+                            'releaseCount' => 1,
                             'mediaCount' => 1,
                         ],
                     ],
@@ -121,7 +166,11 @@ class ListSongTest extends DatabaseTestCase
                             'value' => 2,
                         ],
                         'description' => '2 曲目',
+                        'lyricists' => [],
+                        'composers' => [],
+                        'arrangers' => [],
                         'counts' => [
+                            'releaseCount' => 0,
                             'mediaCount' => 1,
                         ],
                     ],

--- a/src/viewer/src/generated/types.gen.ts
+++ b/src/viewer/src/generated/types.gen.ts
@@ -12,6 +12,9 @@ export type SongListItem = {
     description: Description;
     type: SongType;
     counts: SongRelationCounts;
+    lyricists: Array<string>;
+    composers: Array<string>;
+    arrangers: Array<string>;
 };
 
 export type SongListResponse = {
@@ -23,6 +26,10 @@ export type SongListResponse = {
 };
 
 export type SongRelationCounts = {
+    /**
+     * 関連リリース数
+     */
+    releaseCount: number;
     /**
      * 関連メディア数
      */


### PR DESCRIPTION
## 概要

Viewer の楽曲一覧 API に、検索や表示で使う人物配列と公開リリース件数を追加します。
あわせて server / viewer の生成物と feature test を更新します。

## やったこと

- Viewer songs contract に `lyricists` `composers` `arrangers` と `counts.releaseCount` を追加
- `Song` と `SongPerson` の Eloquent relation を追加し、Viewer の query service で人物名を role ごとの配列へ整形
- Presenter と Viewer 生成型を更新し、一覧 feature test を新しいレスポンス shape に合わせて修正

## やってないこと

- Song 詳細 API の追加
- Viewer 一覧 UI 側での検索ロジック変更
- dump.sql のようなローカル検証用ファイルの取り込み

## 関連

- 特になし