### PR TITLE
登録ユースケースをAuthパッケージへ移動

### DIFF
--- a/src/server/app/Http/Controllers/Api/Admin/V1/Auth/RegisterFinishController.php
+++ b/src/server/app/Http/Controllers/Api/Admin/V1/Auth/RegisterFinishController.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\Api\Admin\V1\Auth;
 
-use AdminUser\Application\Admin\UseCase\RegisterFinish\RegisterFinishInputData;
-use AdminUser\Application\Admin\UseCase\RegisterFinish\RegisterFinishUseCase;
 use App\Http\Controllers\Controller;
 use App\Http\Presenters\Api\Admin\V1\Auth\RegisterFinishPresenter;
+use Auth\Application\Admin\UseCase\RegisterFinish\RegisterFinishInputData;
+use Auth\Application\Admin\UseCase\RegisterFinish\RegisterFinishUseCase;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 

--- a/src/server/app/Http/Controllers/Api/Admin/V1/Auth/RegisterStartController.php
+++ b/src/server/app/Http/Controllers/Api/Admin/V1/Auth/RegisterStartController.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\Api\Admin\V1\Auth;
 
-use AdminUser\Application\Admin\UseCase\RegisterStart\RegisterStartInputData;
-use AdminUser\Application\Admin\UseCase\RegisterStart\RegisterStartUseCase;
 use App\Http\Controllers\Controller;
 use App\Http\Presenters\Api\Admin\V1\Auth\RegisterStartPresenter;
+use Auth\Application\Admin\UseCase\RegisterStart\RegisterStartInputData;
+use Auth\Application\Admin\UseCase\RegisterStart\RegisterStartUseCase;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 

--- a/src/server/app/Http/Presenters/Api/Admin/V1/Auth/RegisterFinishPresenter.php
+++ b/src/server/app/Http/Presenters/Api/Admin/V1/Auth/RegisterFinishPresenter.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace App\Http\Presenters\Api\Admin\V1\Auth;
 
-use AdminUser\Application\Admin\UseCase\RegisterFinish\RegisterFinishOutputData;
 use App\Http\Presenters\Api\Support\ResolvesUseCaseError;
+use Auth\Application\Admin\UseCase\RegisterFinish\RegisterFinishOutputData;
 use Illuminate\Http\JsonResponse;
 use OpenAPI\Client\Model\ErrorResponse;
 use OpenAPI\Client\Model\RegisterFinishResponse;

--- a/src/server/app/Http/Presenters/Api/Admin/V1/Auth/RegisterStartPresenter.php
+++ b/src/server/app/Http/Presenters/Api/Admin/V1/Auth/RegisterStartPresenter.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace App\Http\Presenters\Api\Admin\V1\Auth;
 
-use AdminUser\Application\Admin\UseCase\RegisterStart\RegisterStartOutputData;
 use App\Http\Presenters\Api\Support\ResolvesUseCaseError;
+use Auth\Application\Admin\UseCase\RegisterStart\RegisterStartOutputData;
 use Illuminate\Http\JsonResponse;
 use OpenAPI\Client\Model\ErrorResponse;
 use OpenAPI\Client\Model\RegisterStartResponse;

