### PR TITLE
登録完了時の整合性と監査ログを強化

### DIFF
--- a/src/admin/src/components/audit-log/SearchList.tsx
+++ b/src/admin/src/components/audit-log/SearchList.tsx
@@ -12,7 +12,7 @@ type TargetType = AuditTargetType;
 
 // 生成された型 (AuditAction / AuditTargetType) を網羅する const タプル。
 // 型注釈で完全性を担保し、生成型に値が増減したらコンパイルエラーで気付ける形にする。
-const ACTION_OPTIONS = ['create', 'update', 'delete', 'login', 'refresh'] as const satisfies readonly Action[];
+const ACTION_OPTIONS = ['create', 'update', 'delete', 'register', 'login', 'refresh'] as const satisfies readonly Action[];
 
 const TARGET_TYPE_OPTIONS = ['AdminUser', 'Media', 'Person', 'Release', 'Song', 'SongTag'] as const satisfies readonly TargetType[];
 
@@ -20,6 +20,7 @@ const ACTION_LABEL: Record<Action, string> = {
   create: '作成',
   update: '更新',
   delete: '削除',
+  register: '登録',
   login: 'ログイン',
   refresh: 'リフレッシュ',
 };

--- a/src/admin/src/generated/types.gen.ts
+++ b/src/admin/src/generated/types.gen.ts
@@ -20,7 +20,7 @@ export type AdminUserListResponse = {
 /**
  * 監査ログの操作種別
  */
-export type AuditAction = 'create' | 'update' | 'delete' | 'login' | 'refresh';
+export type AuditAction = 'create' | 'update' | 'delete' | 'register' | 'login' | 'refresh';
 
 /**
  * 監査ログ詳細

--- a/src/admin/src/server/routes/audit-logs.ts
+++ b/src/admin/src/server/routes/audit-logs.ts
@@ -12,6 +12,7 @@ const AuditActionSchema = t.Union([
   t.Literal('create'),
   t.Literal('update'),
   t.Literal('delete'),
+  t.Literal('register'),
   t.Literal('login'),
   t.Literal('refresh'),
 ]);

--- a/src/contracts/generated/oas/IsekaiObservatory.Admin.v1.yaml
+++ b/src/contracts/generated/oas/IsekaiObservatory.Admin.v1.yaml
@@ -1685,6 +1685,7 @@ components:
         - create
         - update
         - delete
+        - register
         - login
         - refresh
       description: 監査ログの操作種別

--- a/src/contracts/src/admin/audit-logs/domain.tsp
+++ b/src/contracts/src/admin/audit-logs/domain.tsp
@@ -10,6 +10,7 @@ enum AuditAction {
   create: "create",
   update: "update",
   delete: "delete",
+  register: "register",
   login: "login",
   refresh: "refresh",
 }

--- a/src/server/Generated/lib/Model/AuditAction.php
+++ b/src/server/Generated/lib/Model/AuditAction.php
@@ -49,6 +49,8 @@ enum AuditAction: string
 
     case DELETE = 'delete';
 
+    case REGISTER = 'register';
+
     case LOGIN = 'login';
 
     case REFRESH = 'refresh';

--- a/src/server/packages/AdminUser/Application/Admin/UseCase/RegisterFinish/RegisterFinishUseCase.php
+++ b/src/server/packages/AdminUser/Application/Admin/UseCase/RegisterFinish/RegisterFinishUseCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AdminUser\Application\Admin\UseCase\RegisterFinish;
 
+use AdminUser\Domain\Exceptions\DuplicateAdminUserEmailException;
 use AdminUser\Domain\Models\AdminUserRepositoryInterface;
 use AdminUser\Domain\Models\Email;
 use AdminUser\Domain\Models\RegistrationToken\RegistrationTokenRepositoryInterface;
@@ -30,6 +31,9 @@ use Support\Domain\Error\BusinessRuleViolationError;
 use Support\Domain\Error\DomainError;
 use Support\Domain\Error\DomainValidationError;
 use Support\Domain\Error\EntityRuleViolationError;
+use Support\UseCase\AuditLog\AuditAction;
+use Support\UseCase\AuditLog\AuditLogRecorderInterface;
+use Support\UseCase\AuditLog\AuditTargetType;
 use Support\UseCase\Error\BusinessLogicError;
 use Support\UseCase\Error\InvalidInputError;
 use Support\UseCase\Error\UseCaseError;
@@ -49,6 +53,7 @@ readonly class RegisterFinishUseCase
         private RefreshTokenIssueService $refreshTokenIssueService,
         private AccessTokenIssueService $accessTokenIssueService,
         private RefreshTokenRepositoryInterface $refreshTokenRepository,
+        private AuditLogRecorderInterface $recorder,
         private UuidGeneratorInterface $uuidGenerator,
         private ClockInterface $clock,
     ) {
@@ -127,9 +132,16 @@ readonly class RegisterFinishUseCase
 
         ['token' => $refreshToken, 'plainToken' => $plainRefreshToken] = $refreshTokenResult->unwrap();
 
-        $adminUser = $this->adminUserRepository->register($adminUser);
+        try {
+            $adminUser = $this->adminUserRepository->register($adminUser);
+        } catch (DuplicateAdminUserEmailException $exception) {
+            return new Err(new BusinessLogicError($exception->getMessage()));
+        }
+
+        $adminUserPasskeyId = $this->uuidGenerator->generate();
+
         $this->passkeyRepository->save(new AdminUserPasskey(
-            $this->uuidGenerator->generate(),
+            $adminUserPasskeyId,
             $adminUser->adminUserId->value,
             $verification->userHandle,
             $state->name,
@@ -149,6 +161,17 @@ readonly class RegisterFinishUseCase
         $accessToken = $this->accessTokenIssueService->issue($refreshToken->refreshTokenId->value);
 
         $this->refreshTokenRepository->save($refreshToken);
+
+        $this->recorder->record(
+            AuditAction::Register,
+            AuditTargetType::AdminUser,
+            $adminUser->adminUserId,
+            [
+                'admin_user_passkey_id' => $adminUserPasskeyId,
+                'refresh_token_id' => $refreshToken->refreshTokenId->value,
+            ],
+            $adminUser->adminUserId,
+        );
 
         return new Ok(new RegisterFinishOutputData(
             $accessToken,

--- a/src/server/packages/AdminUser/Domain/Exceptions/DuplicateAdminUserEmailException.php
+++ b/src/server/packages/AdminUser/Domain/Exceptions/DuplicateAdminUserEmailException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AdminUser\Domain\Exceptions;
+
+use RuntimeException;
+
+class DuplicateAdminUserEmailException extends RuntimeException
+{
+}

--- a/src/server/packages/AdminUser/Domain/Models/AdminUserRepositoryInterface.php
+++ b/src/server/packages/AdminUser/Domain/Models/AdminUserRepositoryInterface.php
@@ -15,5 +15,7 @@ interface AdminUserRepositoryInterface
 
     public function findByEmail(Email $email): ?AdminUser;
 
+    public function findByEmailForUpdate(Email $email): ?AdminUser;
+
     public function register(AdminUser $adminUser): AdminUser;
 }

--- a/src/server/packages/AdminUser/Domain/Services/AdminUserIntegrityService.php
+++ b/src/server/packages/AdminUser/Domain/Services/AdminUserIntegrityService.php
@@ -74,7 +74,7 @@ class AdminUserIntegrityService
 
         $user = $result->unwrap();
 
-        if (! is_null($this->repository->findByEmail($user->email))) {
+        if (! is_null($this->repository->findByEmailForUpdate($user->email))) {
             return new Err(new BusinessRuleViolationError(sprintf('すでに使われているメールアドレスです "%s"', $email)));
         }
 

--- a/src/server/packages/AdminUser/Infrastructures/AdminUserRepository.php
+++ b/src/server/packages/AdminUser/Infrastructures/AdminUserRepository.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace AdminUser\Infrastructures;
 
+use AdminUser\Domain\Exceptions\DuplicateAdminUserEmailException;
 use AdminUser\Domain\Models\AdminUser;
 use AdminUser\Domain\Models\AdminUserId;
 use AdminUser\Domain\Models\AdminUserRepositoryInterface;
 use AdminUser\Domain\Models\Email;
 use App\Models\AdminUser\AdminUser as ModelsAdminUser;
 use App\Models\AdminUser\AdminUserPermission;
+use Illuminate\Database\QueryException;
 use Override;
 use Support\Contracts\Uuid\UuidConverterInterface;
 
@@ -58,22 +60,48 @@ readonly class AdminUserRepository implements AdminUserRepositoryInterface
     }
 
     #[Override]
+    public function findByEmailForUpdate(Email $email): ?AdminUser
+    {
+        $found = ModelsAdminUser::query()
+            ->where('email', $email->value)
+            ->lockForUpdate()
+            ->first();
+
+        if (is_null($found)) {
+            return null;
+        }
+
+        return $this->hydrate($found);
+    }
+
+    #[Override]
     public function register(AdminUser $adminUser): AdminUser
     {
         $data = $adminUser->toArray();
 
         $id = $this->converter->toBin($data['admin_user_id']);
 
-        ModelsAdminUser::query()->insert(
-            [
-                'admin_user_id' => $id,
-                'name' => $data['name'],
-                'email' => $data['email'],
-                'role' => $data['role'],
-                'created_at' => $data['created_at'],
-                'updated_at' => now(),
-            ],
-        );
+        try {
+            ModelsAdminUser::query()->insert(
+                [
+                    'admin_user_id' => $id,
+                    'name' => $data['name'],
+                    'email' => $data['email'],
+                    'role' => $data['role'],
+                    'created_at' => $data['created_at'],
+                    'updated_at' => now(),
+                ],
+            );
+        } catch (QueryException $exception) {
+            if ($this->isDuplicateEmail($exception)) {
+                throw new DuplicateAdminUserEmailException(
+                    sprintf('すでに使われているメールアドレスです "%s"', $data['email']),
+                    previous: $exception,
+                );
+            }
+
+            throw $exception;
+        }
 
         if ($data['permissions'] !== []) {
             AdminUserPermission::query()->insert(
@@ -85,6 +113,12 @@ readonly class AdminUserRepository implements AdminUserRepositoryInterface
         }
 
         return $adminUser;
+    }
+
+    private function isDuplicateEmail(QueryException $exception): bool
+    {
+        return ($exception->errorInfo[0] ?? null) === '23000'
+            && str_contains($exception->getMessage(), 'admin_users_email_unique');
     }
 
     private function hydrate(ModelsAdminUser $model): AdminUser

--- a/src/server/packages/Support/UseCase/AuditLog/AuditAction.php
+++ b/src/server/packages/Support/UseCase/AuditLog/AuditAction.php
@@ -12,6 +12,8 @@ enum AuditAction: string
 
     case Delete = 'delete';
 
+    case Register = 'register';
+
     case Login = 'login';
 
     case Refresh = 'refresh';

--- a/src/server/tests/Feature/Api/Admin/V1/AuditLog/SearchAuditLogTest.php
+++ b/src/server/tests/Feature/Api/Admin/V1/AuditLog/SearchAuditLogTest.php
@@ -94,6 +94,43 @@ class SearchAuditLogTest extends DatabaseTestCase
     }
 
     #[Test]
+    public function canFilterRegisterAction(): void
+    {
+        $actorId = $this->generateUuid();
+        $this->storeAdminUsers($this->createAdminUser($actorId, 'actor@example.com', Role::Privilege, name: '監査太郎'));
+
+        $registerAuditLogId = $this->generateUuid();
+
+        $this->insertAuditLog(
+            $registerAuditLogId,
+            $actorId,
+            AuditAction::Register,
+            AuditTargetType::AdminUser,
+            $actorId,
+            ['refresh_token_id' => $this->generateUuid()],
+            new DateTimeImmutable('2026-04-02 10:00:00'),
+        );
+        $this->insertAuditLog(
+            $this->generateUuid(),
+            $actorId,
+            AuditAction::Login,
+            AuditTargetType::AdminUser,
+            $actorId,
+            ['refresh_token_id' => $this->generateUuid()],
+            new DateTimeImmutable('2026-04-03 10:00:00'),
+        );
+
+        $response = $this->withAuth()
+            ->get(route(AuditLogRouteMap::Search, ['action' => 'register']))
+            ->assertStatus(200)
+            ->json();
+        /** @var array{auditLogs: list<array{auditLogId: string, action: string}>} $response */
+        $this->assertCount(1, $response['auditLogs']);
+        $this->assertSame($registerAuditLogId, $response['auditLogs'][0]['auditLogId']);
+        $this->assertSame('register', $response['auditLogs'][0]['action']);
+    }
+
+    #[Test]
     public function filtersByAdminUserNameWithPartialMatch(): void
     {
         $actor1Id = $this->generateUuid();

--- a/src/server/tests/Feature/Api/Admin/V1/Auth/RegisterFinishTest.php
+++ b/src/server/tests/Feature/Api/Admin/V1/Auth/RegisterFinishTest.php
@@ -30,10 +30,15 @@ use Override;
 use PHPUnit\Framework\Attributes\Test;
 use RuntimeException;
 use Support\Contracts\Uuid\UuidConverterInterface;
+use Support\UseCase\AuditLog\AuditAction;
+use Support\UseCase\AuditLog\AuditTargetType;
+use Tests\Support\Concerns\AssertsAuditLog;
 use Tests\Support\DatabaseTestCase;
 
 class RegisterFinishTest extends DatabaseTestCase
 {
+    use AssertsAuditLog;
+
     #[Override]
     protected function setUp(): void
     {
@@ -86,6 +91,21 @@ class RegisterFinishTest extends DatabaseTestCase
         $this->assertTrue($passkeyRow->backup_eligible);
         $this->assertFalse($passkeyRow->backup_state);
         $this->assertSame(1, AuthRefreshToken::query()->count());
+
+        $converter = $this->app->make(UuidConverterInterface::class);
+        $adminUserId = $converter->toUuid($userRow->admin_user_id);
+        $passkeyId = $converter->toUuid($passkeyRow->admin_user_passkey_id);
+        $refreshTokenRow = AuthRefreshToken::query()->first();
+        $this->assertNotNull($refreshTokenRow);
+        $refreshTokenId = $converter->toUuid($refreshTokenRow->refresh_token_id);
+
+        $this->assertAuditLogCount(1);
+        $log = $this->findAuditLog(AuditAction::Register, AuditTargetType::AdminUser, $adminUserId);
+        $this->assertSame($adminUserId, $log['admin_user_id']);
+        $snapshot = $log['snapshot'];
+        $this->assertIsArray($snapshot);
+        $this->assertSame($passkeyId, $snapshot['admin_user_passkey_id'] ?? null);
+        $this->assertSame($refreshTokenId, $snapshot['refresh_token_id'] ?? null);
     }
 
     #[Test]
@@ -105,6 +125,7 @@ class RegisterFinishTest extends DatabaseTestCase
         $this->assertSame(0, ModelsAdminUser::query()->count());
         $this->assertSame(0, ModelsAdminUserPasskey::query()->count());
         $this->assertSame(0, AuthRefreshToken::query()->count());
+        $this->assertAuditLogCount(0);
         $token = ModelsRegistrationToken::query()->first();
         $this->assertNotNull($token);
         $this->assertSame(ConsumptionStatus::Unused->value, $token->status);

--- a/src/server/tests/Integration/AdminUser/Infrastructures/AdminUserRepositoryTest.php
+++ b/src/server/tests/Integration/AdminUser/Infrastructures/AdminUserRepositoryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Integration\AdminUser\Infrastructures;
 
 use AdminUser\Domain\Models\AdminUserId;
+use AdminUser\Domain\Models\Email;
 use AdminUser\Domain\Models\Role;
 use AdminUser\Infrastructures\AdminUserRepository;
 use DateTimeImmutable;
@@ -86,6 +87,35 @@ class AdminUserRepositoryTest extends DatabaseTestCase
         $found = $repository->findByEmail($user->email);
 
         $this->assertNull($found);
+    }
+
+    #[Test]
+    public function findByEmailForUpdateIssuesSelectForUpdate(): void
+    {
+        $repository = $this->getInstance();
+
+        $createdAt = new DateTimeImmutable('2026-01-01 00:00:00');
+        $user = $this->createAdminUser($this->generateUuid(), 'user@example.com', Role::General, [], $createdAt);
+
+        $repository->register($user);
+
+        DB::enableQueryLog();
+
+        $found = $repository->findByEmailForUpdate(Email::reconstruct('user@example.com'));
+
+        $queries = DB::getQueryLog();
+        DB::disableQueryLog();
+
+        $selectQueries = array_values(array_filter(
+            $queries,
+            fn (array $query): bool => str_starts_with(strtolower((string)$query['query']), 'select')
+                && str_contains((string)$query['query'], 'admin_users'),
+        ));
+
+        $this->assertNotNull($found);
+        $this->assertEquals($user, $found);
+        $this->assertNotSame([], $selectQueries);
+        $this->assertStringContainsString('for update', strtolower((string)$selectQueries[0]['query']));
     }
 
     #[Test]

--- a/src/server/tests/Unit/AdminUser/Application/Admin/UseCase/RegisterFinish/RegisterFinishUseCaseTest.php
+++ b/src/server/tests/Unit/AdminUser/Application/Admin/UseCase/RegisterFinish/RegisterFinishUseCaseTest.php
@@ -42,7 +42,11 @@ use RuntimeException;
 use Support\Contracts\ClockInterface;
 use Support\Contracts\TransactionInterface;
 use Support\Contracts\Uuid\UuidGeneratorInterface;
+use Support\Domain\Error\BusinessRuleViolationError;
 use Support\Domain\Error\EntityRuleViolationError;
+use Support\UseCase\AuditLog\AuditAction;
+use Support\UseCase\AuditLog\AuditLogRecorderInterface;
+use Support\UseCase\AuditLog\AuditTargetType;
 use Support\UseCase\Error\BusinessLogicError;
 use Tests\Support\Domain\EntityFactory;
 use Tests\TestCase;
@@ -73,6 +77,8 @@ class RegisterFinishUseCaseTest extends TestCase
 
     private MockInterface&RefreshTokenRepositoryInterface $refreshTokenRepository;
 
+    private AuditLogRecorderInterface&MockInterface $recorder;
+
     private MockInterface&UuidGeneratorInterface $uuidGenerator;
 
     private ClockInterface&MockInterface $clock;
@@ -93,6 +99,7 @@ class RegisterFinishUseCaseTest extends TestCase
         $this->refreshTokenIssueService = Mockery::mock(RefreshTokenIssueService::class);
         $this->accessTokenIssueService = Mockery::mock(AccessTokenIssueService::class);
         $this->refreshTokenRepository = Mockery::mock(RefreshTokenRepositoryInterface::class);
+        $this->recorder = Mockery::mock(AuditLogRecorderInterface::class);
         $this->uuidGenerator = Mockery::mock(UuidGeneratorInterface::class);
         $this->clock = Mockery::mock(ClockInterface::class);
     }
