### PR TITLE
AdminUserPasskeyをCredentialRecord由来の保存仕様に変更

### DIFF
--- a/src/server/app/Models/AdminUser/AdminUserPasskey.php
+++ b/src/server/app/Models/AdminUser/AdminUserPasskey.php
@@ -10,15 +10,21 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Override;
 
 /**
- * @property string               $admin_user_passkey_id 管理ユーザーパスキーID
- * @property string               $admin_user_id         管理ユーザーID
- * @property string               $credential_id         WebAuthn credential ID
- * @property string               $public_key            WebAuthn 公開鍵
- * @property int                  $sign_count            署名カウンタ
- * @property CarbonImmutable|null $last_used_at          最終利用日時
- * @property CarbonImmutable      $created_at            作成日時
- * @property CarbonImmutable      $updated_at            更新日時
- * @property-read AdminUser       $adminUser
+ * @property string                  $admin_user_passkey_id 管理ユーザーのパスキーID
+ * @property string                  $admin_user_id         管理ユーザーID
+ * @property string                  $user_handle           WebAuthn ユーザーハンドル
+ * @property string                  $name                  パスキー名
+ * @property string                  $credential_id         WebAuthn クレデンシャル ID
+ * @property string                  $public_key            WebAuthn 公開鍵(COSE Key)
+ * @property string                  $aaguid                認証器 AAGUID
+ * @property array<array-key, mixed> $transports            認証器のトランスポート
+ * @property bool|null               $backup_eligible       バックアップ可能か
+ * @property bool|null               $backup_state          バックアップ済みか
+ * @property int                     $sign_count            署名カウンター
+ * @property CarbonImmutable|null    $last_used_at          最終利用日時
+ * @property CarbonImmutable         $created_at            作成日時
+ * @property CarbonImmutable         $updated_at            更新日時
+ * @property-read AdminUser $adminUser
  *
  * @method static \Illuminate\Database\Eloquent\Builder<static>|AdminUserPasskey newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|AdminUserPasskey newQuery()
@@ -41,6 +47,9 @@ class AdminUserPasskey extends Model
     protected function casts()
     {
         return [
+            'transports' => 'array',
+            'backup_eligible' => 'boolean',
+            'backup_state' => 'boolean',
             'sign_count' => 'integer',
             'last_used_at' => 'immutable_datetime',
             'created_at' => 'immutable_datetime',

--- a/src/server/app/Providers/Domain/AuthServiceProvider.php
+++ b/src/server/app/Providers/Domain/AuthServiceProvider.php
@@ -11,6 +11,7 @@ use Auth\Domain\Models\PasskeyCeremonyStoreInterface;
 use Auth\Domain\Models\Token\AccessToken\AccessTokenFactoryInterface;
 use Auth\Domain\Models\Token\RefreshToken\RefreshTokenRepositoryInterface;
 use Auth\Domain\Services\PasskeyAuthenticatorInterface;
+use Auth\Domain\Services\PasskeyUserHandleGeneratorInterface;
 use Auth\Domain\Services\Token\AccessToken\JwtConfig;
 use Auth\Domain\Services\Token\AccessToken\JwtHandlerInterface;
 use Auth\Domain\Services\Token\RefreshToken\RandomTokenGeneratorInterface;
@@ -21,6 +22,7 @@ use Auth\Infrastructures\Auth\AuthUserProvider;
 use Auth\Infrastructures\Auth\UseCaseAuthorizationContext;
 use Auth\Infrastructures\PasskeyAuthenticator;
 use Auth\Infrastructures\PasskeyCeremonyStore;
+use Auth\Infrastructures\RandomPasskeyUserHandleGenerator;
 use Auth\Infrastructures\Token\AccessToken\AccessTokenFactory;
 use Auth\Infrastructures\Token\AccessToken\JwtHandler;
 use Auth\Infrastructures\Token\RefreshToken\RandomTokenGenerator;
@@ -44,6 +46,7 @@ class AuthServiceProvider extends ServiceProvider
         $this->app->bind(AuthAdminUserRepositoryInterface::class, AuthAdminUserRepository::class);
         $this->app->bind(AdminUserPasskeyRepositoryInterface::class, AdminUserPasskeyRepository::class);
         $this->app->bind(PasskeyAuthenticatorInterface::class, PasskeyAuthenticator::class);
+        $this->app->bind(PasskeyUserHandleGeneratorInterface::class, RandomPasskeyUserHandleGenerator::class);
         $this->app->bind(PasskeyCeremonyStoreInterface::class, PasskeyCeremonyStore::class);
         $this->app->bind(AuthorizationContextInterface::class, UseCaseAuthorizationContext::class);
 

--- a/src/server/database/atlas/schemas/admin-user-passkeys.my.hcl
+++ b/src/server/database/atlas/schemas/admin-user-passkeys.my.hcl
@@ -1,34 +1,62 @@
 table "admin_user_passkeys" {
   schema  = schema.db
-  comment = "管理ユーザーパスキー"
+  comment = "管理ユーザーのパスキー"
 
   column "admin_user_passkey_id" {
     null    = false
     type    = binary(16)
-    comment = "管理ユーザーパスキーID"
+    comment = "管理ユーザーのパスキーID"
   }
   column "admin_user_id" {
     null    = false
     type    = binary(16)
     comment = "管理ユーザーID"
   }
-  // credential_id は base64url 文字列として保持し、MySQL の unique index を素直に張れるよう varchar にする。
+  column "user_handle" {
+    null    = false
+    type    = varbinary(64)
+    comment = "WebAuthn ユーザーハンドル"
+  }
+  column "name" {
+    null    = false
+    type    = varchar(255)
+    comment = "パスキー名"
+  }
   column "credential_id" {
     null    = false
-    type    = varchar(512)
-    comment = "WebAuthn credential ID"
+    type    = varbinary(1023)
+    comment = "WebAuthn クレデンシャル ID"
   }
-  // 公開鍵は COSE 形式のシリアライズ結果を保持する想定。
   column "public_key" {
     null    = false
-    type    = text
-    comment = "WebAuthn 公開鍵"
+    type    = varbinary(4096)
+    comment = "WebAuthn 公開鍵(COSE Key)"
+  }
+  column "aaguid" {
+    null    = false
+    type    = char(36)
+    comment = "認証器 AAGUID"
+  }
+  column "transports" {
+    null    = false
+    type    = json
+    comment = "認証器のトランスポート"
+  }
+  column "backup_eligible" {
+    null    = true
+    type    = bool
+    comment = "バックアップ可能か"
+  }
+  column "backup_state" {
+    null    = true
+    type    = bool
+    comment = "バックアップ済みか"
   }
   column "sign_count" {
     null     = false
     type     = bigint
     unsigned = true
-    comment  = "署名カウンタ"
+    comment  = "署名カウンター"
   }
   column "last_used_at" {
     null    = true
@@ -52,6 +80,10 @@ table "admin_user_passkeys" {
 
   index "admin_user_passkeys_admin_user_id_index" {
     columns = [column.admin_user_id]
+  }
+
+  index "admin_user_passkeys_user_handle_index" {
+    columns = [column.user_handle]
   }
 
   index "admin_user_passkeys_credential_id_unique" {

--- a/src/server/packages/AdminUser/Application/Admin/UseCase/RegisterFinish/RegisterFinishUseCase.php
+++ b/src/server/packages/AdminUser/Application/Admin/UseCase/RegisterFinish/RegisterFinishUseCase.php
@@ -16,7 +16,7 @@ use Auth\Domain\Models\PasskeyCeremonyStoreInterface;
 use Auth\Domain\Models\PasskeyCeremonyType;
 use Auth\Domain\Models\Token\RefreshToken\RefreshTokenRepositoryInterface;
 use Auth\Domain\Services\PasskeyAuthenticatorInterface;
-use Auth\Domain\Services\PasskeyVerificationResult;
+use Auth\Domain\Services\PasskeyRegistrationResult;
 use Auth\Domain\Services\Token\AccessToken\AccessTokenIssueService;
 use Auth\Domain\Services\Token\RefreshToken\RefreshTokenIssueService;
 use LogicException;
@@ -87,7 +87,7 @@ readonly class RegisterFinishUseCase
     private function persist(
         PasskeyCeremonyState $state,
         string $plainToken,
-        PasskeyVerificationResult $verification,
+        PasskeyRegistrationResult $verification,
     ): Result {
         if (is_null($state->name)) {
             return new Err(new BusinessLogicError('register_ceremony_not_found'));
@@ -131,8 +131,14 @@ readonly class RegisterFinishUseCase
         $this->passkeyRepository->save(new AdminUserPasskey(
             $this->uuidGenerator->generate(),
             $adminUser->adminUserId->value,
+            $verification->userHandle,
+            $state->name,
             $verification->credentialId,
             $verification->publicKey,
+            $verification->aaguid,
+            $verification->transports,
+            $verification->backupEligible,
+            $verification->backupState,
             $verification->signCount,
             $this->clock->now(),
             null,

--- a/src/server/packages/AdminUser/Application/Admin/UseCase/RegisterStart/RegisterStartUseCase.php
+++ b/src/server/packages/AdminUser/Application/Admin/UseCase/RegisterStart/RegisterStartUseCase.php
@@ -11,6 +11,7 @@ use Auth\Domain\Models\PasskeyCeremonyState;
 use Auth\Domain\Models\PasskeyCeremonyStoreInterface;
 use Auth\Domain\Models\PasskeyCeremonyType;
 use Auth\Domain\Services\PasskeyAuthenticatorInterface;
+use Auth\Domain\Services\PasskeyUserHandleGeneratorInterface;
 use LogicException;
 use ResultType\Err;
 use ResultType\Ok;
@@ -30,6 +31,7 @@ readonly class RegisterStartUseCase
         private RegistrationTokenConsumeService $consumeService,
         private AdminUserIntegrityService $integrityService,
         private PasskeyAuthenticatorInterface $passkeyAuthenticator,
+        private PasskeyUserHandleGeneratorInterface $userHandleGenerator,
         private PasskeyCeremonyStoreInterface $ceremonyStore,
         private UuidGeneratorInterface $uuidGenerator,
     ) {
@@ -67,7 +69,7 @@ readonly class RegisterStartUseCase
         $adminUser = $adminUserResult->unwrap();
         $authCeremonyId = $this->uuidGenerator->generate();
         $startResult = $this->passkeyAuthenticator->startRegistration(
-            $adminUser->adminUserId->value,
+            $this->userHandleGenerator->generate(),
             $adminUser->email->value,
             $adminUser->name->value,
         );

--- a/src/server/packages/Auth/Application/Admin/UseCase/Login/LoginFinishUseCase.php
+++ b/src/server/packages/Auth/Application/Admin/UseCase/Login/LoginFinishUseCase.php
@@ -10,8 +10,8 @@ use Auth\Domain\Models\PasskeyCeremonyState;
 use Auth\Domain\Models\PasskeyCeremonyStoreInterface;
 use Auth\Domain\Models\PasskeyCeremonyType;
 use Auth\Domain\Models\Token\RefreshToken\RefreshTokenRepositoryInterface;
+use Auth\Domain\Services\PasskeyAuthenticationResult;
 use Auth\Domain\Services\PasskeyAuthenticatorInterface;
-use Auth\Domain\Services\PasskeyVerificationResult;
 use Auth\Domain\Services\Token\AccessToken\AccessTokenIssueService;
 use Auth\Domain\Services\Token\RefreshToken\RefreshTokenIssueService;
 use LogicException;
@@ -57,7 +57,7 @@ readonly class LoginFinishUseCase
             return new Err(new AuthenticationError());
         }
 
-        $credentialId = $this->credentialId($inputData->credential);
+        $credentialId = $this->passkeyAuthenticator->credentialId($inputData->credential);
 
         if (is_null($credentialId)) {
             return new Err(new AuthenticationError());
@@ -74,7 +74,7 @@ readonly class LoginFinishUseCase
                 $inputData->credential,
                 $state->optionsJson,
                 $passkey,
-                $state->adminUserId,
+                $passkey->userHandle,
             );
         } catch (Throwable) {
             return new Err(new AuthenticationError());
@@ -95,7 +95,7 @@ readonly class LoginFinishUseCase
     private function persist(
         PasskeyCeremonyState $state,
         AdminUserPasskey $passkey,
-        PasskeyVerificationResult $verification,
+        PasskeyAuthenticationResult $verification,
     ): Result {
         $refreshTokenResult = $this->refreshTokenIssueService->issue($state->adminUserId);
 
@@ -127,16 +127,6 @@ readonly class LoginFinishUseCase
             $refreshToken->refreshTokenId->value,
             $plainRefreshToken,
         ));
-    }
-
-    /**
-     * @param array<string, mixed> $credential
-     */
-    private function credentialId(array $credential): ?string
-    {
-        $id = $credential['id'] ?? null;
-
-        return is_string($id) && $id !== '' ? $id : null;
     }
 
     private function handleError(DomainError $error): UseCaseError

