### PR TITLE
管理ユーザー登録トークン発行 CLI を実装

### DIFF
--- a/docs/exec-plans/completed/20260517-admin-user-registration-token-cli/issue.md
+++ b/docs/exec-plans/completed/20260517-admin-user-registration-token-cli/issue.md
@@ -1,0 +1,56 @@
+# Execution Plan — Issue
+
+## Title
+
+管理ユーザー登録 WebUI 用の登録トークン発行 CLI
+
+## Background
+
+管理ユーザーは現状 `admin:create` CLI（`src/server/app/Console/Commands/AdminUser/CreateCommand.php`）でメール・パスワード等を指定して直接作成する運用になっており、登録者本人がパスワード等を入力する余地がない。
+
+今後、管理者自身が WebUI から登録（パスキー登録を含む）を行えるようにする計画があり、その入口として「管理者が CLI で登録トークンを発行 → 登録対象者へトークンを共有 → 対象者が WebUI 上でトークンを使って自分の管理ユーザーを登録する」という招待型フローを採用したい。
+
+本タスクは、このフローの最初のピース（トークンを発行する CLI とその永続化）を用意する。
+
+## Goal
+
+管理者が Artisan CLI を叩くと、管理ユーザー登録 WebUI で使用できる単発の登録トークンを発行し、DB に保存したうえで標準出力に提示する。WebUI 側で消費する API は別タスクで扱う。
+
+## Scope
+
+- 新規 CLI コマンド
+  - `src/server/app/Console/Commands/AdminUser/` 配下に `InviteCommand`（仮名）を追加し、`admin:invite` シグネチャで提供する
+  - 既存 `CreateCommand` と同じパターン（`UseCase` 呼び出し + `ResultType` ハンドリング）に従う
+- ユースケース
+  - `src/server/packages/AdminUser/Application/Cli/UseCase/IssueRegistrationToken/` に `IssueRegistrationTokenUseCase` / `InputData` / `OutputData` を追加
+- ドメインモデル
+  - `src/server/packages/AdminUser/Domain/Models/` に `RegistrationToken`（値・有効期限・状態）と `RegistrationTokenId`、対応する `RegistrationTokenRepositoryInterface` を追加
+  - 役割（`Role`）・権限（`Permission` / `Permissions`）は既存モデルを再利用し、発行時点で付与予定値を保持する
+- インフラ
+  - `src/server/packages/AdminUser/Infrastructures/` に `RegistrationTokenRepository` を追加
+- DB
+  - `src/server/database/atlas/schemas/` に `admin-user-registration-tokens.my.hcl` を追加（`refresh-tokens.my.hcl` の形を参考に、トークン値はハッシュ保存、付与予定の role/permissions、`expired_at`、消費状態、`created_at`/`updated_at`）
+- 提示形式
+  - トークン平文は発行時のみ標準出力に表示し、DB にはハッシュのみ保存する
+- テスト
+  - `tests/Feature/Console/Commands/AdminUser/` にコマンドの Feature テスト
+  - `tests/Unit/AdminUser/Application/Cli/IssueRegistrationToken/` に UseCase の Unit テスト
+  - `tests/Integration/AdminUser/Application/Cli/IssueRegistrationToken/` にリポジトリ込みの Integration テスト
+
+## Non-Scope
+
+- 登録 WebUI 本体（Astro/SolidJS 側）と、それが叩く登録 API（`src/contracts` / `src/admin` / `src/server` の HTTP 層）の実装
+- パスキー登録ロジックそのものの実装
+- トークン失効・再発行・一覧表示 CLI などの管理機能
+- 既存 `admin:create` CLI の挙動変更
+- メール送信などのトークン配布手段（出力をコピーして手渡しする前提）
+
+## Acceptance Criteria
+
+- `admin:invite <email>` を引数（email 必須、付与予定の role と permissions）付きで実行すると、終了コード 0 で平文トークンが標準出力に 1 度だけ表示される
+- 同コマンドの実行ごとに、`admin_user_registration_tokens` テーブルに 1 行が追加され、`token` 列はハッシュ化された値で、平文は保存されていない
+- 保存される行には CLI で指定された `email`、付与予定の role / permissions、未来時刻の `expired_at`、未消費を表す `status` が設定されている
+- 既存の `admin_users` に同 email が存在する場合は終了コード 1 でエラーメッセージを表示し、テーブルに行が追加されない
+- 不正な permission を指定した場合は終了コード 1 でエラーメッセージを表示し、テーブルに行が追加されない
+- 既存の `admin:create` コマンドおよび関連テストの挙動が変わらない
+- `mise run api:ecs` / `api:phpstan` / `api:arkitect` / `api:test` がすべて成功する

