### PR TITLE
パスキーログイン完了処理を競合安全にする

### DIFF
--- a/src/server/packages/Auth/Application/Admin/UseCase/Login/LoginFinishUseCase.php
+++ b/src/server/packages/Auth/Application/Admin/UseCase/Login/LoginFinishUseCase.php
@@ -63,15 +63,30 @@ readonly class LoginFinishUseCase
             return new Err(new AuthenticationError());
         }
 
-        $passkey = $this->passkeyRepository->findByCredentialId($credentialId);
+        return $this->transaction->scope(
+            fn (): Result => $this->authenticateAndPersist($state, $credentialId, $inputData->credential),
+        );
+    }
 
-        if (is_null($passkey) || $passkey->adminUserId !== $state->adminUserId) {
+    /**
+     * @param array<string, mixed> $credential
+     *
+     * @return Result<LoginFinishOutputData, UseCaseError>
+     */
+    private function authenticateAndPersist(
+        PasskeyCeremonyState $state,
+        string $credentialId,
+        array $credential,
+    ): Result {
+        $passkey = $this->passkeyRepository->findByAdminUserIdAndCredentialIdForUpdate($state->adminUserId, $credentialId);
+
+        if (is_null($passkey)) {
             return new Err(new AuthenticationError());
         }
 
         try {
             $verification = $this->passkeyAuthenticator->finishAuthentication(
-                $inputData->credential,
+                $credential,
                 $state->optionsJson,
                 $passkey,
                 $passkey->userHandle,
@@ -84,9 +99,7 @@ readonly class LoginFinishUseCase
             return new Err(new AuthenticationError());
         }
 
-        return $this->transaction->scope(
-            fn (): Result => $this->persist($state, $passkey, $verification),
-        );
+        return $this->persist($state, $passkey, $verification);
     }
 
     /**
@@ -105,7 +118,11 @@ readonly class LoginFinishUseCase
 
         ['token' => $refreshToken, 'plainToken' => $plainRefreshToken] = $refreshTokenResult->unwrap();
 
-        $this->passkeyRepository->update($passkey->withCounter($verification->signCount, $this->clock->now()));
+        $updatedPasskey = $passkey->withCounter($verification->signCount, $this->clock->now());
+
+        if (! $this->passkeyRepository->updateCounter($updatedPasskey, $passkey->signCount)) {
+            return new Err(new AuthenticationError());
+        }
 
         $accessToken = $this->accessTokenIssueService->issue($refreshToken->refreshTokenId->value);
 

--- a/src/server/packages/Auth/Domain/Models/AdminUserPasskeyRepositoryInterface.php
+++ b/src/server/packages/Auth/Domain/Models/AdminUserPasskeyRepositoryInterface.php
@@ -15,7 +15,11 @@ interface AdminUserPasskeyRepositoryInterface
 
     public function findByUserHandle(string $userHandle): ?AdminUserPasskey;
 
+    public function findByAdminUserIdAndCredentialIdForUpdate(string $adminUserId, string $credentialId): ?AdminUserPasskey;
+
     public function save(AdminUserPasskey $passkey): AdminUserPasskey;
 
     public function update(AdminUserPasskey $passkey): AdminUserPasskey;
+
+    public function updateCounter(AdminUserPasskey $passkey, int $expectedSignCount): bool;
 }

--- a/src/server/packages/Auth/Infrastructures/AdminUserPasskeyRepository.php
+++ b/src/server/packages/Auth/Infrastructures/AdminUserPasskeyRepository.php
@@ -53,6 +53,18 @@ readonly class AdminUserPasskeyRepository implements AdminUserPasskeyRepositoryI
     }
 
     #[Override]
+    public function findByAdminUserIdAndCredentialIdForUpdate(string $adminUserId, string $credentialId): ?AdminUserPasskey
+    {
+        $found = Model::query()
+            ->where('admin_user_id', $this->converter->toBin($adminUserId))
+            ->where('credential_id', $credentialId)
+            ->lockForUpdate()
+            ->first();
+
+        return is_null($found) ? null : $this->hydrate($found);
+    }
+
+    #[Override]
     public function save(AdminUserPasskey $passkey): AdminUserPasskey
     {
         Model::query()->insert($this->toPersistence($passkey));
@@ -72,6 +84,19 @@ readonly class AdminUserPasskeyRepository implements AdminUserPasskeyRepositoryI
             ]);
 
         return $passkey;
+    }
+
+    #[Override]
+    public function updateCounter(AdminUserPasskey $passkey, int $expectedSignCount): bool
+    {
+        return Model::query()
+            ->where('admin_user_passkey_id', $this->converter->toBin($passkey->adminUserPasskeyId))
+            ->where('sign_count', $expectedSignCount)
+            ->update([
+                'sign_count' => $passkey->signCount,
+                'last_used_at' => $passkey->lastUsedAt?->format('Y-m-d H:i:s'),
+                'updated_at' => now(),
+            ]) === 1;
     }
 
     private function hydrate(Model $model): AdminUserPasskey

--- a/src/server/tests/Integration/Auth/Infrastructures/AdminUserPasskeyRepositoryTest.php
+++ b/src/server/tests/Integration/Auth/Infrastructures/AdminUserPasskeyRepositoryTest.php
@@ -9,6 +9,7 @@ use AdminUser\Infrastructures\AdminUserRepository;
 use Auth\Domain\Models\AdminUserPasskey;
 use Auth\Infrastructures\AdminUserPasskeyRepository;
 use DateTimeImmutable;
+use Illuminate\Support\Facades\DB;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\Support\DatabaseTestCase;
 use Tests\Support\Domain\EntityFactory;
@@ -55,5 +56,117 @@ class AdminUserPasskeyRepositoryTest extends DatabaseTestCase
         $this->assertNotNull($found);
         $this->assertSame(2, $found->signCount);
         $this->assertEquals(new DateTimeImmutable('2026-01-02 00:00:00'), $found->lastUsedAt);
+    }
+
+    #[Test]
+    public function findByAdminUserIdAndCredentialIdForUpdate(): void
+    {
+        $adminUserId = $this->generateUuid();
+        $otherAdminUserId = $this->generateUuid();
+        $this->app->make(AdminUserRepository::class)->register(
+            $this->createAdminUser($adminUserId, 'user@example.com', Role::General),
+        );
+        $this->app->make(AdminUserRepository::class)->register(
+            $this->createAdminUser($otherAdminUserId, 'other@example.com', Role::General),
+        );
+
+        $repository = $this->app->make(AdminUserPasskeyRepository::class);
+        $passkey = new AdminUserPasskey(
+            $this->generateUuid(),
+            $adminUserId,
+            'user-handle',
+            'Primary passkey',
+            'credential-id',
+            'public-key',
+            '00000000-0000-0000-0000-000000000000',
+            ['internal'],
+            true,
+            false,
+            1,
+            new DateTimeImmutable('2026-01-01 00:00:00'),
+            null,
+        );
+
+        $repository->save($passkey);
+
+        $this->assertEquals($passkey, $repository->findByAdminUserIdAndCredentialIdForUpdate($adminUserId, 'credential-id'));
+        $this->assertNull($repository->findByAdminUserIdAndCredentialIdForUpdate($otherAdminUserId, 'credential-id'));
+    }
+
+    #[Test]
+    public function findByAdminUserIdAndCredentialIdForUpdateIssuesSelectForUpdate(): void
+    {
+        $adminUserId = $this->generateUuid();
+        $this->app->make(AdminUserRepository::class)->register(
+            $this->createAdminUser($adminUserId, 'user@example.com', Role::General),
+        );
+
+        $repository = $this->app->make(AdminUserPasskeyRepository::class);
+        $repository->save(new AdminUserPasskey(
+            $this->generateUuid(),
+            $adminUserId,
+            'user-handle',
+            'Primary passkey',
+            'credential-id',
+            'public-key',
+            '00000000-0000-0000-0000-000000000000',
+            ['internal'],
+            true,
+            false,
+            1,
+            new DateTimeImmutable('2026-01-01 00:00:00'),
+            null,
+        ));
+
+        DB::enableQueryLog();
+
+        $repository->findByAdminUserIdAndCredentialIdForUpdate($adminUserId, 'credential-id');
+
+        $queries = DB::getQueryLog();
+        DB::disableQueryLog();
+
+        $selectQueries = array_values(array_filter(
+            $queries,
+            fn (array $query): bool => str_starts_with(strtolower((string)$query['query']), 'select')
+                && str_contains((string)$query['query'], 'admin_user_passkeys'),
+        ));
+
+        $this->assertNotSame([], $selectQueries);
+        $this->assertStringContainsString('for update', strtolower((string)$selectQueries[0]['query']));
+    }
+
+    #[Test]
+    public function updateCounterReturnsFalseWhenExpectedSignCountDoesNotMatch(): void
+    {
+        $adminUserId = $this->generateUuid();
+        $this->app->make(AdminUserRepository::class)->register(
+            $this->createAdminUser($adminUserId, 'user@example.com', Role::General),
+        );
+
+        $repository = $this->app->make(AdminUserPasskeyRepository::class);
+        $passkey = new AdminUserPasskey(
+            $this->generateUuid(),
+            $adminUserId,
+            'user-handle',
+            'Primary passkey',
+            'credential-id',
+            'public-key',
+            '00000000-0000-0000-0000-000000000000',
+            ['internal'],
+            true,
+            false,
+            1,
+            new DateTimeImmutable('2026-01-01 00:00:00'),
+            null,
+        );
+
+        $repository->save($passkey);
+
+        $updated = $passkey->withCounter(2, new DateTimeImmutable('2026-01-02 00:00:00'));
+
+        $this->assertFalse($repository->updateCounter($updated, 999));
+        $this->assertSame(1, $repository->findByCredentialId('credential-id')?->signCount);
+        $this->assertTrue($repository->updateCounter($updated, 1));
+        $this->assertSame(2, $repository->findByCredentialId('credential-id')?->signCount);
     }
 }

--- a/src/server/tests/Unit/Auth/Application/Admin/UseCase/Login/LoginFinishUseCaseTest.php
+++ b/src/server/tests/Unit/Auth/Application/Admin/UseCase/Login/LoginFinishUseCaseTest.php
@@ -1,0 +1,289 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Auth\Application\Admin\UseCase\Login;
+
+use Auth\Application\Admin\UseCase\Login\LoginFinishInputData;
+use Auth\Application\Admin\UseCase\Login\LoginFinishUseCase;
+use Auth\Domain\Models\AdminUserPasskey;
+use Auth\Domain\Models\AdminUserPasskeyRepositoryInterface;
+use Auth\Domain\Models\PasskeyCeremonyState;
+use Auth\Domain\Models\PasskeyCeremonyStoreInterface;
+use Auth\Domain\Models\PasskeyCeremonyType;
+use Auth\Domain\Models\Token\RefreshToken\ConsumptionStatus;
+use Auth\Domain\Models\Token\RefreshToken\RefreshToken;
+use Auth\Domain\Models\Token\RefreshToken\RefreshTokenRepositoryInterface;
+use Auth\Domain\Services\PasskeyAuthenticationResult;
+use Auth\Domain\Services\PasskeyAuthenticatorInterface;
+use Auth\Domain\Services\Token\AccessToken\AccessTokenIssueService;
+use Auth\Domain\Services\Token\RefreshToken\RefreshTokenIssueService;
+use DateTimeImmutable;
+use Mockery;
+use Mockery\MockInterface;
+use Override;
+use PHPUnit\Framework\Attributes\Test;
+use ResultType\Ok;
+use RuntimeException;
+use Support\Contracts\ClockInterface;
+use Support\Contracts\TransactionInterface;
+use Support\UseCase\AuditLog\AuditAction;
+use Support\UseCase\AuditLog\AuditLogRecorderInterface;
+use Support\UseCase\AuditLog\AuditTargetType;
+use Support\UseCase\Error\AuthenticationError;
+use Tests\Support\Domain\EntityFactory;
+use Tests\TestCase;
+
+class LoginFinishUseCaseTest extends TestCase
+{
+    use EntityFactory;
+
+    private MockInterface&TransactionInterface $transaction;
+
+    private MockInterface&PasskeyCeremonyStoreInterface $ceremonyStore;
+
+    private AdminUserPasskeyRepositoryInterface&MockInterface $passkeyRepository;
+
+    private MockInterface&PasskeyAuthenticatorInterface $passkeyAuthenticator;
+
+    private MockInterface&RefreshTokenIssueService $refreshTokenIssueService;
+
+    private AccessTokenIssueService&MockInterface $accessTokenIssueService;
+
+    private MockInterface&RefreshTokenRepositoryInterface $refreshTokenRepository;
+
+    private AuditLogRecorderInterface&MockInterface $recorder;
+
+    private ClockInterface&MockInterface $clock;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->transaction = Mockery::mock(TransactionInterface::class);
+        $this->ceremonyStore = Mockery::mock(PasskeyCeremonyStoreInterface::class);
+        $this->passkeyRepository = Mockery::mock(AdminUserPasskeyRepositoryInterface::class);
+        $this->passkeyAuthenticator = Mockery::mock(PasskeyAuthenticatorInterface::class);
+        $this->refreshTokenIssueService = Mockery::mock(RefreshTokenIssueService::class);
+        $this->accessTokenIssueService = Mockery::mock(AccessTokenIssueService::class);
+        $this->refreshTokenRepository = Mockery::mock(RefreshTokenRepositoryInterface::class);
+        $this->recorder = Mockery::mock(AuditLogRecorderInterface::class);
+        $this->clock = Mockery::mock(ClockInterface::class);
+
+        $this->transaction->shouldReceive('scope')
+            ->andReturnUsing(fn (callable $callback) => $callback())
+            ->byDefault();
+    }
+
+    #[Test]
+    public function canFinishWithLockedPasskeyAndCounterCas(): void
+    {
+        $adminUserId = 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA';
+        $state = $this->loginState($adminUserId);
+        $passkey = $this->passkey($adminUserId);
+        $refreshToken = $this->refreshToken($adminUserId);
+        $now = new DateTimeImmutable('2026-01-02 03:04:05');
+
+        $this->ceremonyStore->shouldReceive('pull')
+            ->with($state->authCeremonyId)
+            ->andReturn($state)
+            ->once();
+        $this->passkeyAuthenticator->shouldReceive('credentialId')
+            ->with(['id' => 'credential-id'])
+            ->andReturn('credential-id')
+            ->once();
+        $this->passkeyRepository->shouldReceive('findByAdminUserIdAndCredentialIdForUpdate')
+            ->with($adminUserId, 'credential-id')
+            ->andReturn($passkey)
+            ->once();
+        $this->passkeyAuthenticator->shouldReceive('finishAuthentication')
+            ->with(['id' => 'credential-id'], $state->optionsJson, $passkey, $passkey->userHandle)
+            ->andReturn(new PasskeyAuthenticationResult('credential-id', 456))
+            ->once();
+        $this->refreshTokenIssueService->shouldReceive('issue')
+            ->with($adminUserId)
+            ->andReturn(new Ok(['token' => $refreshToken, 'plainToken' => 'plain-refresh-token']))
+            ->once();
+        $this->clock->shouldReceive('now')
+            ->andReturn($now)
+            ->once();
+        $this->passkeyRepository->shouldReceive('updateCounter')
+            ->withArgs(fn (AdminUserPasskey $updated, int $expectedSignCount): bool => $updated->adminUserPasskeyId === $passkey->adminUserPasskeyId
+                && $updated->signCount === 456
+                && $updated->lastUsedAt === $now
+                && $expectedSignCount === 123)
+            ->andReturnTrue()
+            ->once();
+        $this->accessTokenIssueService->shouldReceive('issue')
+            ->with($refreshToken->refreshTokenId->value)
+            ->andReturn($this->createAccessToken('access-token'))
+            ->once();
+        $this->refreshTokenRepository->shouldReceive('save')
+            ->with($refreshToken)
+            ->andReturn($refreshToken)
+            ->once();
+        $this->recorder->shouldReceive('record')
+            ->withArgs(fn (AuditAction $action, AuditTargetType $targetType): bool => $action === AuditAction::Login
+                && $targetType === AuditTargetType::AdminUser)
+            ->once();
+
+        $result = $this->getInstance()->handle(new LoginFinishInputData($state->authCeremonyId, ['id' => 'credential-id']));
+
+        $this->assertTrue($result->isOk());
+        $this->assertSame('access-token', $result->unwrap()->accessToken->jwt->value);
+        $this->assertSame($refreshToken->refreshTokenId->value, $result->unwrap()->refreshTokenId);
+        $this->assertSame('plain-refresh-token', $result->unwrap()->plainRefreshToken);
+    }
+
+    #[Test]
+    public function returnsAuthenticationErrorWhenCredentialIdIsInvalid(): void
+    {
+        $state = $this->loginState('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA');
+
+        $this->ceremonyStore->shouldReceive('pull')->andReturn($state)->once();
+        $this->passkeyAuthenticator->shouldReceive('credentialId')->andReturnNull()->once();
+        $this->transaction->shouldReceive('scope')->never();
+
+        $result = $this->getInstance()->handle(new LoginFinishInputData($state->authCeremonyId, []));
+
+        $this->assertTrue($result->isErr());
+        $this->assertInstanceOf(AuthenticationError::class, $result->unwrapErr());
+    }
+
+    #[Test]
+    public function returnsAuthenticationErrorWhenLockedPasskeyIsNotFound(): void
+    {
+        $adminUserId = 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA';
+        $state = $this->loginState($adminUserId);
+
+        $this->ceremonyStore->shouldReceive('pull')->andReturn($state)->once();
+        $this->passkeyAuthenticator->shouldReceive('credentialId')->andReturn('credential-id')->once();
+        $this->passkeyRepository->shouldReceive('findByAdminUserIdAndCredentialIdForUpdate')
+            ->with($adminUserId, 'credential-id')
+            ->andReturnNull()
+            ->once();
+        $this->passkeyAuthenticator->shouldReceive('finishAuthentication')->never();
+        $this->refreshTokenIssueService->shouldReceive('issue')->never();
+
+        $result = $this->getInstance()->handle(new LoginFinishInputData($state->authCeremonyId, ['id' => 'credential-id']));
+
+        $this->assertTrue($result->isErr());
+        $this->assertInstanceOf(AuthenticationError::class, $result->unwrapErr());
+    }
+
+    #[Test]
+    public function returnsAuthenticationErrorWhenVerificationFails(): void
+    {
+        $adminUserId = 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA';
+        $state = $this->loginState($adminUserId);
+        $passkey = $this->passkey($adminUserId);
+
+        $this->ceremonyStore->shouldReceive('pull')->andReturn($state)->once();
+        $this->passkeyAuthenticator->shouldReceive('credentialId')->andReturn('credential-id')->once();
+        $this->passkeyRepository->shouldReceive('findByAdminUserIdAndCredentialIdForUpdate')
+            ->andReturn($passkey)
+            ->once();
+        $this->passkeyAuthenticator->shouldReceive('finishAuthentication')
+            ->andThrow(new RuntimeException('verification failed'))
+            ->once();
+        $this->passkeyRepository->shouldReceive('updateCounter')->never();
+        $this->refreshTokenIssueService->shouldReceive('issue')->never();
+
+        $result = $this->getInstance()->handle(new LoginFinishInputData($state->authCeremonyId, ['id' => 'credential-id']));
+
+        $this->assertTrue($result->isErr());
+        $this->assertInstanceOf(AuthenticationError::class, $result->unwrapErr());
+    }
+
+    #[Test]
+    public function returnsAuthenticationErrorWhenCounterUpdateFails(): void
+    {
+        $adminUserId = 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA';
+        $state = $this->loginState($adminUserId);
+        $passkey = $this->passkey($adminUserId);
+        $refreshToken = $this->refreshToken($adminUserId);
+
+        $this->ceremonyStore->shouldReceive('pull')->andReturn($state)->once();
+        $this->passkeyAuthenticator->shouldReceive('credentialId')->andReturn('credential-id')->once();
+        $this->passkeyRepository->shouldReceive('findByAdminUserIdAndCredentialIdForUpdate')
+            ->andReturn($passkey)
+            ->once();
+        $this->passkeyAuthenticator->shouldReceive('finishAuthentication')
+            ->andReturn(new PasskeyAuthenticationResult('credential-id', 456))
+            ->once();
+        $this->refreshTokenIssueService->shouldReceive('issue')
+            ->andReturn(new Ok(['token' => $refreshToken, 'plainToken' => 'plain-refresh-token']))
+            ->once();
+        $this->clock->shouldReceive('now')
+            ->andReturn(new DateTimeImmutable('2026-01-02 03:04:05'))
+            ->once();
+        $this->passkeyRepository->shouldReceive('updateCounter')
+            ->andReturnFalse()
+            ->once();
+        $this->refreshTokenRepository->shouldReceive('save')->never();
+        $this->recorder->shouldReceive('record')->never();
+
+        $result = $this->getInstance()->handle(new LoginFinishInputData($state->authCeremonyId, ['id' => 'credential-id']));
+
+        $this->assertTrue($result->isErr());
+        $this->assertInstanceOf(AuthenticationError::class, $result->unwrapErr());
+    }
+
+    private function getInstance(): LoginFinishUseCase
+    {
+        return new LoginFinishUseCase(
+            $this->transaction,
+            $this->ceremonyStore,
+            $this->passkeyRepository,
+            $this->passkeyAuthenticator,
+            $this->refreshTokenIssueService,
+            $this->accessTokenIssueService,
+            $this->refreshTokenRepository,
+            $this->recorder,
+            $this->clock,
+        );
+    }
+
+    private function loginState(string $adminUserId): PasskeyCeremonyState
+    {
+        return new PasskeyCeremonyState(
+            'BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB',
+            PasskeyCeremonyType::Login,
+            'user@example.com',
+            null,
+            $adminUserId,
+            '{"challenge":"login-challenge"}',
+        );
+    }
+
+    private function passkey(string $adminUserId): AdminUserPasskey
+    {
+        return new AdminUserPasskey(
+            'CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC',
+            $adminUserId,
+            'user-handle',
+            'Primary passkey',
+            'credential-id',
+            'public-key',
+            '00000000-0000-0000-0000-000000000000',
+            ['internal'],
+            true,
+            false,
+            123,
+            new DateTimeImmutable('2026-01-01 00:00:00'),
+            null,
+        );
+    }
+
+    private function refreshToken(string $adminUserId): RefreshToken
+    {
+        return $this->createRefreshToken(
+            'DDDDDDDD-DDDD-DDDD-DDDD-DDDDDDDDDDDD',
+            $adminUserId,
+            'hashed-refresh-token',
+            new DateTimeImmutable('2026-01-09 00:00:00'),
+            ConsumptionStatus::Unused,
+        );
+    }
+}


### PR DESCRIPTION
## 概要

パスキーログイン完了時の credential lookup と sign_count 更新を、DB 上の最新状態に対して競合安全に行うようにします。

## やったこと

- login finish の passkey 取得を `admin_user_id + credential_id` の `lockForUpdate()` lookup に変更
- WebAuthn 検証、counter 更新、refresh token 保存、audit log 記録を同一 transaction 内で実行
- `sign_count` を CAS 条件付きで更新し、更新対象が 0 件の場合は認証失敗として扱うように変更
- LoginFinishUseCase の unit test と AdminUserPasskeyRepository の integration test を追加

## やってないこと

- WebAuthn の例外分類を server log / audit snapshot に残す対応は未実施
- 並行 finish を実スレッドで再現する feature / integration test は未追加

## 関連

- `docs/exec-plans/active/20260524-passkey-improvements-pr-plan.md` の PR 5