--- a/src/server/packages/Auth/Domain/Models/AdminUserPasskey.php
+++ b/src/server/packages/Auth/Domain/Models/AdminUserPasskey.php
@@ -8,11 +8,20 @@ use DateTimeImmutable;
 
 readonly class AdminUserPasskey
 {
+    /**
+     * @param list<string> $transports
+     */
     public function __construct(
         public string $adminUserPasskeyId,
         public string $adminUserId,
+        public string $userHandle,
+        public string $name,
         public string $credentialId,
         public string $publicKey,
+        public string $aaguid,
+        public array $transports,
+        public ?bool $backupEligible,
+        public ?bool $backupState,
         public int $signCount,
         public DateTimeImmutable $createdAt,
         public ?DateTimeImmutable $lastUsedAt,
@@ -24,8 +33,14 @@ readonly class AdminUserPasskey
         return new self(
             $this->adminUserPasskeyId,
             $this->adminUserId,
+            $this->userHandle,
+            $this->name,
             $this->credentialId,
             $this->publicKey,
+            $this->aaguid,
+            $this->transports,
+            $this->backupEligible,
+            $this->backupState,
             $signCount,
             $this->createdAt,
             $lastUsedAt,

--- a/src/server/packages/Auth/Domain/Models/AdminUserPasskeyRepositoryInterface.php
+++ b/src/server/packages/Auth/Domain/Models/AdminUserPasskeyRepositoryInterface.php
@@ -13,6 +13,8 @@ interface AdminUserPasskeyRepositoryInterface
 
     public function findByCredentialId(string $credentialId): ?AdminUserPasskey;
 
+    public function findByUserHandle(string $userHandle): ?AdminUserPasskey;
+
     public function save(AdminUserPasskey $passkey): AdminUserPasskey;
 
     public function update(AdminUserPasskey $passkey): AdminUserPasskey;

--- a/src/server/packages/Auth/Domain/Services/PasskeyAuthenticationResult.php
+++ b/src/server/packages/Auth/Domain/Services/PasskeyAuthenticationResult.php
@@ -4,11 +4,10 @@ declare(strict_types=1);
 
 namespace Auth\Domain\Services;
 
-readonly class PasskeyVerificationResult
+readonly class PasskeyAuthenticationResult
 {
     public function __construct(
         public string $credentialId,
-        public string $publicKey,
         public int $signCount,
     ) {
     }

--- a/src/server/packages/Auth/Domain/Services/PasskeyAuthenticatorInterface.php
+++ b/src/server/packages/Auth/Domain/Services/PasskeyAuthenticatorInterface.php
@@ -8,16 +8,20 @@ use Auth\Domain\Models\AdminUserPasskey;
 
 interface PasskeyAuthenticatorInterface
 {
+    /**
+     * @param list<AdminUserPasskey> $excludePasskeys
+     */
     public function startRegistration(
         string $userHandle,
         string $userName,
         string $displayName,
+        array $excludePasskeys = [],
     ): PasskeyStartResult;
 
     /**
      * @param array<string, mixed> $credential
      */
-    public function finishRegistration(array $credential, string $optionsJson): PasskeyVerificationResult;
+    public function finishRegistration(array $credential, string $optionsJson): PasskeyRegistrationResult;
 
     /**
      * @param list<AdminUserPasskey> $passkeys
@@ -27,10 +31,15 @@ interface PasskeyAuthenticatorInterface
     /**
      * @param array<string, mixed> $credential
      */
+    public function credentialId(array $credential): ?string;
+
+    /**
+     * @param array<string, mixed> $credential
+     */
     public function finishAuthentication(
         array $credential,
         string $optionsJson,
         AdminUserPasskey $passkey,
         string $userHandle,
-    ): PasskeyVerificationResult;
+    ): PasskeyAuthenticationResult;
 }

--- a/src/server/packages/Auth/Domain/Services/PasskeyRegistrationResult.php
+++ b/src/server/packages/Auth/Domain/Services/PasskeyRegistrationResult.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth\Domain\Services;
+
+readonly class PasskeyRegistrationResult
+{
+    /**
+     * @param list<string> $transports
+     */
+    public function __construct(
+        public string $credentialId,
+        public string $publicKey,
+        public string $userHandle,
+        public string $aaguid,
+        public array $transports,
+        public ?bool $backupEligible,
+        public ?bool $backupState,
+        public int $signCount,
+    ) {
+    }
+}

--- a/src/server/packages/Auth/Domain/Services/PasskeyUserHandleGeneratorInterface.php
+++ b/src/server/packages/Auth/Domain/Services/PasskeyUserHandleGeneratorInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth\Domain\Services;
+
+interface PasskeyUserHandleGeneratorInterface
+{
+    public function generate(): string;
+}

--- a/src/server/packages/Auth/Infrastructures/AdminUserPasskeyRepository.php
+++ b/src/server/packages/Auth/Infrastructures/AdminUserPasskeyRepository.php
@@ -38,7 +38,18 @@ readonly class AdminUserPasskeyRepository implements AdminUserPasskeyRepositoryI
             ->where('credential_id', $credentialId)
             ->first();
 
-        return $found === null ? null : $this->hydrate($found);
+        return is_null($found) ? null : $this->hydrate($found);
+    }
+
+    #[Override]
+    public function findByUserHandle(string $userHandle): ?AdminUserPasskey
+    {
+        $found = Model::query()
+            ->where('user_handle', $userHandle)
+            ->orderBy('created_at')
+            ->first();
+
+        return is_null($found) ? null : $this->hydrate($found);
     }
 
     #[Override]
@@ -68,8 +79,14 @@ readonly class AdminUserPasskeyRepository implements AdminUserPasskeyRepositoryI
         return new AdminUserPasskey(
             $this->converter->toUuid($model->admin_user_passkey_id),
             $this->converter->toUuid($model->admin_user_id),
+            $model->user_handle,
+            $model->name,
             $model->credential_id,
             $model->public_key,
+            $model->aaguid,
+            $this->transports($model->transports),
+            $model->backup_eligible,
+            $model->backup_state,
             $model->sign_count,
             $model->created_at->toDateTimeImmutable(),
             $model->last_used_at?->toDateTimeImmutable(),
@@ -80,8 +97,14 @@ readonly class AdminUserPasskeyRepository implements AdminUserPasskeyRepositoryI
      * @return array{
      *   admin_user_passkey_id: string,
      *   admin_user_id: string,
+     *   user_handle: string,
+     *   name: string,
      *   credential_id: string,
      *   public_key: string,
+     *   aaguid: string,
+     *   transports: string,
+     *   backup_eligible: bool|null,
+     *   backup_state: bool|null,
      *   sign_count: int,
      *   last_used_at: string|null,
      *   created_at: string,
@@ -93,12 +116,31 @@ readonly class AdminUserPasskeyRepository implements AdminUserPasskeyRepositoryI
         return [
             'admin_user_passkey_id' => $this->converter->toBin($passkey->adminUserPasskeyId),
             'admin_user_id' => $this->converter->toBin($passkey->adminUserId),
+            'user_handle' => $passkey->userHandle,
+            'name' => $passkey->name,
             'credential_id' => $passkey->credentialId,
             'public_key' => $passkey->publicKey,
+            'aaguid' => $passkey->aaguid,
+            'transports' => json_encode($passkey->transports, JSON_THROW_ON_ERROR),
+            'backup_eligible' => $passkey->backupEligible,
+            'backup_state' => $passkey->backupState,
             'sign_count' => $passkey->signCount,
             'last_used_at' => $passkey->lastUsedAt?->format('Y-m-d H:i:s'),
             'created_at' => $passkey->createdAt->format('Y-m-d H:i:s'),
             'updated_at' => now(),
         ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function transports(mixed $transports): array
+    {
+        if (! is_array($transports)) {
+            return [];
+        }
+
+        return array_filter($transports, fn (mixed $transport): bool => is_string($transport))
+            |> array_values(...);
     }
 }

--- a/src/server/packages/Auth/Infrastructures/PasskeyAuthenticator.php
+++ b/src/server/packages/Auth/Infrastructures/PasskeyAuthenticator.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace Auth\Infrastructures;
 
 use Auth\Domain\Models\AdminUserPasskey;
+use Auth\Domain\Services\PasskeyAuthenticationResult;
 use Auth\Domain\Services\PasskeyAuthenticatorInterface;
+use Auth\Domain\Services\PasskeyRegistrationResult;
 use Auth\Domain\Services\PasskeyStartResult;
-use Auth\Domain\Services\PasskeyVerificationResult;
 use Cose\Algorithms;
 use InvalidArgumentException;
 use Override;
@@ -16,6 +17,7 @@ use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\Serializer;
+use Throwable;
 use Webauthn\AttestationStatement\AttestationStatementSupportManager;
 use Webauthn\AuthenticatorAssertionResponse;
 use Webauthn\AuthenticatorAssertionResponseValidator;
@@ -34,25 +36,29 @@ use Webauthn\PublicKeyCredentialUserEntity;
 
 readonly class PasskeyAuthenticator implements PasskeyAuthenticatorInterface
 {
-    /**
-     * @var Serializer&NormalizerInterface&DenormalizerInterface
-     */
-    private Serializer $serializer;
+    private DenormalizerInterface&NormalizerInterface&Serializer $serializer;
 
-    public function __construct(
-        private PasskeyCredentialRecordConverter $credentialRecordConverter,
-    ) {
+    public function __construct(private PasskeyCredentialRecordConverter $credentialRecordConverter)
+    {
         $serializer = new WebauthnSerializerFactory(AttestationStatementSupportManager::create())->create();
         assert($serializer instanceof Serializer);
         $this->serializer = $serializer;
     }
 
+    /**
+     * @param list<AdminUserPasskey> $excludePasskeys
+     */
     #[Override]
     public function startRegistration(
         string $userHandle,
         string $userName,
         string $displayName,
+        array $excludePasskeys = [],
     ): PasskeyStartResult {
+        $excludeCredentials = array_map(
+            fn (AdminUserPasskey $passkey): PublicKeyCredentialDescriptor => $this->toDescriptor($passkey),
+            $excludePasskeys,
+        );
         $timeout = config('auth.passkey.timeout_ms');
 
         $options = PublicKeyCredentialCreationOptions::create(
@@ -68,10 +74,10 @@ readonly class PasskeyAuthenticator implements PasskeyAuthenticatorInterface
             ],
             AuthenticatorSelectionCriteria::create(
                 userVerification: AuthenticatorSelectionCriteria::USER_VERIFICATION_REQUIREMENT_REQUIRED,
-                residentKey: AuthenticatorSelectionCriteria::RESIDENT_KEY_REQUIREMENT_PREFERRED,
+                residentKey: AuthenticatorSelectionCriteria::RESIDENT_KEY_REQUIREMENT_REQUIRED,
             ),
             PublicKeyCredentialCreationOptions::ATTESTATION_CONVEYANCE_PREFERENCE_NONE,
-            [],
+            $excludeCredentials,
             is_int($timeout) && $timeout > 0 ? $timeout : 60000,
         );
 
@@ -88,7 +94,7 @@ readonly class PasskeyAuthenticator implements PasskeyAuthenticatorInterface
      * @param array<string, mixed> $credential
      */
     #[Override]
-    public function finishRegistration(array $credential, string $optionsJson): PasskeyVerificationResult
+    public function finishRegistration(array $credential, string $optionsJson): PasskeyRegistrationResult
     {
         $publicKeyCredential = $this->deserializeCredential($credential);
         $response = $publicKeyCredential->response;
@@ -110,9 +116,18 @@ readonly class PasskeyAuthenticator implements PasskeyAuthenticatorInterface
         $credentialRecord = AuthenticatorAttestationResponseValidator::create($factory->creationCeremony())
             ->check($response, $options, $this->host());
 
-        return new PasskeyVerificationResult(
-            Base64UrlSafe::encodeUnpadded($publicKeyCredential->rawId),
-            Base64UrlSafe::encodeUnpadded($credentialRecord->credentialPublicKey),
+        if (! hash_equals($publicKeyCredential->rawId, $credentialRecord->publicKeyCredentialId)) {
+            throw new InvalidArgumentException('Credential ID が一致しません');
+        }
+
+        return new PasskeyRegistrationResult(
+            $credentialRecord->publicKeyCredentialId,
+            $credentialRecord->credentialPublicKey,
+            $credentialRecord->userHandle,
+            $credentialRecord->aaguid->toRfc4122(),
+            array_values($credentialRecord->transports),
+            $credentialRecord->backupEligible,
+            $credentialRecord->backupStatus,
             $credentialRecord->counter,
         );
     }
@@ -123,13 +138,7 @@ readonly class PasskeyAuthenticator implements PasskeyAuthenticatorInterface
     #[Override]
     public function startAuthentication(array $passkeys): PasskeyStartResult
     {
-        $descriptors = array_map(
-            fn (AdminUserPasskey $passkey) => PublicKeyCredentialDescriptor::create(
-                PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
-                Base64UrlSafe::decodeNoPadding($passkey->credentialId),
-            ),
-            $passkeys,
-        );
+        $descriptors = array_map($this->toDescriptor(...), $passkeys);
 
         $timeout = config('auth.passkey.timeout_ms');
 
@@ -154,12 +163,37 @@ readonly class PasskeyAuthenticator implements PasskeyAuthenticatorInterface
      * @param array<string, mixed> $credential
      */
     #[Override]
+    public function credentialId(array $credential): ?string
+    {
+        $rawId = $credential['rawId'] ?? null;
+
+        if (is_string($rawId) && $rawId !== '') {
+            try {
+                return Base64UrlSafe::decodeNoPadding($rawId);
+            } catch (Throwable) {
+                return null;
+            }
+        }
+
+        $id = $credential['id'] ?? null;
+
+        if (! is_string($id) || $id === '') {
+            return null;
+        }
+
+        return $id;
+    }
+
+    /**
+     * @param array<string, mixed> $credential
+     */
+    #[Override]
     public function finishAuthentication(
         array $credential,
         string $optionsJson,
         AdminUserPasskey $passkey,
         string $userHandle,
-    ): PasskeyVerificationResult {
+    ): PasskeyAuthenticationResult {
         $publicKeyCredential = $this->deserializeCredential($credential);
         $response = $publicKeyCredential->response;
 
@@ -186,9 +220,8 @@ readonly class PasskeyAuthenticator implements PasskeyAuthenticatorInterface
                 $userHandle,
             );
 
-        return new PasskeyVerificationResult(
-            Base64UrlSafe::encodeUnpadded($publicKeyCredential->rawId),
-            $passkey->publicKey,
+        return new PasskeyAuthenticationResult(
+            $publicKeyCredential->rawId,
             $credentialRecord->counter,
         );
     }
@@ -203,6 +236,15 @@ readonly class PasskeyAuthenticator implements PasskeyAuthenticatorInterface
             $credential,
             PublicKeyCredential::class,
             JsonEncoder::FORMAT,
+        );
+    }
+
+    private function toDescriptor(AdminUserPasskey $passkey): PublicKeyCredentialDescriptor
+    {
+        return PublicKeyCredentialDescriptor::create(
+            PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
+            $passkey->credentialId,
+            $passkey->transports,
         );
     }
 

--- a/src/server/packages/Auth/Infrastructures/PasskeyCredentialRecordConverter.php
+++ b/src/server/packages/Auth/Infrastructures/PasskeyCredentialRecordConverter.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Auth\Infrastructures;
 
 use Auth\Domain\Models\AdminUserPasskey;
-use ParagonIE\ConstantTime\Base64UrlSafe;
 use Symfony\Component\Uid\Uuid;
 use Webauthn\CredentialRecord;
 use Webauthn\PublicKeyCredentialDescriptor;
@@ -16,15 +15,17 @@ readonly class PasskeyCredentialRecordConverter
     public function toCredentialRecord(AdminUserPasskey $passkey): CredentialRecord
     {
         return CredentialRecord::create(
-            Base64UrlSafe::decodeNoPadding($passkey->credentialId),
+            $passkey->credentialId,
             PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
-            [],
+            $passkey->transports,
             'none',
             EmptyTrustPath::create(),
-            Uuid::v4(),
-            Base64UrlSafe::decodeNoPadding($passkey->publicKey),
-            $passkey->adminUserId,
+            Uuid::fromString($passkey->aaguid),
+            $passkey->publicKey,
+            $passkey->userHandle,
             $passkey->signCount,
+            backupEligible: $passkey->backupEligible,
+            backupStatus: $passkey->backupState,
         );
     }
 }

--- a/src/server/packages/Auth/Infrastructures/RandomPasskeyUserHandleGenerator.php
+++ b/src/server/packages/Auth/Infrastructures/RandomPasskeyUserHandleGenerator.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth\Infrastructures;
+
+use Auth\Domain\Services\PasskeyUserHandleGeneratorInterface;
+use Override;
+
+readonly class RandomPasskeyUserHandleGenerator implements PasskeyUserHandleGeneratorInterface
+{
+    private const int LENGTH = 64;
+
+    #[Override]
+    public function generate(): string
+    {
+        return random_bytes(self::LENGTH);
+    }
+}

--- a/src/server/tests/Feature/Api/Admin/V1/Auth/LoginTest.php
+++ b/src/server/tests/Feature/Api/Admin/V1/Auth/LoginTest.php
@@ -11,9 +11,10 @@ use Auth\Domain\Models\AdminUserPasskeyRepositoryInterface;
 use Auth\Domain\Models\PasskeyCeremonyState;
 use Auth\Domain\Models\PasskeyCeremonyStoreInterface;
 use Auth\Domain\Models\PasskeyCeremonyType;
+use Auth\Domain\Services\PasskeyAuthenticationResult;
 use Auth\Domain\Services\PasskeyAuthenticatorInterface;
+use Auth\Domain\Services\PasskeyRegistrationResult;
 use Auth\Domain\Services\PasskeyStartResult;
-use Auth\Domain\Services\PasskeyVerificationResult;
 use Auth\Route\AuthRouteMap;
 use Carbon\CarbonImmutable;
 use DateTimeImmutable;
@@ -56,6 +57,7 @@ class LoginTest extends DatabaseTestCase
                 fn (AssertableJson $json) => $json->whereType('authCeremonyId', 'string')
                     ->where('publicKey.challenge', 'login-challenge')
                     ->where('publicKey.allowCredentials.0.id', 'credential-id')
+                    ->where('publicKey.allowCredentials.0.transports', ['internal'])
                     ->etc(),
             );
 
@@ -227,8 +229,14 @@ class LoginTest extends DatabaseTestCase
         $this->app->make(AdminUserPasskeyRepositoryInterface::class)->save(new AdminUserPasskey(
             $this->generateUuid(),
             $adminUserId,
+            'user-handle-' . $credentialId,
+            'Primary passkey',
             $credentialId,
             'public-key',
+            '00000000-0000-0000-0000-000000000000',
+            ['internal'],
+            true,
+            false,
             123,
             new DateTimeImmutable('2026-01-01 00:00:00'),
             null,
@@ -260,12 +268,12 @@ class LoginTest extends DatabaseTestCase
             {
             }
 
-            public function startRegistration(string $userHandle, string $userName, string $displayName): PasskeyStartResult
+            public function startRegistration(string $userHandle, string $userName, string $displayName, array $excludePasskeys = []): PasskeyStartResult
             {
                 throw new RuntimeException('unused');
             }
 
-            public function finishRegistration(array $credential, string $optionsJson): PasskeyVerificationResult
+            public function finishRegistration(array $credential, string $optionsJson): PasskeyRegistrationResult
             {
                 throw new RuntimeException('unused');
             }
@@ -276,19 +284,26 @@ class LoginTest extends DatabaseTestCase
                 return new PasskeyStartResult('{"challenge":"login-challenge"}', [
                     'challenge' => 'login-challenge',
                     'allowCredentials' => array_map(
-                        fn (AdminUserPasskey $passkey): array => ['type' => 'public-key', 'id' => $passkey->credentialId],
+                        fn (AdminUserPasskey $passkey): array => ['type' => 'public-key', 'id' => $passkey->credentialId, 'transports' => $passkey->transports],
                         $passkeys,
                     ),
                 ]);
             }
 
-            public function finishAuthentication(array $credential, string $optionsJson, AdminUserPasskey $passkey, string $userHandle): PasskeyVerificationResult
+            public function credentialId(array $credential): ?string
+            {
+                $id = $credential['id'] ?? null;
+
+                return is_string($id) && $id !== '' ? $id : null;
+            }
+
+            public function finishAuthentication(array $credential, string $optionsJson, AdminUserPasskey $passkey, string $userHandle): PasskeyAuthenticationResult
             {
                 if ($this->failFinish) {
                     throw new RuntimeException('verification failed');
                 }
 
-                return new PasskeyVerificationResult($passkey->credentialId, $passkey->publicKey, 456);
+                return new PasskeyAuthenticationResult($passkey->credentialId, 456);
             }
         });
     }

--- a/src/server/tests/Feature/Api/Admin/V1/Auth/RegisterFinishTest.php
+++ b/src/server/tests/Feature/Api/Admin/V1/Auth/RegisterFinishTest.php
@@ -19,9 +19,10 @@ use App\Models\AdminUser\AdminUserPasskey as ModelsAdminUserPasskey;
 use App\Models\AdminUser\RegistrationToken as ModelsRegistrationToken;
 use App\Models\Auth\RefreshToken as AuthRefreshToken;
 use Auth\Domain\Models\AdminUserPasskey;
+use Auth\Domain\Services\PasskeyAuthenticationResult;
 use Auth\Domain\Services\PasskeyAuthenticatorInterface;
+use Auth\Domain\Services\PasskeyRegistrationResult;
 use Auth\Domain\Services\PasskeyStartResult;
-use Auth\Domain\Services\PasskeyVerificationResult;
 use Auth\Route\AuthRouteMap;
 use DateTimeImmutable;
 use Illuminate\Testing\Fluent\AssertableJson;
@@ -76,7 +77,14 @@ class RegisterFinishTest extends DatabaseTestCase
         $this->assertSame('新規ユーザー', $userRow->name);
         $this->assertArrayNotHasKey('password', $userRow->getAttributes());
 
-        $this->assertSame(1, ModelsAdminUserPasskey::query()->count());
+        $passkeyRow = ModelsAdminUserPasskey::query()->first();
+        $this->assertNotNull($passkeyRow);
+        $this->assertSame('credential-id', $passkeyRow->credential_id);
+        $this->assertSame('user-handle', $passkeyRow->user_handle);
+        $this->assertSame('00000000-0000-0000-0000-000000000000', $passkeyRow->aaguid);
+        $this->assertSame(['internal'], $passkeyRow->transports);
+        $this->assertTrue($passkeyRow->backup_eligible);
+        $this->assertFalse($passkeyRow->backup_state);
         $this->assertSame(1, AuthRefreshToken::query()->count());
     }
 
@@ -123,18 +131,18 @@ class RegisterFinishTest extends DatabaseTestCase
             {
             }
 
-            public function startRegistration(string $userHandle, string $userName, string $displayName): PasskeyStartResult
+            public function startRegistration(string $userHandle, string $userName, string $displayName, array $excludePasskeys = []): PasskeyStartResult
             {
                 return new PasskeyStartResult('{"challenge":"challenge"}', ['challenge' => 'challenge']);
             }
 
-            public function finishRegistration(array $credential, string $optionsJson): PasskeyVerificationResult
+            public function finishRegistration(array $credential, string $optionsJson): PasskeyRegistrationResult
             {
                 if ($this->failFinish) {
                     throw new RuntimeException('verification failed');
                 }
 
-                return new PasskeyVerificationResult('credential-id', 'public-key', 123);
+                return new PasskeyRegistrationResult('credential-id', 'public-key', 'user-handle', '00000000-0000-0000-0000-000000000000', ['internal'], true, false, 123);
             }
 
             public function startAuthentication(array $passkeys): PasskeyStartResult
@@ -142,7 +150,12 @@ class RegisterFinishTest extends DatabaseTestCase
                 throw new RuntimeException('unused');
             }
 