@@ -153,6 +160,22 @@ class RegisterFinishUseCaseTest extends TestCase
             ->once();
         $this->accessTokenIssueService->shouldReceive('issue')->with($refreshTokenId)->andReturn($accessToken)->once();
         $this->refreshTokenRepository->shouldReceive('save')->with($refreshToken)->andReturn($refreshToken)->once();
+        $this->recorder->shouldReceive('record')
+            ->withArgs(fn (
+                AuditAction $action,
+                AuditTargetType $targetType,
+                mixed $targetId,
+                array $snapshot,
+                mixed $actorId,
+            ): bool => $action === AuditAction::Register
+                && $targetType === AuditTargetType::AdminUser
+                && $targetId->value === $adminUserId
+                && $snapshot === [
+                    'admin_user_passkey_id' => $passkeyId,
+                    'refresh_token_id' => $refreshTokenId,
+                ]
+                && $actorId->value === $adminUserId)
+            ->once();
 
         $result = $this->getInstance()->handle(new RegisterFinishInputData('EEEEEEEE-EEEE-EEEE-EEEE-EEEEEEEEEEEE', 'plain-token', ['id' => 'credential-id']));
 
@@ -213,10 +236,50 @@ class RegisterFinishUseCaseTest extends TestCase
         $this->passkeyRepository->shouldReceive('save')->never();
         $this->registrationTokenRepository->shouldReceive('save')->never();
         $this->refreshTokenRepository->shouldReceive('save')->never();