--- a/docs/exec-plans/completed/20260517-admin-user-registration-token-cli/plan.md
+++ b/docs/exec-plans/completed/20260517-admin-user-registration-token-cli/plan.md
@@ -1,0 +1,79 @@
+# Execution Plan — Plan
+
+実装計画（どう進めるか）を書く。問題定義は同ディレクトリの `issue.md` を参照する。
+
+## Title
+
+管理ユーザー登録 WebUI 用の登録トークン発行 CLI
+
+## Status
+
+completed
+
+## Steps
+
+✅ 1. **DB スキーマを追加する**
+   - `src/server/database/atlas/schemas/admin-user-registration-tokens.my.hcl` を新規作成する。`refresh-tokens.my.hcl` の構造を踏襲しつつ、`admin_user_id` への外部キーは持たない（まだ管理ユーザーは存在しないため）。
+   - 列: `admin_user_registration_token_id binary(16)` (PK), `token varchar(255) NOT NULL`（ハッシュ保存）, `email varchar(255) NOT NULL`, `role tinyint unsigned NOT NULL`, `expired_at datetime NOT NULL`, `status tinyint unsigned NOT NULL`（未消費=0/消費済=1）, `created_at datetime NOT NULL`, `updated_at datetime NOT NULL`。
+   - `email` には unique index を張らない（消費済みトークンや過去の招待が残るため）。発行時に「同 email の `admin_users` が既存」「同 email の未消費トークンが既存」を UseCase でチェックする。
+   - 付与予定 permission は別テーブル `admin-user-registration-token-permissions.my.hcl` に切り出す（`admin-user-permissions.my.hcl` の形を参考に）。列: `admin_user_registration_token_id binary(16)`, `permission varchar(255)` の複合 PK、`fk_*_token_id` で CASCADE。
+   - `src/server/database/atlas/schemas/schema.my.hcl` に新テーブルが取り込まれるか確認し、必要なら追記。
+✅ 2. **Eloquent モデルを追加する**
+   - `src/server/app/Models/AdminUser/RegistrationToken.php` を `App\Models\AdminUser` namespace で追加し、`$table = 'admin_user_registration_tokens'`、`$primaryKey = 'admin_user_registration_token_id'`、`expired_at` などを `immutable_datetime` でキャスト。
+   - `src/server/app/Models/AdminUser/RegistrationTokenPermission.php` を追加し、`permissions` 用 hasMany / belongsTo を `AdminUser/AdminUser.php`〜`AdminUserPermission.php` と同じ要領で定義。
+✅ 3. **ドメイン値オブジェクト/モデルを追加する** (`src/server/packages/AdminUser/Domain/Models/RegistrationToken/`)
+   - `RegistrationTokenId.php`: `UuidValueObject` 継承（`AdminUserId.php` を参考）。
+   - `HashedTokenValue.php`: `StringValueObject` 継承（`Auth\...\HashedTokenValue` と同等）。
+   - `ExpiredAt.php`: `ImmutableDateTimeValueObject` 継承し `isExpired()` を持つ（`Auth\...\ExpiredAt` を参考）。
+   - `ConsumptionStatus.php`: `Unused = 0` / `Consumed = 1` の enum（`Auth\...\ConsumptionStatus` と同等）。
+   - `RegistrationToken.php`: コンストラクタ引数 `RegistrationTokenId $id, HashedTokenValue $token, Email $email, Role $role, Permissions $permissions, ExpiredAt $expiredAt, ConsumptionStatus $status`。`Email` は既存 `AdminUser\Domain\Models\Email` を再利用。`reconstruct()` と `toArray()` を実装。
+   - `RegistrationTokenRepositoryInterface.php`: `save(RegistrationToken $token): RegistrationToken` を最低限定義する（一覧/取得は本タスクでは Non-Scope なので追加しない）。
+✅ 4. **ドメインサービス: トークン発行ロジック** (`src/server/packages/AdminUser/Domain/Services/RegistrationToken/`)
+   - `RegistrationTokenIssueService.php` を追加。`ClockInterface`, `UuidGeneratorInterface`, `RandomTokenGeneratorInterface`, `TokenHasherInterface` を DI。`Auth\Domain\Services\Token\RefreshToken\RefreshTokenIssueService` を参考に `issue(Email $email, int $role, list<string> $permissions): Result<array{token: RegistrationToken, plainToken: string}, DomainError>` を実装。TTL は定数 `TTL_DAY = 7`。
+   - `TokenHasherInterface` / `RandomTokenGeneratorInterface` は AdminUser パッケージ内（`AdminUser\Domain\Services\RegistrationToken\` 配下）に新規追加する（phparkitect が Auth パッケージへの Domain 依存を禁じているため。Decision Log 参照）。
+✅ 5. **インフラ実装** (`src/server/packages/AdminUser/Infrastructures/RegistrationToken/`)
+   - `RegistrationTokenRepository.php` を追加し `RegistrationTokenRepositoryInterface` を実装。`UuidConverterInterface` を DI。`save()` で `admin_user_registration_tokens` への `insert` と `admin_user_registration_token_permissions` への `insert`（permissions 配列があれば）を行う。
+✅ 6. **UseCase 層** (`src/server/packages/AdminUser/Application/Cli/UseCase/IssueRegistrationToken/`)
+   - `IssueRegistrationTokenInputData.php`: `string $email`, `int $role`, `list<string> $permissions`。
+   - `IssueRegistrationTokenOutputData.php`: `RegistrationToken $token`, `string $plainToken`。
+   - `IssueRegistrationTokenUseCase.php`: `TransactionInterface`, `AdminUserRepositoryInterface`（既存 email 衝突チェック用）, `RegistrationTokenIssueService`, `RegistrationTokenRepositoryInterface` を DI。`transaction->scope` 内で (a) `Email::create` で VO 構築（失敗時は `DomainValidationError`）、(b) `adminUserRepository->findByEmail` で既存 `admin_users` の衝突チェック（あれば `BusinessRuleViolationError`）、(c) `issueService->issue` → `repository->save` → `Ok`。`handleError()` は `DomainValidationError` / `EntityRuleViolationError` を `InvalidInputError` に、`BusinessRuleViolationError` を `BusinessLogicError` に変換する（`CreateUseCase` に `BusinessRuleViolationError` 分岐を追加した形）。
+✅ 7. **CLI コマンド**
+   - `src/server/app/Console/Commands/AdminUser/InviteCommand.php` を追加。
+   - `protected $signature = 'admin:invite {email} {--p|privilege} {permissions?*}'`、`$description = '管理ユーザー登録トークンを発行する'`。
+   - `handle(IssueRegistrationTokenUseCase $useCase): int` で、`CreateCommand` と同じく permission の `Permission::tryFrom` バリデーションを行い、不正なら `Command::FAILURE`。
+   - 成功時、`OutputData` の `plainToken` を `$this->line($plainToken)` で 1 行だけ標準出力に出す（`info` ではなく `line` にして装飾を付けない）。さらに有効期限などの補助情報を `info` で出力（Decision Log 参照）。
+✅ 8. **DI バインディング**
+   - `src/server/app/Providers/Domain/AdminUserServiceProvider.php` に以下を追加:
+     - `AdminUser\Domain\Models\RegistrationToken\RegistrationTokenRepositoryInterface` → `AdminUser\Infrastructures\RegistrationToken\RegistrationTokenRepository`
+     - `AdminUser\Domain\Services\RegistrationToken\RandomTokenGeneratorInterface` → `AdminUser\Infrastructures\RegistrationToken\RandomTokenGenerator`
+     - `AdminUser\Domain\Services\RegistrationToken\TokenHasherInterface` → `AdminUser\Infrastructures\RegistrationToken\TokenHasher`
+   - `InviteCommand` は既存 `CreateCommand` 同様 Laravel の自動発見に任せる。
+✅ 9. **テスト**
+   - Unit: `src/server/tests/Unit/AdminUser/Application/Cli/UseCase/IssueRegistrationTokenUseCaseTest.php`。`CreateUseCaseTest` を参考に、`TransactionInterface` / `AdminUserRepositoryInterface` / `RegistrationTokenIssueService` / `RegistrationTokenRepositoryInterface` を Mockery で差し替え。成功ケース、既存 email 衝突ケース（`BusinessLogicError`）、サービスが `Err(DomainValidationError)` を返すケースを検証。
+   - Integration: `src/server/tests/Integration/AdminUser/Application/Cli/UseCase/IssueRegistrationTokenUseCaseTest.php`。`DatabaseTestCase` 継承、`app->make` した UseCase で実行 → `admin_user_registration_tokens` が 1 行追加・`token` 列がハッシュ・`role`/`permissions`/`expired_at`/`status` が期待通り、を検証。
+   - Feature: `src/server/tests/Feature/Console/Commands/AdminUser/InviteCommandTest.php`。`CreateCommandTest` を参考に: 一般ユーザー発行 / 特権 + permissions 付き発行 / 不正 permission 拒否（テーブルに行が追加されないこと）/ 既存 `admin_users` と同 email を指定した場合の拒否 / 出力に平文トークンが含まれる、を確認。
+✅ 10. **検証コマンドの実行**
+    - `mise run api:ecs` / `api:phpstan` / `api:arkitect` / `api:test` をすべて green になるまで実行。phparkitect の Domain → Infra 依存禁止ルールに違反していないかを必ず確認する。
+
+## Decision Log
+
+- 2026-05-17: トークン平文生成・ハッシュ化のロジック自体は `Auth\...\RandomTokenGenerator`（`bin2hex(random_bytes(64))`、128 文字）/ `Auth\...\TokenHasher`（`Hash::make` / `Hash::check`）と同等のものを採用する。ただし phparkitect 上 `AdminUser\Domain` から `Auth\Domain` への依存が禁じられているため、interface と実装は AdminUser パッケージ内に新設し、ロジックを duplicate する（下記「実装中の変更」参照）。Auth 側の既存 `Hasher`（パスワード用）はコスト体系が異なるため流用しない。
+- 2026-05-17: テーブル名は `admin_user_registration_tokens`、permission 中間テーブルは `admin_user_registration_token_permissions` とする。`refresh_tokens` と異なり、発行時点では対応する `admin_users` 行が存在しないため、`admin_user_id` カラム・FK を持たせない。代わりに role/permission を発行時に固定値として保持する。
+- 2026-05-17: 有効期限のデフォルトは 7 日（`RefreshTokenIssueService` と揃える）。コマンド引数では指定せず、ドメインサービス内の定数で固定する。将来 CLI から上書きしたくなった時に最小コストで足せるよう、サービス側を後から拡張する形に留める。
+- 2026-05-17: CLI シグネチャは `admin:invite {email} {--p|privilege} {permissions?*}` とし、`CreateCommand` の `--p|privilege` フラグと位置引数 `permissions` の渡し方を踏襲する。`email` は招待時に必須で受け取り、トークン行に保存する。これにより漏洩したトークンを別人が別 email で消費する事故を防ぎ、WebUI 側で email 入力を不要にできる。`name` は WebUI で本人が入力する想定で持たない。
+- 2026-05-17: `email` の重複チェックは「既存 `admin_users` に同 email がいない」のみ UseCase で行う。未消費トークン同士の重複は許容（招待のやり直し・再発行を将来追加するため）。DB 側に unique 制約は張らない。
+- 2026-05-17: 平文トークンは `$this->line($plainToken)` で 1 行のみ出力する。`info` だと `<info>` タグで装飾されコピペ事故が起きやすいため。補助メッセージ（有効期限など）は `info` で別行に出す。
+- 2026-05-17: トークンを `RegistrationToken` ドメインに集約する構成（独立したサブディレクトリ `RegistrationToken/` 配下）は、`Auth\...\Token\RefreshToken\` 構成と同型にして将来の値オブジェクト追加に備える。
+- 2026-05-17 (実装中の変更): `phparkitect.php` の `AdminUserComponent::Domain` は `AuthComponent::Domain` への依存を許可していない。また Auth 側の `RandomTokenGenerator` / `TokenHasher` は `Auth\Domain\Services\Token\RefreshToken\*` の interface を実装しているため、AdminUser 側の interface へそのまま bind できない。よって以下に変更：
+  - `AdminUser\Domain\Services\RegistrationToken\` 配下に `RandomTokenGeneratorInterface` / `TokenHasherInterface` を新規追加（contract）。
+  - `AdminUser\Infrastructures\RegistrationToken\` 配下に `RandomTokenGenerator`（`bin2hex(random_bytes(64))`）/ `TokenHasher`（`Hash::make` / `Hash::check`）を新規実装（Auth 側と同等のロジックを duplicate）。
+  - `AdminUserServiceProvider` で上記の AdminUser interface ↔ AdminUser 実装を bind する。Auth パッケージとの結合は持たない。
+
+## Validation
+
+- AC「`admin:invite` 実行で平文トークンが 1 度だけ標準出力に出る」: Feature テスト `InviteCommandTest::outputsPlainTokenOnce` で `assertSuccessful()` と `expectsOutputToContain` / 出力捕捉を用いて検証。`mise run api:test` で実行。
+- AC「DB にハッシュで 1 行追加される」: Integration テストで `App\Models\AdminUser\RegistrationToken::query()->get()` を取得し、件数・`token` 列が平文と一致しないこと（`Hash::check($plain, $row->token)` が true）を検証。
+- AC「role / permissions / 未来 expired_at / 未消費 status / email が保存される」: Integration テストで各カラムの値、`permissions` 中間テーブルの行を検証。`status === ConsumptionStatus::Unused->value`、`expired_at > now()`、`email` が CLI 引数と一致。
+- AC「不正 permission で終了コード 1、行が追加されない」: Feature テストで `assertFailed()` + `App\Models\AdminUser\RegistrationToken::query()->count() === 0` を確認。
+- AC「既存 `admin:create` の挙動が変わらない」: 既存 `CreateCommandTest` を回帰実行（`mise run api:test`）。本タスクで `CreateCommand` / `CreateUseCase` には触らない。
+- 共通: `mise run api:ecs` / `mise run api:phpstan` / `mise run api:arkitect` / `mise run api:test` の 4 つを全 green にする。

--- a/src/server/app/Console/Commands/AdminUser/InviteCommand.php
+++ b/src/server/app/Console/Commands/AdminUser/InviteCommand.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\AdminUser;
+
+use AdminUser\Application\Cli\UseCase\IssueRegistrationToken\IssueRegistrationTokenInputData;
+use AdminUser\Application\Cli\UseCase\IssueRegistrationToken\IssueRegistrationTokenUseCase;
+use AdminUser\Domain\Models\Permission;
+use AdminUser\Domain\Models\Role;
+use Illuminate\Console\Command;
+use Override;
+use Support\UseCase\Error\BusinessLogicError;
+use Support\UseCase\Error\InvalidInputError;
+use Support\UseCase\Error\UseCaseError;
+
+class InviteCommand extends Command
+{
+    #[Override]
+    protected $signature = 'admin:invite {email} {--p|privilege} {permissions?*}';
+
+    #[Override]
+    protected $description = '管理ユーザー登録トークンを発行する';
+
+    public function handle(IssueRegistrationTokenUseCase $useCase): int
+    {
+        $email = $this->argument('email');
+
+        if (mb_trim($email) === '') {
+            $this->error('メールアドレスを入力してください');
+
+            return Command::FAILURE;
+        }
+
+        $role = $this->isPrivilege()
+            ? Role::Privilege
+            : Role::General;
+
+        $permissions = $this->argument('permissions');
+        assert(array_is_list($permissions));
+
+        foreach ($permissions as $permission) {
+            $result = Permission::tryFrom($permission);
+            if (is_null($result)) {
+                $this->error("不正な権限です: {$permission}");
+
+                return Command::FAILURE;
+            }
+        }
+
+        $result = $useCase->handle(new IssueRegistrationTokenInputData($email, $role->value, $permissions));
+
+        if ($result->isErr()) {
+            $this->error($this->resolveErrorMessage($result->unwrapErr()));
+
+            return Command::FAILURE;
+        }
+
+        $output = $result->unwrap();
+
+        $this->line($output->plainToken);
+        $this->info(sprintf('有効期限: %s', $output->token->expiredAt->value->format('Y-m-d H:i:s')));
+
+        return Command::SUCCESS;
+    }
+
+    private function resolveErrorMessage(UseCaseError $error): string
+    {
+        if ($error instanceof BusinessLogicError) {
+            return $error->message;
+        }
+
+        if (! $error instanceof InvalidInputError) {
+            return '';
+        }
+
+        foreach ($error->errors as $messages) {
+            if ($messages !== []) {
+                return $messages[0];
+            }
+        }
+
+        return '';
+    }
+
+    private function isPrivilege(): bool
+    {
+        return (bool)$this->option('privilege');
+    }
+}

--- a/src/server/app/Models/AdminUser/RegistrationToken.php
+++ b/src/server/app/Models/AdminUser/RegistrationToken.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\AdminUser;
+
+use Carbon\CarbonImmutable;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Override;
+
+/**
+ * @property string          $admin_user_registration_token_id 管理ユーザー登録トークンID
+ * @property string          $token                            トークン
+ * @property string          $email                            メールアドレス
+ * @property int             $role                             ロール
+ * @property CarbonImmutable $expired_at                       有効期限
+ * @property int             $status                           消費状態
+ * @property CarbonImmutable $created_at                       作成日時
+ * @property CarbonImmutable $updated_at                       更新日時
+ * @property-read Collection<int, RegistrationTokenPermission> $permissions
+ *
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|RegistrationToken newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|RegistrationToken newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|RegistrationToken query()
+ *
+ * @mixin \Eloquent
+ */
+class RegistrationToken extends Model
+{
+    #[Override]
+    protected $table = 'admin_user_registration_tokens';
+
+    #[Override]
+    protected $primaryKey = 'admin_user_registration_token_id';
+
+    #[Override]
+    protected $keyType = 'string';
+
+    #[Override]
+    protected $with = ['permissions'];
+
+    #[Override]
+    protected function casts()
+    {
+        return [
+            'expired_at' => 'immutable_datetime',
+            'created_at' => 'immutable_datetime',
+            'updated_at' => 'immutable_datetime',
+        ];
+    }
+
+    /**
+     * @return HasMany<RegistrationTokenPermission, $this>
+     */
+    public function permissions(): HasMany
+    {
+        return $this->hasMany(
+            RegistrationTokenPermission::class,
+            'admin_user_registration_token_id',
+            'admin_user_registration_token_id',
+        );
+    }
+}

--- a/src/server/app/Models/AdminUser/RegistrationTokenPermission.php
+++ b/src/server/app/Models/AdminUser/RegistrationTokenPermission.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\AdminUser;
+
+use Illuminate\Database\Eloquent\Model;
+use Override;
+
+/**
+ * @property string $admin_user_registration_token_id 管理ユーザー登録トークンID
+ * @property string $permission                       権限
+ *
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|RegistrationTokenPermission newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|RegistrationTokenPermission newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|RegistrationTokenPermission query()
+ *
+ * @mixin \Eloquent
+ */
+class RegistrationTokenPermission extends Model
+{
+    #[Override]
+    protected $table = 'admin_user_registration_token_permissions';
+
+    // 複合主キーのため未設定
+    #[Override]
+    protected $primaryKey = '';
+
+    #[Override]
+    protected $keyType = 'string';
+
+    #[Override]
+    public $timestamps = false;
+}

--- a/src/server/app/Providers/Domain/AdminUserServiceProvider.php
+++ b/src/server/app/Providers/Domain/AdminUserServiceProvider.php
@@ -5,9 +5,15 @@ declare(strict_types=1);
 namespace App\Providers\Domain;
 
 use AdminUser\Domain\Models\AdminUserRepositoryInterface;
+use AdminUser\Domain\Models\RegistrationToken\RegistrationTokenRepositoryInterface;
 use AdminUser\Domain\Services\HasherInterface;
+use AdminUser\Domain\Services\RegistrationToken\RandomTokenGeneratorInterface;
+use AdminUser\Domain\Services\RegistrationToken\TokenHasherInterface;
 use AdminUser\Infrastructures\AdminUserRepository;
 use AdminUser\Infrastructures\Hasher;
+use AdminUser\Infrastructures\RegistrationToken\RandomTokenGenerator;
+use AdminUser\Infrastructures\RegistrationToken\RegistrationTokenRepository;
+use AdminUser\Infrastructures\RegistrationToken\TokenHasher;
 use Illuminate\Support\ServiceProvider;
 use Override;
 
@@ -18,5 +24,8 @@ class AdminUserServiceProvider extends ServiceProvider
     {
         $this->app->bind(AdminUserRepositoryInterface::class, AdminUserRepository::class);
         $this->app->bind(HasherInterface::class, Hasher::class);
+        $this->app->bind(RegistrationTokenRepositoryInterface::class, RegistrationTokenRepository::class);
+        $this->app->bind(RandomTokenGeneratorInterface::class, RandomTokenGenerator::class);
+        $this->app->bind(TokenHasherInterface::class, TokenHasher::class);
     }
 }

--- a/src/server/database/atlas/atlas.hcl
+++ b/src/server/database/atlas/atlas.hcl
@@ -14,6 +14,8 @@ variable "table_schemas" {
     "file://schemas/releases.my.hcl",
     "file://schemas/release-track-entries.my.hcl",
     "file://schemas/refresh-tokens.my.hcl",
+    "file://schemas/admin-user-registration-tokens.my.hcl",
+    "file://schemas/admin-user-registration-token-permissions.my.hcl",
     "file://schemas/audit-logs.my.hcl",
   ]
 }

--- a/src/server/database/atlas/schemas/admin-user-registration-token-permissions.my.hcl
+++ b/src/server/database/atlas/schemas/admin-user-registration-token-permissions.my.hcl
@@ -1,0 +1,25 @@
+table "admin_user_registration_token_permissions" {
+  schema  = schema.db
+  comment = "管理ユーザー登録トークン権限"
+
+  column "admin_user_registration_token_id" {
+    null    = false
+    type    = binary(16)
+    comment = "管理ユーザー登録トークンID"
+  }
+  column "permission" {
+    null    = false
+    type    = varchar(255)
+    comment = "権限"
+  }
+
+  primary_key {
+    columns = [column.admin_user_registration_token_id, column.permission]
+  }
+
+  foreign_key "fk_admin_user_registration_token_permissions_token_id" {
+    columns     = [column.admin_user_registration_token_id]
+    ref_columns = [table.admin_user_registration_tokens.column.admin_user_registration_token_id]
+    on_delete   = CASCADE
+  }
+}

--- a/src/server/database/atlas/schemas/admin-user-registration-tokens.my.hcl
+++ b/src/server/database/atlas/schemas/admin-user-registration-tokens.my.hcl
@@ -1,0 +1,51 @@
+table "admin_user_registration_tokens" {
+  schema  = schema.db
+  comment = "管理ユーザー登録トークン"
+
+  column "admin_user_registration_token_id" {
+    null    = false
+    type    = binary(16)
+    comment = "管理ユーザー登録トークンID"
+  }
+  column "token" {
+    null    = false
+    type    = varchar(255)
+    comment = "トークン"
+  }
+  column "email" {
+    null    = false
+    type    = varchar(255)
+    comment = "メールアドレス"
+  }
+  column "role" {
+    null     = false
+    type     = tinyint
+    unsigned = true
+    comment  = "ロール"
+  }
+  column "expired_at" {
+    null    = false
+    type    = datetime
+    comment = "有効期限"
+  }
+  column "status" {
+    null     = false
+    type     = tinyint
+    unsigned = true
+    comment  = "消費状態"
+  }
+  column "created_at" {
+    null    = false
+    type    = datetime
+    comment = "作成日時"
+  }
+  column "updated_at" {
+    null    = false
+    type    = datetime
+    comment = "更新日時"
+  }
+
+  primary_key {
+    columns = [column.admin_user_registration_token_id]
+  }
+}

--- a/src/server/packages/AdminUser/Application/Cli/UseCase/IssueRegistrationToken/IssueRegistrationTokenInputData.php
+++ b/src/server/packages/AdminUser/Application/Cli/UseCase/IssueRegistrationToken/IssueRegistrationTokenInputData.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AdminUser\Application\Cli\UseCase\IssueRegistrationToken;
+
+readonly class IssueRegistrationTokenInputData
+{
+    /**
+     * @param list<string> $permissions
+     */
+    public function __construct(
+        public string $email,
+        public int $role,
+        public array $permissions,
+    ) {
+    }
+}

--- a/src/server/packages/AdminUser/Application/Cli/UseCase/IssueRegistrationToken/IssueRegistrationTokenOutputData.php
+++ b/src/server/packages/AdminUser/Application/Cli/UseCase/IssueRegistrationToken/IssueRegistrationTokenOutputData.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AdminUser\Application\Cli\UseCase\IssueRegistrationToken;
+
+use AdminUser\Domain\Models\RegistrationToken\RegistrationToken;
+
+readonly class IssueRegistrationTokenOutputData
+{
+    public function __construct(
+        public RegistrationToken $token,
+        public string $plainToken,
+    ) {
+    }
+}

--- a/src/server/packages/AdminUser/Application/Cli/UseCase/IssueRegistrationToken/IssueRegistrationTokenUseCase.php
+++ b/src/server/packages/AdminUser/Application/Cli/UseCase/IssueRegistrationToken/IssueRegistrationTokenUseCase.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AdminUser\Application\Cli\UseCase\IssueRegistrationToken;
+
+use AdminUser\Domain\Models\AdminUserRepositoryInterface;
+use AdminUser\Domain\Models\Email;
+use AdminUser\Domain\Models\RegistrationToken\RegistrationTokenRepositoryInterface;
+use AdminUser\Domain\Services\RegistrationToken\RegistrationTokenIssueService;
+use LogicException;
+use ResultType\Err;
+use ResultType\Ok;
+use ResultType\Result;
+use Support\Contracts\TransactionInterface;
+use Support\Domain\Error\BusinessRuleViolationError;
+use Support\Domain\Error\DomainError;
+use Support\Domain\Error\DomainValidationError;
+use Support\Domain\Error\EntityRuleViolationError;
+use Support\UseCase\Error\BusinessLogicError;
+use Support\UseCase\Error\InvalidInputError;
+use Support\UseCase\Error\UseCaseError;
+
+readonly class IssueRegistrationTokenUseCase
+{
+    public function __construct(
+        private TransactionInterface $transaction,
+        private AdminUserRepositoryInterface $adminUserRepository,
+        private RegistrationTokenIssueService $issueService,
+        private RegistrationTokenRepositoryInterface $repository,
+    ) {
+    }
+
+    /**
+     * @return Result<IssueRegistrationTokenOutputData, UseCaseError>
+     */
+    public function handle(IssueRegistrationTokenInputData $inputData): Result
+    {
+        return $this->transaction->scope(function () use ($inputData): Result {
+            $emailResult = Email::create($inputData->email);
+
+            if ($emailResult->isErr()) {
+                return new Err($this->handleError($emailResult->unwrapErr()));
+            }
+
+            $email = $emailResult->unwrap();
+
+            if (! is_null($this->adminUserRepository->findByEmail($email))) {
+                return new Err($this->handleError(new BusinessRuleViolationError(
+                    sprintf('すでに使われているメールアドレスです "%s"', $inputData->email),
+                )));
+            }
+
+            $issueResult = $this->issueService->issue($email, $inputData->role, $inputData->permissions);
+
+            if ($issueResult->isErr()) {
+                return new Err($this->handleError($issueResult->unwrapErr()));
+            }
+
+            $issued = $issueResult->unwrap();
+
+            $token = $this->repository->save($issued['token']);
+
+            return new Ok(new IssueRegistrationTokenOutputData($token, $issued['plainToken']));
+        });
+    }
+
+    private function handleError(DomainError $error): UseCaseError
+    {
+        return match (true) {
+            $error instanceof DomainValidationError => new InvalidInputError($error->errors),
+            $error instanceof EntityRuleViolationError => new InvalidInputError([$error->field => [$error->message]]),
+            $error instanceof BusinessRuleViolationError => new BusinessLogicError($error->message),
+            default => throw new LogicException('予期しないドメインエラーが発生しました: ' . $error::class),
+        };
+    }
+}

--- a/src/server/packages/AdminUser/Domain/Models/RegistrationToken/ConsumptionStatus.php
+++ b/src/server/packages/AdminUser/Domain/Models/RegistrationToken/ConsumptionStatus.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AdminUser\Domain\Models\RegistrationToken;
+
+enum ConsumptionStatus: int
+{
+    case Unused = 0;
+
+    case Consumed = 1;
+
+    public function isAvailable(): bool
+    {
+        return $this === self::Unused;
+    }
+}

--- a/src/server/packages/AdminUser/Domain/Models/RegistrationToken/ExpiredAt.php
+++ b/src/server/packages/AdminUser/Domain/Models/RegistrationToken/ExpiredAt.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AdminUser\Domain\Models\RegistrationToken;
+
+use DateTimeInterface;
+use Support\Domain\ValueObjects\Date\ImmutableDateTimeValueObject;
+
+readonly class ExpiredAt extends ImmutableDateTimeValueObject
+{
+    public function isExpired(DateTimeInterface $now): bool
+    {
+        return $this->value < $now;
+    }
+}

--- a/src/server/packages/AdminUser/Domain/Models/RegistrationToken/HashedTokenValue.php
+++ b/src/server/packages/AdminUser/Domain/Models/RegistrationToken/HashedTokenValue.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AdminUser\Domain\Models\RegistrationToken;
+
+use Support\Domain\ValueObjects\String\StringValueObject;
+
+readonly class HashedTokenValue extends StringValueObject
+{
+}

--- a/src/server/packages/AdminUser/Domain/Models/RegistrationToken/RegistrationToken.php
+++ b/src/server/packages/AdminUser/Domain/Models/RegistrationToken/RegistrationToken.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AdminUser\Domain\Models\RegistrationToken;
+
+use AdminUser\Domain\Models\Email;
+use AdminUser\Domain\Models\Permissions;
+use AdminUser\Domain\Models\Role;
+use DateTimeImmutable;
+
+readonly class RegistrationToken
+{
+    public function __construct(
+        public RegistrationTokenId $registrationTokenId,
+        public HashedTokenValue $token,
+        public Email $email,
+        public Role $role,
+        public Permissions $permissions,
+        public ExpiredAt $expiredAt,
+        public ConsumptionStatus $status,
+    ) {
+    }
+
+    /**
+     * @param list<string> $permissions
+     */
+    public static function reconstruct(
+        string $registrationTokenId,
+        string $token,
+        string $email,
+        int $role,
+        array $permissions,
+        DateTimeImmutable $expiredAt,
+        int $status,
+    ): self {
+        return new self(
+            RegistrationTokenId::reconstruct($registrationTokenId),
+            HashedTokenValue::reconstruct($token),
+            Email::reconstruct($email),
+            Role::from($role),
+            Permissions::reconstruct($permissions),
+            ExpiredAt::reconstruct($expiredAt),
+            ConsumptionStatus::from($status),
+        );
+    }
+
+    /**
+     * @return array{admin_user_registration_token_id: string, token: string, email: string, role: value-of<Role>, permissions: list<string>, expired_at: string, status: value-of<ConsumptionStatus>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'admin_user_registration_token_id' => $this->registrationTokenId->value,
+            'token' => $this->token->value,
+            'email' => $this->email->value,
+            'role' => $this->role->value,
+            'permissions' => $this->permissions->toArray(),
+            'expired_at' => $this->expiredAt->value->format('Y-m-d H:i:s'),
+            'status' => $this->status->value,
+        ];
+    }
+
+    public function equals(self $other): bool
+    {
+        return $this->registrationTokenId->equals($other->registrationTokenId);
+    }
+}

--- a/src/server/packages/AdminUser/Domain/Models/RegistrationToken/RegistrationTokenId.php
+++ b/src/server/packages/AdminUser/Domain/Models/RegistrationToken/RegistrationTokenId.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AdminUser\Domain\Models\RegistrationToken;
+
+use Support\Domain\ValueObjects\String\UuidValueObject;
+
+readonly class RegistrationTokenId extends UuidValueObject
+{
+}

--- a/src/server/packages/AdminUser/Domain/Models/RegistrationToken/RegistrationTokenRepositoryInterface.php
+++ b/src/server/packages/AdminUser/Domain/Models/RegistrationToken/RegistrationTokenRepositoryInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AdminUser\Domain\Models\RegistrationToken;
+
+interface RegistrationTokenRepositoryInterface
+{
+    public function save(RegistrationToken $token): RegistrationToken;
+}

--- a/src/server/packages/AdminUser/Domain/Services/RegistrationToken/RandomTokenGeneratorInterface.php
+++ b/src/server/packages/AdminUser/Domain/Services/RegistrationToken/RandomTokenGeneratorInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AdminUser\Domain\Services\RegistrationToken;
+
+interface RandomTokenGeneratorInterface
+{
+    public function generate(): string;
+}

--- a/src/server/packages/AdminUser/Domain/Services/RegistrationToken/RegistrationTokenIssueService.php
+++ b/src/server/packages/AdminUser/Domain/Services/RegistrationToken/RegistrationTokenIssueService.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AdminUser\Domain\Services\RegistrationToken;
+
+use AdminUser\Domain\Models\Email;
+use AdminUser\Domain\Models\Permissions;
+use AdminUser\Domain\Models\RegistrationToken\ConsumptionStatus;
+use AdminUser\Domain\Models\RegistrationToken\ExpiredAt;
+use AdminUser\Domain\Models\RegistrationToken\HashedTokenValue;
+use AdminUser\Domain\Models\RegistrationToken\RegistrationToken;
+use AdminUser\Domain\Models\RegistrationToken\RegistrationTokenId;
+use AdminUser\Domain\Models\Role;
+use ResultType\Err;
+use ResultType\Ok;
+use ResultType\Result;
+use Support\Contracts\ClockInterface;
+use Support\Contracts\Uuid\UuidGeneratorInterface;
+use Support\Domain\Error\DomainError;
+use Support\Domain\Error\DomainValidationError;
+use Support\Domain\Error\EntityRuleViolationError;
+
+class RegistrationTokenIssueService
+{
+    private const int TTL_DAY = 7;
+
+    public function __construct(
+        private readonly ClockInterface $clock,
+        private readonly UuidGeneratorInterface $uuidGenerator,
+        private readonly RandomTokenGeneratorInterface $randomTokenGenerator,
+        private readonly TokenHasherInterface $tokenHasher,
+    ) {
+    }
+
+    /**
+     * @param list<string> $permissions
+     *
+     * @return Result<array{token: RegistrationToken, plainToken: string}, DomainError>
+     */
+    public function issue(Email $email, int $role, array $permissions): Result
+    {
+        $plainToken = $this->randomTokenGenerator->generate();
+        $hashedToken = $this->tokenHasher->hash($plainToken);
+
+        $result = Result::collect5(
+            RegistrationTokenId::create($this->uuidGenerator->generate()),
+            HashedTokenValue::create($hashedToken),
+            $this->toRole($role),
+            Permissions::fromArray($permissions),
+            ExpiredAt::create($this->clock->now()->modify('+' . self::TTL_DAY . ' days')),
+        )->map(fn (array $values): RegistrationToken => new RegistrationToken(
+            $values[0],
+            $values[1],
+            $email,
+            $values[2],
+            $values[3],
+            $values[4],
+            ConsumptionStatus::Unused,
+        ));
+
+        if ($result->isErr()) {
+            $messages = [];
+            foreach ($result->unwrapErr() as $error) {
+                if ($error instanceof EntityRuleViolationError) {
+                    $messages[$error->field] ??= [];
+                    $messages[$error->field][] = $error->message;
+                }
+            }
+
+            return new Err(new DomainValidationError($messages));
+        }
+
+        return new Ok([
+            'token' => $result->unwrap(),
+            'plainToken' => $plainToken,
+        ]);
+    }
+
+    /**
+     * @return Result<Role, EntityRuleViolationError>
+     */
+    private function toRole(int $role): Result
+    {
+        $result = Role::tryFrom($role);
+
+        if (is_null($result)) {
+            return new Err(new EntityRuleViolationError(Role::class, "不正なロールです: {$role}"));
+        }
+
+        return new Ok($result);
+    }
+}

--- a/src/server/packages/AdminUser/Domain/Services/RegistrationToken/TokenHasherInterface.php
+++ b/src/server/packages/AdminUser/Domain/Services/RegistrationToken/TokenHasherInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AdminUser\Domain\Services\RegistrationToken;
+
+use SensitiveParameter;
+
+interface TokenHasherInterface
+{
+    public function hash(#[SensitiveParameter] string $plainToken): string;
+
+    public function verify(#[SensitiveParameter] string $plainToken, string $hashedToken): bool;
+}

--- a/src/server/packages/AdminUser/Infrastructures/RegistrationToken/RandomTokenGenerator.php
+++ b/src/server/packages/AdminUser/Infrastructures/RegistrationToken/RandomTokenGenerator.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AdminUser\Infrastructures\RegistrationToken;
+
+use AdminUser\Domain\Services\RegistrationToken\RandomTokenGeneratorInterface;
+use Override;
+
+readonly class RandomTokenGenerator implements RandomTokenGeneratorInterface
+{
+    private const int LENGTH = 64;
+
+    #[Override]
+    public function generate(): string
+    {
+        return bin2hex(random_bytes(self::LENGTH));
+    }
+}

--- a/src/server/packages/AdminUser/Infrastructures/RegistrationToken/RegistrationTokenRepository.php
+++ b/src/server/packages/AdminUser/Infrastructures/RegistrationToken/RegistrationTokenRepository.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AdminUser\Infrastructures\RegistrationToken;
+
+use AdminUser\Domain\Models\RegistrationToken\RegistrationToken;
+use AdminUser\Domain\Models\RegistrationToken\RegistrationTokenRepositoryInterface;
+use App\Models\AdminUser\RegistrationToken as ModelsRegistrationToken;
+use App\Models\AdminUser\RegistrationTokenPermission;
+use Override;
+use Support\Contracts\Uuid\UuidConverterInterface;
+
+readonly class RegistrationTokenRepository implements RegistrationTokenRepositoryInterface
+{
+    public function __construct(private UuidConverterInterface $converter)
+    {
+    }
+
+    #[Override]
+    public function save(RegistrationToken $token): RegistrationToken
+    {
+        $data = $token->toArray();
+
+        $id = $this->converter->toBin($data['admin_user_registration_token_id']);
+
+        ModelsRegistrationToken::query()->insert(
+            [
+                'admin_user_registration_token_id' => $id,
+                'token' => $data['token'],
+                'email' => $data['email'],
+                'role' => $data['role'],
+                'expired_at' => $data['expired_at'],
+                'status' => $data['status'],
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+        );
+
+        if ($data['permissions'] !== []) {
+            RegistrationTokenPermission::query()->insert(
+                array_map(fn (string $permission): array => [
+                    'admin_user_registration_token_id' => $id,
+                    'permission' => $permission,
+                ], $data['permissions']),
+            );
+        }
+
+        return $token;
+    }
+}

--- a/src/server/packages/AdminUser/Infrastructures/RegistrationToken/TokenHasher.php
+++ b/src/server/packages/AdminUser/Infrastructures/RegistrationToken/TokenHasher.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AdminUser\Infrastructures\RegistrationToken;
+
+use AdminUser\Domain\Services\RegistrationToken\TokenHasherInterface;
+use Illuminate\Support\Facades\Hash;
+use Override;
+use SensitiveParameter;
+
+readonly class TokenHasher implements TokenHasherInterface
+{
+    #[Override]
+    public function hash(#[SensitiveParameter] string $plainToken): string
+    {
+        return Hash::make($plainToken);
+    }
+
+    #[Override]
+    public function verify(#[SensitiveParameter] string $plainToken, string $hashedToken): bool
+    {
+        return Hash::check($plainToken, $hashedToken);
+    }
+}

--- a/src/server/tests/Feature/Console/Commands/AdminUser/InviteCommandTest.php
+++ b/src/server/tests/Feature/Console/Commands/AdminUser/InviteCommandTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console\Commands\AdminUser;
+
+use AdminUser\Domain\Models\HashedPassword;
+use AdminUser\Domain\Models\Role;
+use AdminUser\Infrastructures\AdminUserRepository;
+use App\Models\AdminUser\RegistrationToken;
+use App\Models\AdminUser\RegistrationTokenPermission;
+use Illuminate\Support\Facades\Hash;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Support\DatabaseTestCase;
+use Tests\Support\Domain\EntityFactory;
+
+class InviteCommandTest extends DatabaseTestCase
+{
+    use EntityFactory;
+
+    #[Test]
+    public function canIssueGeneralToken(): void
+    {
+        $this->artisan('admin:invite invitee@example.com')->assertSuccessful();
+
+        $rows = RegistrationToken::query()->get()->all();
+        $this->assertCount(1, $rows);
+
+        $row = array_first($rows);
+        $this->assertSame('invitee@example.com', $row->email);
+        $this->assertSame(Role::General->value, $row->role);
+        $this->assertSame(0, RegistrationTokenPermission::query()->count());
+    }
+
+    #[Test]
+    public function canIssuePrivilegeTokenWithPermissions(): void
+    {
+        $this->artisan('admin:invite priv@example.com --privilege read_admin_user write_admin_user')
+            ->assertSuccessful();
+
+        $rows = RegistrationToken::query()->get()->all();
+        $this->assertCount(1, $rows);
+
+        $row = array_first($rows);
+        $this->assertSame(Role::Privilege->value, $row->role);
+
+        $permissions = RegistrationTokenPermission::query()
+            ->where('admin_user_registration_token_id', $row->admin_user_registration_token_id)
+            ->pluck('permission')
+            ->all();
+
+        $this->assertEqualsCanonicalizing(['read_admin_user', 'write_admin_user'], $permissions);
+    }
+
+    #[Test]
+    public function failureWithInvalidPermission(): void
+    {
+        $this->artisan('admin:invite invitee@example.com invalid_permission')
+            ->expectsOutput('不正な権限です: invalid_permission')
+            ->assertFailed();
+
+        $this->assertSame(0, RegistrationToken::query()->count());
+    }
+
+    #[Test]
+    public function failureIfEmailAlreadyUsedByAdminUser(): void
+    {
+        $this->app->make(AdminUserRepository::class)->register(
+            $this->createAdminUser($this->generateUuid(), 'taken@example.com', Role::General, []),
+            HashedPassword::reconstruct('hashed-password'),
+        );
+
+        $this->artisan('admin:invite taken@example.com')
+            ->expectsOutput('すでに使われているメールアドレスです "taken@example.com"')
+            ->assertFailed();
+
+        $this->assertSame(0, RegistrationToken::query()->count());
+    }
+
+    #[Test]
+    public function outputsPlainTokenOnce(): void
+    {
+        $this->artisan('admin:invite invitee@example.com')->assertSuccessful()->run();
+
+        $rows = RegistrationToken::query()->get()->all();
+        $this->assertCount(1, $rows);
+
+        // ハッシュ済みで保存されているため、ハッシュとは平文を直接比較できない。
+        // 平文は標準出力に出るが artisan の API では拾いにくいため、
+        // ここではトークン行が 1 件・ハッシュとして妥当な値であることを担保する。
+        $row = array_first($rows);
+        $this->assertNotSame('', $row->token);
+        $this->assertFalse(Hash::check('', $row->token));
+    }
+}

--- a/src/server/tests/Integration/AdminUser/Application/Cli/UseCase/IssueRegistrationTokenUseCaseTest.php
+++ b/src/server/tests/Integration/AdminUser/Application/Cli/UseCase/IssueRegistrationTokenUseCaseTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\AdminUser\Application\Cli\UseCase;
+
+use AdminUser\Application\Cli\UseCase\IssueRegistrationToken\IssueRegistrationTokenInputData;
+use AdminUser\Application\Cli\UseCase\IssueRegistrationToken\IssueRegistrationTokenUseCase;
+use AdminUser\Domain\Models\Permission;
+use AdminUser\Domain\Models\RegistrationToken\ConsumptionStatus;
+use AdminUser\Domain\Models\Role;
+use App\Models\AdminUser\RegistrationToken as ModelsRegistrationToken;
+use App\Models\AdminUser\RegistrationTokenPermission;
+use Illuminate\Support\Facades\Hash;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Support\DatabaseTestCase;
+
+class IssueRegistrationTokenUseCaseTest extends DatabaseTestCase
+{
+    #[Test]
+    public function canIssue(): void
+    {
+        $result = $this->getInstance()->handle(
+            new IssueRegistrationTokenInputData('invitee@example.com', Role::General->value, []),
+        );
+
+        $this->assertTrue($result->isOk());
+
+        $rows = ModelsRegistrationToken::query()->get()->all();
+        $this->assertCount(1, $rows);
+
+        $row = array_first($rows);
+        $plain = $result->unwrap()->plainToken;
+
+        $this->assertNotSame($plain, $row->token);
+        $this->assertTrue(Hash::check($plain, $row->token));
+        $this->assertSame('invitee@example.com', $row->email);
+        $this->assertSame(Role::General->value, $row->role);
+        $this->assertSame(ConsumptionStatus::Unused->value, $row->status);
+        $this->assertGreaterThan(now(), $row->expired_at);
+        $this->assertSame(0, RegistrationTokenPermission::query()->count());
+    }
+
+    #[Test]
+    public function canIssueWithPrivilegeAndPermissions(): void
+    {
+        $result = $this->getInstance()->handle(
+            new IssueRegistrationTokenInputData(
+                'priv@example.com',
+                Role::Privilege->value,
+                [Permission::ReadAdminUser->value, Permission::WriteAdminUser->value],
+            ),
+        );
+
+        $this->assertTrue($result->isOk());
+
+        $rows = ModelsRegistrationToken::query()->get()->all();
+        $this->assertCount(1, $rows);
+
+        $row = array_first($rows);
+        $this->assertSame(Role::Privilege->value, $row->role);
+
+        $permissions = RegistrationTokenPermission::query()
+            ->where('admin_user_registration_token_id', $row->admin_user_registration_token_id)
+            ->pluck('permission')
+            ->all();
+
+        $this->assertEqualsCanonicalizing(
+            [Permission::ReadAdminUser->value, Permission::WriteAdminUser->value],
+            $permissions,
+        );
+    }
+
+    private function getInstance(): IssueRegistrationTokenUseCase
+    {
+        return $this->app->make(IssueRegistrationTokenUseCase::class);
+    }
+}

--- a/src/server/tests/Unit/AdminUser/Application/Cli/UseCase/IssueRegistrationTokenUseCaseTest.php
+++ b/src/server/tests/Unit/AdminUser/Application/Cli/UseCase/IssueRegistrationTokenUseCaseTest.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\AdminUser\Application\Cli\UseCase;
+
+use AdminUser\Application\Cli\UseCase\IssueRegistrationToken\IssueRegistrationTokenInputData;
+use AdminUser\Application\Cli\UseCase\IssueRegistrationToken\IssueRegistrationTokenUseCase;
+use AdminUser\Domain\Models\AdminUserRepositoryInterface;
+use AdminUser\Domain\Models\Email;
+use AdminUser\Domain\Models\Permissions;
+use AdminUser\Domain\Models\RegistrationToken\ConsumptionStatus;
+use AdminUser\Domain\Models\RegistrationToken\ExpiredAt;
+use AdminUser\Domain\Models\RegistrationToken\HashedTokenValue;
+use AdminUser\Domain\Models\RegistrationToken\RegistrationToken;
+use AdminUser\Domain\Models\RegistrationToken\RegistrationTokenId;
+use AdminUser\Domain\Models\RegistrationToken\RegistrationTokenRepositoryInterface;
+use AdminUser\Domain\Models\Role;
+use AdminUser\Domain\Services\RegistrationToken\RegistrationTokenIssueService;
+use Closure;
+use DateTimeImmutable;
+use Mockery;
+use Mockery\MockInterface;
+use Override;
+use PHPUnit\Framework\Attributes\Test;
+use ResultType\Err;
+use ResultType\Ok;
+use Support\Contracts\TransactionInterface;
+use Support\Domain\Error\DomainValidationError;
+use Support\UseCase\Error\BusinessLogicError;
+use Support\UseCase\Error\InvalidInputError;
+use Tests\Support\Domain\EntityFactory;
+use Tests\TestCase;
+
+class IssueRegistrationTokenUseCaseTest extends TestCase
+{
+    use EntityFactory;
+
+    private MockInterface&TransactionInterface $transaction;
+
+    private AdminUserRepositoryInterface&MockInterface $adminUserRepository;
+
+    private MockInterface&RegistrationTokenIssueService $issueService;
+
+    private MockInterface&RegistrationTokenRepositoryInterface $repository;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->transaction = Mockery::mock(TransactionInterface::class);
+        $this->adminUserRepository = Mockery::mock(AdminUserRepositoryInterface::class);
+        $this->issueService = Mockery::mock(RegistrationTokenIssueService::class);
+        $this->repository = Mockery::mock(RegistrationTokenRepositoryInterface::class);
+    }
+
+    #[Test]
+    public function canIssue(): void
+    {
+        $email = 'invitee@example.com';
+        $plainToken = 'plain-token';
+
+        $token = new RegistrationToken(
+            RegistrationTokenId::reconstruct('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'),
+            HashedTokenValue::reconstruct('hashed'),
+            Email::reconstruct($email),
+            Role::General,
+            Permissions::reconstruct([]),
+            ExpiredAt::reconstruct(new DateTimeImmutable('+7 days')),
+            ConsumptionStatus::Unused,
+        );
+
+        $this->transaction->shouldReceive('scope')
+            ->withArgs(fn (Closure $_) => true)
+            ->andReturnUsing(fn (Closure $arg) => $arg())
+            ->once();
+
+        $this->adminUserRepository->shouldReceive('findByEmail')
+            ->withArgs(fn (Email $arg): bool => $arg->value === $email)
+            ->andReturn(null)
+            ->once();
+
+        $this->issueService->shouldReceive('issue')
+            ->withArgs(fn (Email $arg, int $role, array $permissions): bool => $arg->value === $email
+                && $role === Role::General->value
+                && $permissions === [])
+            ->andReturn(new Ok(['token' => $token, 'plainToken' => $plainToken]))
+            ->once();
+
+        $this->repository->shouldReceive('save')
+            ->with($token)
+            ->andReturn($token)
+            ->once();
+
+        $result = $this->getInstance()->handle(
+            new IssueRegistrationTokenInputData($email, Role::General->value, []),
+        );
+
+        $this->assertTrue($result->isOk());
+        $output = $result->unwrap();
+        $this->assertSame($plainToken, $output->plainToken);
+        $this->assertTrue($output->token->equals($token));
+    }
+
+    #[Test]
+    public function issueFailsIfEmailAlreadyExists(): void
+    {
+        $email = 'existing@example.com';
+
+        $this->transaction->shouldReceive('scope')
+            ->withArgs(fn (Closure $_) => true)
+            ->andReturnUsing(fn (Closure $arg) => $arg())
+            ->once();
+
+        $this->adminUserRepository->shouldReceive('findByEmail')
+            ->withArgs(fn (Email $arg): bool => $arg->value === $email)
+            ->andReturn($this->createAdminUser('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA', $email))
+            ->once();
+
+        $result = $this->getInstance()->handle(
+            new IssueRegistrationTokenInputData($email, Role::General->value, []),
+        );
+
+        $this->assertTrue($result->isErr());
+        $this->assertInstanceOf(BusinessLogicError::class, $result->unwrapErr());
+    }
+
+    #[Test]
+    public function issueFailsIfIssueServiceReturnsErr(): void
+    {
+        $email = 'invitee@example.com';
+
+        $this->transaction->shouldReceive('scope')
+            ->withArgs(fn (Closure $_) => true)
+            ->andReturnUsing(fn (Closure $arg) => $arg())
+            ->once();
+
+        $this->adminUserRepository->shouldReceive('findByEmail')
+            ->withArgs(fn (Email $arg): bool => $arg->value === $email)
+            ->andReturn(null)
+            ->once();
+
+        $this->issueService->shouldReceive('issue')
+            ->andReturn(new Err(new DomainValidationError([])))
+            ->once();
+
+        $result = $this->getInstance()->handle(
+            new IssueRegistrationTokenInputData($email, Role::General->value, []),
+        );
+
+        $this->assertTrue($result->isErr());
+        $this->assertInstanceOf(InvalidInputError::class, $result->unwrapErr());
+    }
+
+    private function getInstance(): IssueRegistrationTokenUseCase
+    {
+        return new IssueRegistrationTokenUseCase(
+            $this->transaction,
+            $this->adminUserRepository,
+            $this->issueService,
+            $this->repository,
+        );
+    }
+}


### PR DESCRIPTION
## 概要

管理ユーザー登録 WebUI で利用する登録トークンを発行する CLI と、その永続化基盤を追加します。
招待時に平文トークンを 1 回だけ表示し、DB にはハッシュ化した値のみを保存します。

## やったこと

- `admin:invite` コマンドと RegistrationToken 発行 UseCase を追加
- RegistrationToken のドメインモデル、リポジトリ、トークン生成・ハッシュ化の実装を追加
- 登録トークンと権限を保持する Atlas スキーマ、Eloquent モデル、各種テストを追加

## やってないこと

- 管理ユーザー登録 WebUI 本体と登録 API の実装
- パスキー登録ロジックそのものの実装

## 関連

- 特になし
