### PR TITLE
パスキーセレモニーの消費処理を安全化

### DIFF
--- a/src/admin/src/components/auth/RegisterForm.tsx
+++ b/src/admin/src/components/auth/RegisterForm.tsx
@@ -16,9 +16,10 @@ export const RegisterForm = () => {
 
     const form = e.target as HTMLFormElement;
     const formData = new FormData(form);
+    const token = formData.get('token')?.toString() ?? '';
 
     const start = await client.api.auth.register.start.post({
-      token: formData.get('token')?.toString() ?? '',
+      token,
       email: formData.get('email')?.toString() ?? '',
       name: formData.get('name')?.toString() ?? '',
     });
@@ -37,6 +38,7 @@ export const RegisterForm = () => {
       const credential = await registerPasskey(start.data.publicKey as Record<string, unknown>);
       const finish = await client.api.auth.register.finish.post({
         authCeremonyId: start.data.authCeremonyId,
+        token,
         credential,
       });
 

--- a/src/admin/src/generated/types.gen.ts
+++ b/src/admin/src/generated/types.gen.ts
@@ -234,6 +234,7 @@ export type RefreshTokenResponse = {
 
 export type RegisterFinishRequest = {
     authCeremonyId: AuthCeremonyId;
+    token: RegistrationToken;
     credential: {
         [key: string]: unknown;
     };

--- a/src/admin/src/server/routes/auth.test.ts
+++ b/src/admin/src/server/routes/auth.test.ts
@@ -258,6 +258,7 @@ describe('POST /auth/register/finish', () => {
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({
           authCeremonyId: 'auth-ceremony-id',
+          token: 'plain-token',
           credential: { id: 'credential-id' },
         }),
       }),
@@ -267,6 +268,7 @@ describe('POST /auth/register/finish', () => {
     expect(registerFinishCalls).toHaveLength(1);
     expect(registerFinishCalls[0]).toEqual({
       authCeremonyId: 'auth-ceremony-id',
+      token: 'plain-token',
       credential: { id: 'credential-id' },
     });
 
@@ -292,6 +294,7 @@ describe('POST /auth/register/finish', () => {
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({
           authCeremonyId: 'auth-ceremony-id',
+          token: 'plain-token',
           credential: { fail: true },
         }),
       }),

--- a/src/admin/src/server/routes/auth.ts
+++ b/src/admin/src/server/routes/auth.ts
@@ -90,9 +90,9 @@ export const auth = new Elysia({ prefix: '/auth' })
   )
   .post(
     '/register/finish',
-    async ({ body: { authCeremonyId, credential }, cookie: { session, csrf } }) => {
+    async ({ body: { authCeremonyId, token, credential }, cookie: { session, csrf } }) => {
       const data = resolveApiResponse(
-        await authenticateServiceRegisterFinish({ client: client, body: { authCeremonyId, credential } }),
+        await authenticateServiceRegisterFinish({ client: client, body: { authCeremonyId, token, credential } }),
       );
 
       const sessionId = generateRandomBytes();
@@ -105,6 +105,7 @@ export const auth = new Elysia({ prefix: '/auth' })
     {
       body: t.Object({
         authCeremonyId: t.String(),
+        token: t.String(),
         credential: t.Record(t.String(), t.Any()),
       }),
     },

--- a/src/contracts/generated/oas/IsekaiObservatory.Admin.v1.yaml
+++ b/src/contracts/generated/oas/IsekaiObservatory.Admin.v1.yaml
@@ -2138,10 +2138,13 @@ components:
       type: object
       required:
         - authCeremonyId
+        - token
         - credential
       properties:
         authCeremonyId:
           $ref: '#/components/schemas/authCeremonyId'
+        token:
+          $ref: '#/components/schemas/registrationToken'
         credential:
           type: object
           unevaluatedProperties: {}

--- a/src/contracts/src/admin/auth/transport.tsp
+++ b/src/contracts/src/admin/auth/transport.tsp
@@ -49,6 +49,7 @@ model RegisterStartResponse {
 
 model RegisterFinishRequest {
   authCeremonyId: authCeremonyId;
+  token: registrationToken;
   credential: webAuthnCredential;
 }
 

--- a/src/server/Generated/lib/Model/RegisterFinishRequest.php
+++ b/src/server/Generated/lib/Model/RegisterFinishRequest.php
@@ -58,6 +58,7 @@ class RegisterFinishRequest implements ModelInterface, ArrayAccess, \JsonSeriali
       */
     protected static $openAPITypes = [
         'auth_ceremony_id' => 'string',
+        'token' => 'string',
         'credential' => 'object'
     ];
 
@@ -70,6 +71,7 @@ class RegisterFinishRequest implements ModelInterface, ArrayAccess, \JsonSeriali
       */
     protected static $openAPIFormats = [
         'auth_ceremony_id' => 'uuid',
+        'token' => 'password',
         'credential' => null
     ];
 
@@ -80,6 +82,7 @@ class RegisterFinishRequest implements ModelInterface, ArrayAccess, \JsonSeriali
       */
     protected static array $openAPINullables = [
         'auth_ceremony_id' => false,
+        'token' => false,
         'credential' => false
     ];
 
@@ -170,6 +173,7 @@ class RegisterFinishRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      */
     protected static $attributeMap = [
         'auth_ceremony_id' => 'authCeremonyId',
+        'token' => 'token',
         'credential' => 'credential'
     ];
 
@@ -180,6 +184,7 @@ class RegisterFinishRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      */
     protected static $setters = [
         'auth_ceremony_id' => 'setAuthCeremonyId',
+        'token' => 'setToken',
         'credential' => 'setCredential'
     ];
 
@@ -190,6 +195,7 @@ class RegisterFinishRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      */
     protected static $getters = [
         'auth_ceremony_id' => 'getAuthCeremonyId',
+        'token' => 'getToken',
         'credential' => 'getCredential'
     ];
 
@@ -251,6 +257,7 @@ class RegisterFinishRequest implements ModelInterface, ArrayAccess, \JsonSeriali
     public function __construct(?array $data = null)
     {
         $this->setIfExists('auth_ceremony_id', $data ?? [], null);
+        $this->setIfExists('token', $data ?? [], null);
         $this->setIfExists('credential', $data ?? [], null);
     }
 
@@ -283,6 +290,9 @@ class RegisterFinishRequest implements ModelInterface, ArrayAccess, \JsonSeriali
 
         if ($this->container['auth_ceremony_id'] === null) {
             $invalidProperties[] = "'auth_ceremony_id' can't be null";
+        }
+        if ($this->container['token'] === null) {
+            $invalidProperties[] = "'token' can't be null";
         }
         if ($this->container['credential'] === null) {
             $invalidProperties[] = "'credential' can't be null";
@@ -325,6 +335,33 @@ class RegisterFinishRequest implements ModelInterface, ArrayAccess, \JsonSeriali
             throw new \InvalidArgumentException('non-nullable auth_ceremony_id cannot be null');
         }
         $this->container['auth_ceremony_id'] = $auth_ceremony_id;
+
+        return $this;
+    }
+
+    /**
+     * Gets token
+     *
+     * @return string
+     */
+    public function getToken()
+    {
+        return $this->container['token'];
+    }
+
+    /**
+     * Sets token
+     *
+     * @param string $token 管理ユーザー登録トークン(平文)
+     *
+     * @return self
+     */
+    public function setToken($token)
+    {
+        if (is_null($token)) {
+            throw new \InvalidArgumentException('non-nullable token cannot be null');
+        }
+        $this->container['token'] = $token;
 
         return $this;
     }

--- a/src/server/app/Http/Controllers/Api/Admin/V1/Auth/RegisterFinishController.php
+++ b/src/server/app/Http/Controllers/Api/Admin/V1/Auth/RegisterFinishController.php
@@ -26,6 +26,7 @@ class RegisterFinishController extends Controller
 
         $inputData = new RegisterFinishInputData(
             $request->string('authCeremonyId')->toString(),
+            $request->string('token')->toString(),
             $credential,
         );
 

--- a/src/server/packages/AdminUser/Application/Admin/UseCase/RegisterFinish/RegisterFinishInputData.php
+++ b/src/server/packages/AdminUser/Application/Admin/UseCase/RegisterFinish/RegisterFinishInputData.php
@@ -11,6 +11,7 @@ readonly class RegisterFinishInputData
      */
     public function __construct(
         public string $authCeremonyId,
+        public string $plainToken,
         public array $credential,
     ) {
     }

--- a/src/server/packages/AdminUser/Application/Admin/UseCase/RegisterFinish/RegisterFinishUseCase.php
+++ b/src/server/packages/AdminUser/Application/Admin/UseCase/RegisterFinish/RegisterFinishUseCase.php
@@ -13,6 +13,7 @@ use Auth\Domain\Models\AdminUserPasskey;
 use Auth\Domain\Models\AdminUserPasskeyRepositoryInterface;
 use Auth\Domain\Models\PasskeyCeremonyState;
 use Auth\Domain\Models\PasskeyCeremonyStoreInterface;
+use Auth\Domain\Models\PasskeyCeremonyType;
 use Auth\Domain\Models\Token\RefreshToken\RefreshTokenRepositoryInterface;
 use Auth\Domain\Services\PasskeyAuthenticatorInterface;
 use Auth\Domain\Services\PasskeyVerificationResult;
@@ -60,11 +61,11 @@ readonly class RegisterFinishUseCase
     {
         $state = $this->ceremonyStore->pull($inputData->authCeremonyId);
 
-        if (! $state instanceof PasskeyCeremonyState || $state->type !== 'register') {
+        if (is_null($state) || $state->type !== PasskeyCeremonyType::Register) {
             return new Err(new BusinessLogicError('register_ceremony_not_found'));
         }
 
-        if ($state->token === null || $state->name === null) {
+        if (is_null($state->name)) {
             return new Err(new BusinessLogicError('register_ceremony_not_found'));
         }
 
@@ -77,15 +78,18 @@ readonly class RegisterFinishUseCase
             return new Err(new BusinessLogicError('passkey_verification_failed'));
         }
 
-        return $this->transaction->scope(fn (): Result => $this->persist($state, $verification));
+        return $this->transaction->scope(fn (): Result => $this->persist($state, $inputData->plainToken, $verification));
     }
 
     /**
      * @return Result<RegisterFinishOutputData, UseCaseError>
      */
-    private function persist(PasskeyCeremonyState $state, PasskeyVerificationResult $verification): Result
-    {
-        if ($state->token === null || $state->name === null) {
+    private function persist(
+        PasskeyCeremonyState $state,
+        string $plainToken,
+        PasskeyVerificationResult $verification,
+    ): Result {
+        if (is_null($state->name)) {
             return new Err(new BusinessLogicError('register_ceremony_not_found'));
         }
 
@@ -95,7 +99,7 @@ readonly class RegisterFinishUseCase
             return new Err($this->handleError($emailResult->unwrapErr()));
         }
 
-        $tokenResult = $this->consumeService->verify($state->token, $emailResult->unwrap());
+        $tokenResult = $this->consumeService->verify($plainToken, $emailResult->unwrap());
 
         if ($tokenResult->isErr()) {
             return new Err($this->handleError($tokenResult->unwrapErr()));

--- a/src/server/packages/AdminUser/Application/Admin/UseCase/RegisterStart/RegisterStartUseCase.php
+++ b/src/server/packages/AdminUser/Application/Admin/UseCase/RegisterStart/RegisterStartUseCase.php
@@ -9,6 +9,7 @@ use AdminUser\Domain\Services\AdminUserIntegrityService;
 use AdminUser\Domain\Services\RegistrationToken\RegistrationTokenConsumeService;
 use Auth\Domain\Models\PasskeyCeremonyState;
 use Auth\Domain\Models\PasskeyCeremonyStoreInterface;
+use Auth\Domain\Models\PasskeyCeremonyType;
 use Auth\Domain\Services\PasskeyAuthenticatorInterface;
 use LogicException;
 use ResultType\Err;
@@ -73,8 +74,7 @@ readonly class RegisterStartUseCase
 
         $this->ceremonyStore->put(new PasskeyCeremonyState(
             $authCeremonyId,
-            'register',
-            $inputData->plainToken,
+            PasskeyCeremonyType::Register,
             $adminUser->email->value,
             $adminUser->name->value,
             $adminUser->adminUserId->value,

--- a/src/server/packages/Auth/Application/Admin/UseCase/Login/LoginFinishUseCase.php
+++ b/src/server/packages/Auth/Application/Admin/UseCase/Login/LoginFinishUseCase.php
@@ -8,6 +8,7 @@ use Auth\Domain\Models\AdminUserPasskey;
 use Auth\Domain\Models\AdminUserPasskeyRepositoryInterface;
 use Auth\Domain\Models\PasskeyCeremonyState;
 use Auth\Domain\Models\PasskeyCeremonyStoreInterface;
+use Auth\Domain\Models\PasskeyCeremonyType;
 use Auth\Domain\Models\Token\RefreshToken\RefreshTokenRepositoryInterface;
 use Auth\Domain\Services\PasskeyAuthenticatorInterface;
 use Auth\Domain\Services\PasskeyVerificationResult;
@@ -52,19 +53,19 @@ readonly class LoginFinishUseCase
     {
         $state = $this->ceremonyStore->pull($inputData->authCeremonyId);
 
-        if (! $state instanceof PasskeyCeremonyState || $state->type !== 'login') {
+        if (is_null($state) || $state->type !== PasskeyCeremonyType::Login) {
             return new Err(new AuthenticationError());
         }
 
         $credentialId = $this->credentialId($inputData->credential);
 
-        if ($credentialId === null) {
+        if (is_null($credentialId)) {
             return new Err(new AuthenticationError());
         }
 
         $passkey = $this->passkeyRepository->findByCredentialId($credentialId);
 
-        if ($passkey === null || $passkey->adminUserId !== $state->adminUserId) {
+        if (is_null($passkey) || $passkey->adminUserId !== $state->adminUserId) {
             return new Err(new AuthenticationError());
         }
 

--- a/src/server/packages/Auth/Application/Admin/UseCase/Login/LoginStartUseCase.php
+++ b/src/server/packages/Auth/Application/Admin/UseCase/Login/LoginStartUseCase.php
@@ -9,6 +9,7 @@ use AdminUser\Domain\Models\Email;
 use Auth\Domain\Models\AdminUserPasskeyRepositoryInterface;
 use Auth\Domain\Models\PasskeyCeremonyState;
 use Auth\Domain\Models\PasskeyCeremonyStoreInterface;
+use Auth\Domain\Models\PasskeyCeremonyType;
 use Auth\Domain\Services\PasskeyAuthenticatorInterface;
 use LogicException;
 use ResultType\Err;
@@ -46,7 +47,7 @@ readonly class LoginStartUseCase
 
         $adminUser = $this->adminUserRepository->findByEmail($emailResult->unwrap());
 
-        if ($adminUser === null) {
+        if (is_null($adminUser)) {
             return new Err(new AuthenticationError());
         }
 
@@ -61,8 +62,7 @@ readonly class LoginStartUseCase
 
         $this->ceremonyStore->put(new PasskeyCeremonyState(
             $authCeremonyId,
-            'login',
-            null,
+            PasskeyCeremonyType::Login,
             $adminUser->email->value,
             null,
             $adminUser->adminUserId->value,

--- a/src/server/packages/Auth/Domain/Models/AuthCeremonyId.php
+++ b/src/server/packages/Auth/Domain/Models/AuthCeremonyId.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth\Domain\Models;
+
+use Support\Domain\ValueObjects\String\UuidValueObject;
+
+readonly class AuthCeremonyId extends UuidValueObject
+{
+}

--- a/src/server/packages/Auth/Domain/Models/PasskeyCeremonyState.php
+++ b/src/server/packages/Auth/Domain/Models/PasskeyCeremonyState.php
@@ -4,24 +4,28 @@ declare(strict_types=1);
 
 namespace Auth\Domain\Models;
 
+use AdminUser\Domain\Models\AdminUserId;
+use AdminUser\Domain\Models\Email;
+
 readonly class PasskeyCeremonyState
 {
     public function __construct(
         public string $authCeremonyId,
-        public string $type,
-        public ?string $token,
+        public PasskeyCeremonyType $type,
         public string $email,
         public ?string $name,
         public string $adminUserId,
         public string $optionsJson,
     ) {
+        AuthCeremonyId::reconstruct($this->authCeremonyId);
+        Email::reconstruct($this->email);
+        AdminUserId::reconstruct($this->adminUserId);
     }
 
     /**
      * @return array{
      *   auth_ceremony_id: string,
      *   type: string,
-     *   token: string|null,
      *   email: string,
      *   name: string|null,
      *   admin_user_id: string,
@@ -32,11 +36,10 @@ readonly class PasskeyCeremonyState
     {
         return [
             'auth_ceremony_id' => $this->authCeremonyId,
-            'type' => $this->type,
-            'token' => $this->token,
+            'type' => $this->type->value,
             'email' => $this->email,
-            'admin_user_id' => $this->adminUserId,
             'name' => $this->name,
+            'admin_user_id' => $this->adminUserId,
             'options_json' => $this->optionsJson,
         ];
     }
@@ -45,7 +48,6 @@ readonly class PasskeyCeremonyState
      * @param array{
      *   auth_ceremony_id: string,
      *   type: string,
-     *   token: string|null,
      *   email: string,
      *   name: string|null,
      *   admin_user_id: string,
@@ -56,8 +58,7 @@ readonly class PasskeyCeremonyState
     {
         return new self(
             $data['auth_ceremony_id'],
-            $data['type'],
-            $data['token'],
+            PasskeyCeremonyType::from($data['type']),
             $data['email'],
             $data['name'],
             $data['admin_user_id'],

--- a/src/server/packages/Auth/Domain/Models/PasskeyCeremonyType.php
+++ b/src/server/packages/Auth/Domain/Models/PasskeyCeremonyType.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth\Domain\Models;
+
+enum PasskeyCeremonyType: string
+{
+    case Login = 'login';
+
+    case Register = 'register';
+}

--- a/src/server/packages/Auth/Infrastructures/PasskeyCeremonyStore.php
+++ b/src/server/packages/Auth/Infrastructures/PasskeyCeremonyStore.php
@@ -6,7 +6,9 @@ namespace Auth\Infrastructures;
 
 use Auth\Domain\Models\PasskeyCeremonyState;
 use Auth\Domain\Models\PasskeyCeremonyStoreInterface;
+use Illuminate\Cache\Repository;
 use Illuminate\Contracts\Cache\Factory as CacheFactory;
+use Illuminate\Contracts\Cache\LockTimeoutException;
 use Override;
 
 readonly class PasskeyCeremonyStore implements PasskeyCeremonyStoreInterface
@@ -19,32 +21,39 @@ readonly class PasskeyCeremonyStore implements PasskeyCeremonyStoreInterface
     public function put(PasskeyCeremonyState $state): void
     {
         $ttl = config()->integer('auth.passkey.ceremony_ttl_seconds', 300);
+        $store = $this->store();
 
-        $this->cache
-            ->store(config()->string('auth.passkey.ceremony_cache_store'))
-            ->put(
-                $this->key($state->authCeremonyId),
-                $state->toArray(),
-                $ttl,
-            );
+        $store->put(
+            $this->key($state->authCeremonyId),
+            $state->toArray(),
+            $ttl,
+        );
     }
 
     #[Override]
     public function pull(string $authCeremonyId): ?PasskeyCeremonyState
     {
-        /** @var array<string, mixed>|null $payload */
-        $payload = $this->cache
-            ->store(config()->string('auth.passkey.ceremony_cache_store'))
-            ->pull($this->key($authCeremonyId));
+        $store = $this->store();
 
-        if ($payload === null) {
+        try {
+            /** @var array<string, mixed>|null $payload */
+            $payload = $store->withoutOverlapping(
+                $this->lockKey($authCeremonyId),
+                fn (): mixed => $store->pull($this->key($authCeremonyId)),
+                10,
+                5,
+            );
+        } catch (LockTimeoutException) {
+            return null;
+        }
+
+        if (is_null($payload)) {
             return null;
         }
 
         /** @var array{
          *   auth_ceremony_id: string,
          *   type: string,
-         *   token: string|null,
          *   email: string,
          *   name: string|null,
          *   admin_user_id: string,
@@ -57,5 +66,18 @@ readonly class PasskeyCeremonyStore implements PasskeyCeremonyStoreInterface
     private function key(string $authCeremonyId): string
     {
         return 'auth:passkey:ceremony:' . $authCeremonyId;
+    }
+
+    private function lockKey(string $authCeremonyId): string
+    {
+        return $this->key($authCeremonyId) . ':lock';
+    }
+
+    private function store(): Repository
+    {
+        $store = $this->cache->store(config()->string('auth.passkey.ceremony_cache_store'));
+        assert($store instanceof Repository);
+
+        return $store;
     }
 }

--- a/src/server/tests/Feature/Api/Admin/V1/Auth/LoginTest.php
+++ b/src/server/tests/Feature/Api/Admin/V1/Auth/LoginTest.php
@@ -10,6 +10,7 @@ use Auth\Domain\Models\AdminUserPasskey;
 use Auth\Domain\Models\AdminUserPasskeyRepositoryInterface;
 use Auth\Domain\Models\PasskeyCeremonyState;
 use Auth\Domain\Models\PasskeyCeremonyStoreInterface;
+use Auth\Domain\Models\PasskeyCeremonyType;
 use Auth\Domain\Services\PasskeyAuthenticatorInterface;
 use Auth\Domain\Services\PasskeyStartResult;
 use Auth\Domain\Services\PasskeyVerificationResult;
@@ -149,8 +150,7 @@ class LoginTest extends DatabaseTestCase
 
         $this->app->make(PasskeyCeremonyStoreInterface::class)->put(new PasskeyCeremonyState(
             $authCeremonyId,
-            'register',
-            'plain-token',
+            PasskeyCeremonyType::Register,
             'example@example.com',
             'テストユーザー',
             $adminUserId,

--- a/src/server/tests/Feature/Api/Admin/V1/Auth/RegisterFinishTest.php
+++ b/src/server/tests/Feature/Api/Admin/V1/Auth/RegisterFinishTest.php
@@ -54,6 +54,7 @@ class RegisterFinishTest extends DatabaseTestCase
 
         $this->postJson(route(AuthRouteMap::RegisterFinish), [
             'authCeremonyId' => $authCeremonyId,
+            'token' => 'plain-token',
             'credential' => ['id' => 'credential-id'],
         ])->assertStatus(200)
             ->assertJson(
@@ -89,6 +90,7 @@ class RegisterFinishTest extends DatabaseTestCase
 
         $this->postJson(route(AuthRouteMap::RegisterFinish), [
             'authCeremonyId' => $authCeremonyId,
+            'token' => 'plain-token',
             'credential' => ['id' => 'credential-id'],
         ])->assertStatus(400);
 

--- a/src/server/tests/Integration/Auth/Infrastructures/PasskeyCeremonyStoreTest.php
+++ b/src/server/tests/Integration/Auth/Infrastructures/PasskeyCeremonyStoreTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Auth\Infrastructures;
+
+use Auth\Domain\Models\PasskeyCeremonyState;
+use Auth\Domain\Models\PasskeyCeremonyType;
+use Auth\Infrastructures\PasskeyCeremonyStore;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Facades\Cache;
+use Override;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class PasskeyCeremonyStoreTest extends TestCase
+{
+    #[Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set([
+            'auth.passkey.ceremony_cache_store' => 'array',
+            'auth.passkey.ceremony_ttl_seconds' => 1,
+        ]);
+
+        Cache::store('array')->clear();
+    }
+
+    #[Override]
+    protected function tearDown(): void
+    {
+        CarbonImmutable::setTestNow();
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function putAndPullConsumesStateOnce(): void
+    {
+        $state = new PasskeyCeremonyState(
+            'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA',
+            PasskeyCeremonyType::Register,
+            'invitee@example.com',
+            '招待ユーザー',
+            'BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB',
+            '{"challenge":"challenge"}',
+        );
+
+        $this->getInstance()->put($state);
+
+        $this->assertEquals($state, $this->getInstance()->pull($state->authCeremonyId));
+        $this->assertNull($this->getInstance()->pull($state->authCeremonyId));
+    }
+
+    #[Test]
+    public function pullReturnsNullAfterTtlExpired(): void
+    {
+        $state = new PasskeyCeremonyState(
+            'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA',
+            PasskeyCeremonyType::Login,
+            'user@example.com',
+            null,
+            'BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB',
+            '{"challenge":"challenge"}',
+        );
+
+        $this->getInstance()->put($state);
+
+        CarbonImmutable::setTestNow(CarbonImmutable::now()->addSeconds(2));
+
+        $this->assertNull($this->getInstance()->pull($state->authCeremonyId));
+    }
+
+    #[Test]
+    public function serializedStateDoesNotContainInvitationToken(): void
+    {
+        $state = new PasskeyCeremonyState(
+            'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA',
+            PasskeyCeremonyType::Register,
+            'invitee@example.com',
+            '招待ユーザー',
+            'BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB',
+            '{"challenge":"challenge"}',
+        );
+
+        $payload = $state->toArray();
+
+        $this->assertArrayNotHasKey('token', $payload);
+        $this->assertSame('register', $payload['type']);
+    }
+
+    private function getInstance(): PasskeyCeremonyStore
+    {
+        return $this->app->make(PasskeyCeremonyStore::class);
+    }
+}

--- a/src/server/tests/Unit/AdminUser/Application/Admin/UseCase/RegisterFinish/RegisterFinishUseCaseTest.php
+++ b/src/server/tests/Unit/AdminUser/Application/Admin/UseCase/RegisterFinish/RegisterFinishUseCaseTest.php
@@ -23,6 +23,7 @@ use Auth\Domain\Models\AdminUserPasskey;
 use Auth\Domain\Models\AdminUserPasskeyRepositoryInterface;
 use Auth\Domain\Models\PasskeyCeremonyState;
 use Auth\Domain\Models\PasskeyCeremonyStoreInterface;
+use Auth\Domain\Models\PasskeyCeremonyType;
 use Auth\Domain\Models\Token\RefreshToken\ConsumptionStatus as RefreshConsumptionStatus;
 use Auth\Domain\Models\Token\RefreshToken\RefreshTokenRepositoryInterface;
 use Auth\Domain\Services\PasskeyAuthenticatorInterface;
@@ -103,14 +104,14 @@ class RegisterFinishUseCaseTest extends TestCase
         $passkeyId = 'CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC';
         $refreshTokenId = 'DDDDDDDD-DDDD-DDDD-DDDD-DDDDDDDDDDDD';
         $now = new DateTimeImmutable('2026-01-01 00:00:00');
-        $state = new PasskeyCeremonyState('ceremony-id', 'register', 'plain-token', 'invitee@example.com', '名前', $adminUserId, '{"challenge":"challenge"}');
+        $state = new PasskeyCeremonyState('EEEEEEEE-EEEE-EEEE-EEEE-EEEEEEEEEEEE', PasskeyCeremonyType::Register, 'invitee@example.com', '名前', $adminUserId, '{"challenge":"challenge"}');
         $verification = new PasskeyVerificationResult('credential-id', 'public-key', 123);
         $token = $this->buildToken('invitee@example.com');
         $adminUser = $this->createAdminUser($adminUserId, 'invitee@example.com', name: '名前');
         $refreshToken = $this->createRefreshToken($refreshTokenId, $adminUserId, 'hashed-refresh', new DateTimeImmutable('+7 days'), RefreshConsumptionStatus::Unused);
         $accessToken = $this->createAccessToken('jwt-value');
 
-        $this->ceremonyStore->shouldReceive('pull')->with('ceremony-id')->andReturn($state)->once();
+        $this->ceremonyStore->shouldReceive('pull')->with('EEEEEEEE-EEEE-EEEE-EEEE-EEEEEEEEEEEE')->andReturn($state)->once();
         $this->passkeyAuthenticator->shouldReceive('finishRegistration')
             ->with(['id' => 'credential-id'], '{"challenge":"challenge"}')
             ->andReturn($verification)
@@ -148,7 +149,7 @@ class RegisterFinishUseCaseTest extends TestCase
         $this->accessTokenIssueService->shouldReceive('issue')->with($refreshTokenId)->andReturn($accessToken)->once();
         $this->refreshTokenRepository->shouldReceive('save')->with($refreshToken)->andReturn($refreshToken)->once();
 
-        $result = $this->getInstance()->handle(new RegisterFinishInputData('ceremony-id', ['id' => 'credential-id']));
+        $result = $this->getInstance()->handle(new RegisterFinishInputData('EEEEEEEE-EEEE-EEEE-EEEE-EEEEEEEEEEEE', 'plain-token', ['id' => 'credential-id']));
 
         $this->assertTrue($result->isOk());
         $this->assertSame('jwt-value', $result->unwrap()->accessToken->jwt->value);
@@ -157,16 +158,16 @@ class RegisterFinishUseCaseTest extends TestCase
     #[Test]
     public function doesNotPersistWhenPasskeyVerificationFails(): void
     {
-        $state = new PasskeyCeremonyState('ceremony-id', 'register', 'plain-token', 'invitee@example.com', '名前', 'BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB', '{}');
+        $state = new PasskeyCeremonyState('EEEEEEEE-EEEE-EEEE-EEEE-EEEEEEEEEEEE', PasskeyCeremonyType::Register, 'invitee@example.com', '名前', 'BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB', '{}');
 
-        $this->ceremonyStore->shouldReceive('pull')->with('ceremony-id')->andReturn($state)->once();
+        $this->ceremonyStore->shouldReceive('pull')->with('EEEEEEEE-EEEE-EEEE-EEEE-EEEEEEEEEEEE')->andReturn($state)->once();
         $this->passkeyAuthenticator->shouldReceive('finishRegistration')->andThrow(new RuntimeException('failed'))->once();
         $this->transaction->shouldReceive('scope')->never();
         $this->adminUserRepository->shouldReceive('register')->never();
         $this->passkeyRepository->shouldReceive('save')->never();
         $this->registrationTokenRepository->shouldReceive('save')->never();
 
-        $result = $this->getInstance()->handle(new RegisterFinishInputData('ceremony-id', ['id' => 'credential-id']));
+        $result = $this->getInstance()->handle(new RegisterFinishInputData('EEEEEEEE-EEEE-EEEE-EEEE-EEEEEEEEEEEE', 'plain-token', ['id' => 'credential-id']));
 
         $this->assertTrue($result->isErr());
         $this->assertInstanceOf(BusinessLogicError::class, $result->unwrapErr());
@@ -176,12 +177,12 @@ class RegisterFinishUseCaseTest extends TestCase
     public function doesNotPersistWhenRefreshTokenIssueFails(): void
     {
         $adminUserId = 'BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB';
-        $state = new PasskeyCeremonyState('ceremony-id', 'register', 'plain-token', 'invitee@example.com', '名前', $adminUserId, '{"challenge":"challenge"}');
+        $state = new PasskeyCeremonyState('EEEEEEEE-EEEE-EEEE-EEEE-EEEEEEEEEEEE', PasskeyCeremonyType::Register, 'invitee@example.com', '名前', $adminUserId, '{"challenge":"challenge"}');
         $verification = new PasskeyVerificationResult('credential-id', 'public-key', 123);
         $token = $this->buildToken('invitee@example.com');
         $adminUser = $this->createAdminUser($adminUserId, 'invitee@example.com', name: '名前');
 
-        $this->ceremonyStore->shouldReceive('pull')->with('ceremony-id')->andReturn($state)->once();
+        $this->ceremonyStore->shouldReceive('pull')->with('EEEEEEEE-EEEE-EEEE-EEEE-EEEEEEEEEEEE')->andReturn($state)->once();
         $this->passkeyAuthenticator->shouldReceive('finishRegistration')
             ->with(['id' => 'credential-id'], '{"challenge":"challenge"}')
             ->andReturn($verification)
@@ -208,7 +209,7 @@ class RegisterFinishUseCaseTest extends TestCase
         $this->registrationTokenRepository->shouldReceive('save')->never();
         $this->refreshTokenRepository->shouldReceive('save')->never();
 
-        $result = $this->getInstance()->handle(new RegisterFinishInputData('ceremony-id', ['id' => 'credential-id']));
+        $result = $this->getInstance()->handle(new RegisterFinishInputData('EEEEEEEE-EEEE-EEEE-EEEE-EEEEEEEEEEEE', 'plain-token', ['id' => 'credential-id']));
 
         $this->assertTrue($result->isErr());
     }

--- a/src/server/tests/Unit/AdminUser/Application/Admin/UseCase/RegisterStart/RegisterStartUseCaseTest.php
+++ b/src/server/tests/Unit/AdminUser/Application/Admin/UseCase/RegisterStart/RegisterStartUseCaseTest.php
@@ -18,6 +18,7 @@ use AdminUser\Domain\Services\AdminUserIntegrityService;
 use AdminUser\Domain\Services\RegistrationToken\RegistrationTokenConsumeService;
 use Auth\Domain\Models\PasskeyCeremonyState;
 use Auth\Domain\Models\PasskeyCeremonyStoreInterface;
+use Auth\Domain\Models\PasskeyCeremonyType;
 use Auth\Domain\Services\PasskeyAuthenticatorInterface;
 use Auth\Domain\Services\PasskeyStartResult;
 use DateTimeImmutable;
@@ -89,8 +90,7 @@ class RegisterStartUseCaseTest extends TestCase
 
         $this->ceremonyStore->shouldReceive('put')
             ->withArgs(fn (PasskeyCeremonyState $state): bool => $state->authCeremonyId === $authCeremonyId
-                && $state->type === 'register'
-                && $state->token === 'plain-token'
+                && $state->type === PasskeyCeremonyType::Register
                 && $state->email === 'invitee@example.com'
                 && $state->name === '名前'
                 && $state->adminUserId === $adminUserId


### PR DESCRIPTION
## 概要

パスキーセレモニーの cache 消費を lock 付きにし、登録フローで招待トークン平文を ceremony state に保存しないようにします。
`improvements.md` の PR2 相当の改善です。

## やったこと

- `PasskeyCeremonyStore::pull()` を cache lock 付きにし、取得と削除を同一 critical section で行うように変更
- `PasskeyCeremonyState` から招待トークン平文を削除し、`PasskeyCeremonyType` enum と `AuthCeremonyId` を追加
- `register/finish` request に registration token を追加し、finish 時に token を再提示して再検証する形へ変更
- contract / server generated / admin generated を再生成
- admin BFF と `RegisterForm` を新しい `register/finish` request に追随
- `PasskeyCeremonyStoreTest` を追加し、1 回だけ pull できること、TTL 後に null になること、payload に token を含まないことを検証

## やってないこと

- Rate Limit 対応は PR1 相当として別 PR で対応予定
- 登録トークンの hash 方式変更と複数 token 検証仕様の改善は PR3 相当として別 PR で対応予定
- `src/server/config/auth.php` の既存未コミット差分、`dump.sql`、`improvements*.md`、実行計画 docs はこの PR に含めていません

## 関連

- `improvements.md` の `#2`, `#7`, `#17`, `#23`, `#32`, `#34`, `#39`

## 検証

- `mise run contract:format:check`
- `mise run contract:test`
- `mise run api:test -- tests/Feature/Api/Admin/V1/Auth`
- `mise run api:test -- tests/Unit/AdminUser/Application/Admin/UseCase/RegisterStart`
- `mise run api:test -- tests/Unit/AdminUser/Application/Admin/UseCase/RegisterFinish`
- `mise run api:test -- tests/Integration/Auth/Infrastructures/PasskeyCeremonyStoreTest.php`
- `bun test ./src/server/routes/auth.test.ts` (`src/admin`)
- `mise run api:ecs -- packages/Auth packages/AdminUser app/Http/Controllers/Api/Admin/V1/Auth tests/Unit/AdminUser/Application/Admin/UseCase/RegisterStart tests/Unit/AdminUser/Application/Admin/UseCase/RegisterFinish tests/Integration/Auth/Infrastructures tests/Feature/Api/Admin/V1/Auth`
- `mise run api:phpstan -- packages/Auth packages/AdminUser app/Http/Controllers/Api/Admin/V1/Auth`
- `mise run admin:lint -- src/server/routes/auth.ts src/server/routes/auth.test.ts src/components/auth/RegisterForm.tsx`