+        $this->recorder->shouldReceive('record')->never();
 
         $result = $this->getInstance()->handle(new RegisterFinishInputData('EEEEEEEE-EEEE-EEEE-EEEE-EEEEEEEEEEEE', 'plain-token', ['id' => 'credential-id']));
 
         $this->assertTrue($result->isErr());
+    }
+
+    #[Test]
+    public function doesNotPersistWhenEmailAlreadyExists(): void
+    {
+        $adminUserId = 'BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB';
+        $state = new PasskeyCeremonyState('EEEEEEEE-EEEE-EEEE-EEEE-EEEEEEEEEEEE', PasskeyCeremonyType::Register, 'invitee@example.com', '名前', $adminUserId, '{"challenge":"challenge"}');
+        $verification = new PasskeyRegistrationResult('credential-id', 'public-key', 'user-handle', '00000000-0000-0000-0000-000000000000', [], null, null, 123);
+        $token = $this->buildToken('invitee@example.com');
+
+        $this->ceremonyStore->shouldReceive('pull')->with('EEEEEEEE-EEEE-EEEE-EEEE-EEEEEEEEEEEE')->andReturn($state)->once();
+        $this->passkeyAuthenticator->shouldReceive('finishRegistration')
+            ->with(['id' => 'credential-id'], '{"challenge":"challenge"}')
+            ->andReturn($verification)
+            ->once();
+        $this->transaction->shouldReceive('scope')
+            ->withArgs(fn (Closure $_): bool => true)
+            ->andReturnUsing(fn (Closure $arg) => $arg())
+            ->once();
+        $this->consumeService->shouldReceive('verify')
+            ->withArgs(fn (string $plainToken, Email $email): bool => $plainToken === 'plain-token'
+                && $email->value === 'invitee@example.com')
+            ->andReturn(new Ok($token))
+            ->once();
+        $this->integrityService->shouldReceive('prepareForCreateWithId')
+            ->with($adminUserId, '名前', 'invitee@example.com', Role::General->value, [])
+            ->andReturn(new Err(new BusinessRuleViolationError('すでに使われているメールアドレスです "invitee@example.com"')))
+            ->once();
+        $this->refreshTokenIssueService->shouldReceive('issue')->never();
+        $this->adminUserRepository->shouldReceive('register')->never();
+        $this->passkeyRepository->shouldReceive('save')->never();
+        $this->registrationTokenRepository->shouldReceive('save')->never();
+        $this->refreshTokenRepository->shouldReceive('save')->never();
+        $this->recorder->shouldReceive('record')->never();
+
+        $result = $this->getInstance()->handle(new RegisterFinishInputData('EEEEEEEE-EEEE-EEEE-EEEE-EEEEEEEEEEEE', 'plain-token', ['id' => 'credential-id']));
+
+        $this->assertTrue($result->isErr());
+        $this->assertInstanceOf(BusinessLogicError::class, $result->unwrapErr());
     }
 
     private function buildToken(string $email): RegistrationToken