-            public function finishAuthentication(array $credential, string $optionsJson, AdminUserPasskey $passkey, string $userHandle): PasskeyVerificationResult
+            public function credentialId(array $credential): ?string
+            {
+                throw new RuntimeException('unused');
+            }
+
+            public function finishAuthentication(array $credential, string $optionsJson, AdminUserPasskey $passkey, string $userHandle): PasskeyAuthenticationResult
             {
                 throw new RuntimeException('unused');
             }

--- a/src/server/tests/Feature/Api/Admin/V1/Auth/RegisterStartTest.php
+++ b/src/server/tests/Feature/Api/Admin/V1/Auth/RegisterStartTest.php
@@ -18,9 +18,10 @@ use AdminUser\Infrastructures\AdminUserRepository;
 use App\Models\AdminUser\AdminUser as ModelsAdminUser;
 use App\Models\AdminUser\RegistrationToken as ModelsRegistrationToken;
 use Auth\Domain\Models\AdminUserPasskey;
+use Auth\Domain\Services\PasskeyAuthenticationResult;
 use Auth\Domain\Services\PasskeyAuthenticatorInterface;
+use Auth\Domain\Services\PasskeyRegistrationResult;
 use Auth\Domain\Services\PasskeyStartResult;
-use Auth\Domain\Services\PasskeyVerificationResult;
 use Auth\Route\AuthRouteMap;
 use DateTimeImmutable;
 use Illuminate\Testing\Fluent\AssertableJson;