--- a/src/server/packages/Auth/Application/Admin/UseCase/RegisterFinish/RegisterFinishInputData.php
+++ b/src/server/packages/Auth/Application/Admin/UseCase/RegisterFinish/RegisterFinishInputData.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace AdminUser\Application\Admin\UseCase\RegisterFinish;
+namespace Auth\Application\Admin\UseCase\RegisterFinish;
 
 readonly class RegisterFinishInputData
 {

--- a/src/server/packages/Auth/Application/Admin/UseCase/RegisterFinish/RegisterFinishOutputData.php
+++ b/src/server/packages/Auth/Application/Admin/UseCase/RegisterFinish/RegisterFinishOutputData.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace AdminUser\Application\Admin\UseCase\RegisterFinish;
+namespace Auth\Application\Admin\UseCase\RegisterFinish;
 
 use Auth\Domain\Models\Token\AccessToken\AccessToken;
 

--- a/src/server/packages/Auth/Application/Admin/UseCase/RegisterFinish/RegisterFinishUseCase.php
+++ b/src/server/packages/Auth/Application/Admin/UseCase/RegisterFinish/RegisterFinishUseCase.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace AdminUser\Application\Admin\UseCase\RegisterFinish;
+namespace Auth\Application\Admin\UseCase\RegisterFinish;
 
 use AdminUser\Domain\Exceptions\DuplicateAdminUserEmailException;
 use AdminUser\Domain\Models\AdminUserRepositoryInterface;

--- a/src/server/packages/Auth/Application/Admin/UseCase/RegisterStart/RegisterStartInputData.php
+++ b/src/server/packages/Auth/Application/Admin/UseCase/RegisterStart/RegisterStartInputData.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace AdminUser\Application\Admin\UseCase\RegisterStart;
+namespace Auth\Application\Admin\UseCase\RegisterStart;
 
 use SensitiveParameter;
 

--- a/src/server/packages/Auth/Application/Admin/UseCase/RegisterStart/RegisterStartOutputData.php
+++ b/src/server/packages/Auth/Application/Admin/UseCase/RegisterStart/RegisterStartOutputData.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace AdminUser\Application\Admin\UseCase\RegisterStart;
+namespace Auth\Application\Admin\UseCase\RegisterStart;
 
 readonly class RegisterStartOutputData
 {

--- a/src/server/packages/Auth/Application/Admin/UseCase/RegisterStart/RegisterStartUseCase.php
+++ b/src/server/packages/Auth/Application/Admin/UseCase/RegisterStart/RegisterStartUseCase.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace AdminUser\Application\Admin\UseCase\RegisterStart;
+namespace Auth\Application\Admin\UseCase\RegisterStart;
 
 use AdminUser\Domain\Models\Email;
 use AdminUser\Domain\Services\AdminUserIntegrityService;

--- a/src/server/tests/Unit/Auth/Application/Admin/UseCase/RegisterFinish/RegisterFinishUseCaseTest.php
+++ b/src/server/tests/Unit/Auth/Application/Admin/UseCase/RegisterFinish/RegisterFinishUseCaseTest.php
@@ -2,10 +2,8 @@
 
 declare(strict_types=1);
 
-namespace Tests\Unit\AdminUser\Application\Admin\UseCase\RegisterFinish;
+namespace Tests\Unit\Auth\Application\Admin\UseCase\RegisterFinish;
 
-use AdminUser\Application\Admin\UseCase\RegisterFinish\RegisterFinishInputData;
-use AdminUser\Application\Admin\UseCase\RegisterFinish\RegisterFinishUseCase;
 use AdminUser\Domain\Models\AdminUser;
 use AdminUser\Domain\Models\AdminUserRepositoryInterface;
 use AdminUser\Domain\Models\Email;
@@ -19,6 +17,8 @@ use AdminUser\Domain\Models\RegistrationToken\RegistrationTokenRepositoryInterfa
 use AdminUser\Domain\Models\Role;
 use AdminUser\Domain\Services\AdminUserIntegrityService;
 use AdminUser\Domain\Services\RegistrationToken\RegistrationTokenConsumeService;
+use Auth\Application\Admin\UseCase\RegisterFinish\RegisterFinishInputData;
+use Auth\Application\Admin\UseCase\RegisterFinish\RegisterFinishUseCase;
 use Auth\Domain\Models\AdminUserPasskey;
 use Auth\Domain\Models\AdminUserPasskeyRepositoryInterface;
 use Auth\Domain\Models\PasskeyCeremonyState;

--- a/src/server/tests/Unit/Auth/Application/Admin/UseCase/RegisterStart/RegisterStartUseCaseTest.php
+++ b/src/server/tests/Unit/Auth/Application/Admin/UseCase/RegisterStart/RegisterStartUseCaseTest.php
@@ -2,10 +2,8 @@
 
 declare(strict_types=1);
 
-namespace Tests\Unit\AdminUser\Application\Admin\UseCase\RegisterStart;
+namespace Tests\Unit\Auth\Application\Admin\UseCase\RegisterStart;
 
-use AdminUser\Application\Admin\UseCase\RegisterStart\RegisterStartInputData;
-use AdminUser\Application\Admin\UseCase\RegisterStart\RegisterStartUseCase;
 use AdminUser\Domain\Models\Email;
 use AdminUser\Domain\Models\Permissions;
 use AdminUser\Domain\Models\RegistrationToken\ConsumptionStatus;
@@ -16,6 +14,8 @@ use AdminUser\Domain\Models\RegistrationToken\RegistrationTokenId;
 use AdminUser\Domain\Models\Role;
 use AdminUser\Domain\Services\AdminUserIntegrityService;
 use AdminUser\Domain\Services\RegistrationToken\RegistrationTokenConsumeService;
+use Auth\Application\Admin\UseCase\RegisterStart\RegisterStartInputData;
+use Auth\Application\Admin\UseCase\RegisterStart\RegisterStartUseCase;
 use Auth\Domain\Models\PasskeyCeremonyState;
 use Auth\Domain\Models\PasskeyCeremonyStoreInterface;
 use Auth\Domain\Models\PasskeyCeremonyType;


### PR DESCRIPTION
## 概要

パスキー登録の start / finish ユースケースを Auth package 側へ移動し、AdminUser package は管理ユーザー作成周辺の責務に寄せます。

## やったこと

- `RegisterStartUseCase` / `RegisterFinishUseCase` と入出力 DTO を `Auth\Application\Admin\UseCase` 配下へ移動
- Auth register controller / presenter の参照 namespace を更新
- Register 系 unit test を Auth package 配下のテスト namespace へ移動
- `api:arkitect` / `api:phpstan` / Register 系 unit・feature test / 対象 ECS を通過確認

## やってないこと

- API 契約やレスポンス仕様の変更
- 招待トークン検証や管理ユーザー作成ロジックの挙動変更
- 既存の未コミット差分である `config/auth.php` やローカル検証ファイルの取り込み

## 関連

- `docs/exec-plans/active/20260524-passkey-improvements-pr-plan.md` の PR7