@@ -246,6 +309,7 @@ class RegisterFinishUseCaseTest extends TestCase
             $this->refreshTokenIssueService,
             $this->accessTokenIssueService,
             $this->refreshTokenRepository,
+            $this->recorder,
             $this->uuidGenerator,
             $this->clock,
         );

--- a/src/server/tests/Unit/AdminUser/Domain/Services/AdminUserIntegrityServiceTest.php
+++ b/src/server/tests/Unit/AdminUser/Domain/Services/AdminUserIntegrityServiceTest.php
@@ -109,6 +109,64 @@ class AdminUserIntegrityServiceTest extends TestCase
         $this->assertSame('すでに使われているメールアドレスです "example@example.com"', $error->message);
     }
 
+    #[Test]
+    public function prepareForCreateWithIdUsesLockedEmailLookup(): void
+    {
+        $adminUserName = 'テストユーザー';
+        $email = 'example@example.com';
+        $uuid = 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA';
+        $now = new DateTimeImmutable('2026-01-01 00:00:00');
+        $role = Role::General;
+        $permissions = [];
+
+        $this->clock->shouldReceive('now')
+            ->with()
+            ->andReturn($now)
+            ->once();
+
+        $expectedUser = $this->createAdminUser($uuid, $email, $role, $permissions, $now);
+
+        $this->repository->shouldReceive('findByEmailForUpdate')
+            ->with(Mockery::on(fn (Email $arg): bool => $arg->value === $email))
+            ->andReturnNull()
+            ->once();
+
+        $result = $this->getInstance()->prepareForCreateWithId($uuid, $adminUserName, $email, $role->value, $permissions);
+
+        $this->assertTrue($result->isOk());
+        $this->assertEquals($expectedUser, $result->unwrap());
+    }
+
+    #[Test]
+    public function prepareForCreateWithIdDuplicateEmail(): void
+    {
+        $adminUserName = 'テストユーザー';
+        $email = 'example@example.com';
+        $uuid = 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA';
+        $now = new DateTimeImmutable('2026-01-01 00:00:00');
+        $role = Role::General;
+        $permissions = [];
+
+        $this->clock->shouldReceive('now')
+            ->with()
+            ->andReturn($now)
+            ->once();
+
+        $existingUser = $this->createAdminUser('BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB', $email, $role, $permissions, $now);
+
+        $this->repository->shouldReceive('findByEmailForUpdate')
+            ->with(Mockery::on(fn (Email $arg): bool => $arg->value === $email))
+            ->andReturn($existingUser)
+            ->once();
+
+        $result = $this->getInstance()->prepareForCreateWithId($uuid, $adminUserName, $email, $role->value, $permissions);
+
+        $this->assertTrue($result->isErr());
+        $error = $result->unwrapErr();
+        $this->assertInstanceOf(BusinessRuleViolationError::class, $error);
+        $this->assertSame('すでに使われているメールアドレスです "example@example.com"', $error->message);
+    }
+
     private function getInstance(): AdminUserIntegrityService
     {
         return new AdminUserIntegrityService(


### PR DESCRIPTION
## 概要

管理ユーザー登録完了時の同一 email 競合を業務エラーへ寄せ、登録成功時に監査ログを残すようにします。

## やったこと

- `AdminUserRepository::findByEmailForUpdate()` を追加し、登録完了時の email 重複確認を locked lookup に変更
- `admin_users.email` の unique 制約競合を domain 例外に変換し、UseCase では業務エラーとして扱うように変更
- `AuditAction::Register` を追加し、登録完了時に passkey ID と refresh token ID を含む監査ログを記録
- contract / OpenAPI / server generated / admin generated を更新
- 監査ログ UI / BFF の action enum に `register` を追加
- RegisterFinish / AdminUserRepository / AuditLog の unit・integration・feature test を追加、更新

## やってないこと

- 登録ユースケースの Auth package 側への移動は PR 7 で扱う
- 既存の admin typecheck 失敗箇所の修正はこの PR では扱わない

## 関連

- `docs/exec-plans/active/20260524-passkey-improvements-pr-plan.md` の PR 6