@@ -115,12 +116,12 @@ class RegisterStartTest extends DatabaseTestCase
     private function bindPasskeyAuthenticator(): void
     {
         $this->app->bind(PasskeyAuthenticatorInterface::class, fn (): PasskeyAuthenticatorInterface => new class () implements PasskeyAuthenticatorInterface {
-            public function startRegistration(string $userHandle, string $userName, string $displayName): PasskeyStartResult
+            public function startRegistration(string $userHandle, string $userName, string $displayName, array $excludePasskeys = []): PasskeyStartResult
             {
                 return new PasskeyStartResult('{"challenge":"challenge"}', ['challenge' => 'challenge']);
             }
 
-            public function finishRegistration(array $credential, string $optionsJson): PasskeyVerificationResult
+            public function finishRegistration(array $credential, string $optionsJson): PasskeyRegistrationResult
             {
                 throw new RuntimeException('unused');
             }
@@ -130,7 +131,12 @@ class RegisterStartTest extends DatabaseTestCase
                 throw new RuntimeException('unused');
             }
 
-            public function finishAuthentication(array $credential, string $optionsJson, AdminUserPasskey $passkey, string $userHandle): PasskeyVerificationResult
+            public function credentialId(array $credential): ?string
+            {
+                throw new RuntimeException('unused');
+            }
+
+            public function finishAuthentication(array $credential, string $optionsJson, AdminUserPasskey $passkey, string $userHandle): PasskeyAuthenticationResult
             {
                 throw new RuntimeException('unused');
             }

--- a/src/server/tests/Integration/Auth/Infrastructures/AdminUserPasskeyRepositoryTest.php
+++ b/src/server/tests/Integration/Auth/Infrastructures/AdminUserPasskeyRepositoryTest.php
@@ -29,8 +29,14 @@ class AdminUserPasskeyRepositoryTest extends DatabaseTestCase
         $passkey = new AdminUserPasskey(
             $this->generateUuid(),
             $adminUserId,
+            'user-handle',
+            'Primary passkey',
             'credential-id',
             'public-key',
+            '00000000-0000-0000-0000-000000000000',
+            ['internal', 'hybrid'],
+            true,
+            false,
             1,
             new DateTimeImmutable('2026-01-01 00:00:00'),
             null,
@@ -39,6 +45,7 @@ class AdminUserPasskeyRepositoryTest extends DatabaseTestCase
         $repository->save($passkey);
 
         $this->assertEquals($passkey, $repository->findByCredentialId('credential-id'));
+        $this->assertEquals($passkey, $repository->findByUserHandle('user-handle'));
         $this->assertEquals([$passkey], $repository->findByAdminUserId($adminUserId));
 
         $updated = $passkey->withCounter(2, new DateTimeImmutable('2026-01-02 00:00:00'));

--- a/src/server/tests/Unit/AdminUser/Application/Admin/UseCase/RegisterFinish/RegisterFinishUseCaseTest.php
+++ b/src/server/tests/Unit/AdminUser/Application/Admin/UseCase/RegisterFinish/RegisterFinishUseCaseTest.php
@@ -27,7 +27,7 @@ use Auth\Domain\Models\PasskeyCeremonyType;
 use Auth\Domain\Models\Token\RefreshToken\ConsumptionStatus as RefreshConsumptionStatus;
 use Auth\Domain\Models\Token\RefreshToken\RefreshTokenRepositoryInterface;
 use Auth\Domain\Services\PasskeyAuthenticatorInterface;
-use Auth\Domain\Services\PasskeyVerificationResult;
+use Auth\Domain\Services\PasskeyRegistrationResult;
 use Auth\Domain\Services\Token\AccessToken\AccessTokenIssueService;
 use Auth\Domain\Services\Token\RefreshToken\RefreshTokenIssueService;
 use Closure;
@@ -105,7 +105,7 @@ class RegisterFinishUseCaseTest extends TestCase
         $refreshTokenId = 'DDDDDDDD-DDDD-DDDD-DDDD-DDDDDDDDDDDD';
         $now = new DateTimeImmutable('2026-01-01 00:00:00');
         $state = new PasskeyCeremonyState('EEEEEEEE-EEEE-EEEE-EEEE-EEEEEEEEEEEE', PasskeyCeremonyType::Register, 'invitee@example.com', '名前', $adminUserId, '{"challenge":"challenge"}');
-        $verification = new PasskeyVerificationResult('credential-id', 'public-key', 123);
+        $verification = new PasskeyRegistrationResult('credential-id', 'public-key', 'user-handle', '00000000-0000-0000-0000-000000000000', ['internal'], true, false, 123);
         $token = $this->buildToken('invitee@example.com');
         $adminUser = $this->createAdminUser($adminUserId, 'invitee@example.com', name: '名前');
         $refreshToken = $this->createRefreshToken($refreshTokenId, $adminUserId, 'hashed-refresh', new DateTimeImmutable('+7 days'), RefreshConsumptionStatus::Unused);
@@ -138,7 +138,12 @@ class RegisterFinishUseCaseTest extends TestCase
         $this->passkeyRepository->shouldReceive('save')
             ->withArgs(fn (AdminUserPasskey $passkey): bool => $passkey->adminUserPasskeyId === $passkeyId
                 && $passkey->adminUserId === $adminUserId
-                && $passkey->credentialId === 'credential-id')
+                && $passkey->userHandle === 'user-handle'
+                && $passkey->credentialId === 'credential-id'
+                && $passkey->aaguid === '00000000-0000-0000-0000-000000000000'
+                && $passkey->transports === ['internal']
+                && $passkey->backupEligible === true
+                && $passkey->backupState === false)
             ->andReturnUsing(fn (AdminUserPasskey $passkey): AdminUserPasskey => $passkey)
             ->once();
         $this->registrationTokenRepository->shouldReceive('save')->andReturn($token->consume())->once();
@@ -178,7 +183,7 @@ class RegisterFinishUseCaseTest extends TestCase
     {
         $adminUserId = 'BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB';
         $state = new PasskeyCeremonyState('EEEEEEEE-EEEE-EEEE-EEEE-EEEEEEEEEEEE', PasskeyCeremonyType::Register, 'invitee@example.com', '名前', $adminUserId, '{"challenge":"challenge"}');
-        $verification = new PasskeyVerificationResult('credential-id', 'public-key', 123);
+        $verification = new PasskeyRegistrationResult('credential-id', 'public-key', 'user-handle', '00000000-0000-0000-0000-000000000000', [], null, null, 123);
         $token = $this->buildToken('invitee@example.com');
         $adminUser = $this->createAdminUser($adminUserId, 'invitee@example.com', name: '名前');
 

--- a/src/server/tests/Unit/AdminUser/Application/Admin/UseCase/RegisterStart/RegisterStartUseCaseTest.php
+++ b/src/server/tests/Unit/AdminUser/Application/Admin/UseCase/RegisterStart/RegisterStartUseCaseTest.php
@@ -21,6 +21,7 @@ use Auth\Domain\Models\PasskeyCeremonyStoreInterface;
 use Auth\Domain\Models\PasskeyCeremonyType;
 use Auth\Domain\Services\PasskeyAuthenticatorInterface;
 use Auth\Domain\Services\PasskeyStartResult;
+use Auth\Domain\Services\PasskeyUserHandleGeneratorInterface;
 use DateTimeImmutable;
 use Mockery;
 use Mockery\MockInterface;
@@ -44,6 +45,8 @@ class RegisterStartUseCaseTest extends TestCase
 
     private MockInterface&PasskeyAuthenticatorInterface $passkeyAuthenticator;
 
+    private MockInterface&PasskeyUserHandleGeneratorInterface $userHandleGenerator;
+
     private MockInterface&PasskeyCeremonyStoreInterface $ceremonyStore;
 
     private MockInterface&UuidGeneratorInterface $uuidGenerator;
@@ -56,6 +59,7 @@ class RegisterStartUseCaseTest extends TestCase
         $this->consumeService = Mockery::mock(RegistrationTokenConsumeService::class);
         $this->integrityService = Mockery::mock(AdminUserIntegrityService::class);
         $this->passkeyAuthenticator = Mockery::mock(PasskeyAuthenticatorInterface::class);
+        $this->userHandleGenerator = Mockery::mock(PasskeyUserHandleGeneratorInterface::class);
         $this->ceremonyStore = Mockery::mock(PasskeyCeremonyStoreInterface::class);
         $this->uuidGenerator = Mockery::mock(UuidGeneratorInterface::class);
     }
@@ -83,8 +87,14 @@ class RegisterStartUseCaseTest extends TestCase
             ->andReturn($authCeremonyId)
             ->once();
 
+        $this->userHandleGenerator->shouldReceive('generate')
+            ->andReturn('fixed-user-handle')
+            ->once();
+
         $this->passkeyAuthenticator->shouldReceive('startRegistration')
-            ->with($adminUserId, 'invitee@example.com', '名前')
+            ->withArgs(fn (string $userHandle, string $userName, string $displayName): bool => $userHandle === 'fixed-user-handle'
+                && $userName === 'invitee@example.com'
+                && $displayName === '名前')
             ->andReturn(new PasskeyStartResult('{"challenge":"challenge"}', ['challenge' => 'challenge']))
             ->once();
 
@@ -137,6 +147,7 @@ class RegisterStartUseCaseTest extends TestCase
             $this->consumeService,
             $this->integrityService,
             $this->passkeyAuthenticator,
+            $this->userHandleGenerator,
             $this->ceremonyStore,
             $this->uuidGenerator,
         );


### PR DESCRIPTION
## 概要

パスキー登録時に WebAuthn ライブラリが検証した CredentialRecord 由来の値を保存するように変更します。
credential ID を raw bytes 保存に寄せ、今後の複数パスキー管理に必要な userHandle / aaguid / transports / backup state を保持します。

## やったこと

- admin_user_passkeys に user_handle / name / aaguid / transports / backup_eligible / backup_state を追加し、credential_id / public_key を raw bytes 保存へ変更
- AdminUserPasskey domain / Eloquent / repository を新しい保存仕様へ対応
- passkey 登録結果と認証結果を別 DTO に分割し、登録時は CredentialRecord 由来の値を保存
- 登録 start の userHandle をランダム 64 bytes に変更し、residentKey を REQUIRED に変更
- allowCredentials / exclude credentials に transports を渡すように変更
- CredentialRecord converter が保存済み aaguid / userHandle / transports / backup state を使うように変更
- repository / auth feature / register use case unit test を更新

## やってないこと

- 既存データの base64url credential_id から raw bytes への本番データ移行手順の追加
- Login finish の競合安全な counter 更新対応

## 関連

- docs/exec-plans/active/20260524-passkey-improvements-pr-plan.md の PR 4