### PR TITLE
管理画面のパスキーUXと型利用を改善

### DIFF
--- a/src/admin/src/components/auth/LoginForm.tsx
+++ b/src/admin/src/components/auth/LoginForm.tsx
@@ -1,27 +1,45 @@
-import { Show } from 'solid-js';
+import { createEffect, createSignal, onCleanup, onMount, Show } from 'solid-js';
+import { resolveAuthReturnTo } from '../../utils/auth-redirect';
 import { client } from '../../utils/client';
 import { createFormErrors } from '../../utils/form-error';
 import { createSubmitting } from '../../utils/use-submitting';
-import { authenticatePasskey } from '../../utils/webauthn';
+import { authenticatePasskey, isPasskeyConditionalMediationAvailable, passkeyErrorMessage } from '../../utils/webauthn';
 import { setFlash } from '../Flash';
 import { FormError } from '../FormError';
 
-export const LoginForm = () => {
+type LoginFormProps = {
+  returnTo?: string;
+};
+
+export const LoginForm = (props: LoginFormProps) => {
   const { formError, setFormError, getFieldError, clearErrors, handleError } = createFormErrors();
   const { isSubmitting, withSubmitting } = createSubmitting();
+  const [email, setEmail] = createSignal('');
+  let conditionalAbortController: AbortController | undefined;
+  let emailInput: HTMLInputElement | undefined;
 
-  const handleSubmit = withSubmitting(async (e: Event) => {
-    e.preventDefault();
-    clearErrors();
+  const redirectToReturnPath = () => {
+    window.location.href = resolveAuthReturnTo(props.returnTo);
+  };
 
-    const form = e.target as HTMLFormElement;
-    const formData = new FormData(form);
+  const abortConditionalLogin = () => {
+    conditionalAbortController?.abort();
+    conditionalAbortController = undefined;
+  };
 
+  const loginWithPasskey = async (
+    loginEmail: string,
+    options: { signal?: AbortSignal; mediation?: CredentialMediationRequirement; suppressStartError?: boolean } = {},
+  ) => {
     const start = await client.api.auth.login.start.post({
-      email: formData.get('email')?.toString() ?? '',
+      email: loginEmail,
     });
 
     if (start.error) {
+      if (options.suppressStartError) {
+        return;
+      }
+
       if (start.status === 400 || start.status === 401) {
         setFormError('パスキー認証に失敗しました');
         return;
@@ -32,7 +50,10 @@ export const LoginForm = () => {
     }
 
     try {
-      const credential = await authenticatePasskey(start.data.publicKey as Record<string, unknown>);
+      const credential = await authenticatePasskey(start.data.publicKey, {
+        mediation: options.mediation,
+        signal: options.signal,
+      });
       const finish = await client.api.auth.login.finish.post({
         authCeremonyId: start.data.authCeremonyId,
         credential,
@@ -49,10 +70,75 @@ export const LoginForm = () => {
       }
 
       setFlash('ログインしました');
-      window.location.href = '/song-types';
-    } catch {
-      setFormError('パスキー認証に失敗しました');
+      redirectToReturnPath();
+    } catch (error) {
+      if (options.signal?.aborted) {
+        return;
+      }
+
+      setFormError(passkeyErrorMessage(error, 'パスキー認証に失敗しました'));
     }
+  };
+
+  const startConditionalLogin = async (loginEmail: string, abortController: AbortController) => {
+    if (abortController.signal.aborted || !(await isPasskeyConditionalMediationAvailable())) {
+      return;
+    }
+
+    if (abortController.signal.aborted) {
+      return;
+    }
+
+    abortConditionalLogin();
+    conditionalAbortController = abortController;
+
+    try {
+      await loginWithPasskey(loginEmail, {
+        mediation: 'conditional',
+        signal: abortController.signal,
+        suppressStartError: true,
+      });
+    } finally {
+      if (conditionalAbortController === abortController) {
+        conditionalAbortController = undefined;
+      }
+    }
+  };
+
+  onMount(() => {
+    setEmail(emailInput?.value ?? '');
+  });
+
+  createEffect(() => {
+    const loginEmail = email().trim();
+
+    if (!loginEmail.includes('@') || isSubmitting()) {
+      abortConditionalLogin();
+      return;
+    }
+
+    const abortController = new AbortController();
+    const timeoutId = window.setTimeout(() => {
+      void startConditionalLogin(loginEmail, abortController);
+    }, 300);
+
+    onCleanup(() => {
+      window.clearTimeout(timeoutId);
+      abortController.abort();
+      if (conditionalAbortController === abortController) {
+        conditionalAbortController = undefined;
+      }
+    });
+  });
+
+  const handleSubmit = withSubmitting(async (e: Event) => {
+    e.preventDefault();
+    clearErrors();
+    abortConditionalLogin();
+
+    const form = e.target as HTMLFormElement;
+    const formData = new FormData(form);
+    await loginWithPasskey(formData.get('email')?.toString() ?? '');
   });
 
   return (
@@ -61,10 +147,13 @@ export const LoginForm = () => {
       <fieldset class="fieldset bg-base-200 border-base-300 rounded-box w-xs border p-4">
         <label class="label">メールアドレス</label>
         <input
+          ref={emailInput}
           type="email"
           class="input"
           name="email"
+          autocomplete="username webauthn"
           required
+          onInput={event => setEmail(event.currentTarget.value)}
           classList={{ 'input-error': !!getFieldError('email') }}
         />
         <Show when={getFieldError('email')}>{message => <p class="mt-1 text-xs text-error">{message()}</p>}</Show>

--- a/src/admin/src/components/auth/RegisterForm.tsx
+++ b/src/admin/src/components/auth/RegisterForm.tsx
@@ -2,11 +2,15 @@ import { Show } from 'solid-js';
 import { client } from '../../utils/client';
 import { createFormErrors } from '../../utils/form-error';
 import { createSubmitting } from '../../utils/use-submitting';
-import { registerPasskey } from '../../utils/webauthn';
+import { passkeyErrorMessage, registerPasskey } from '../../utils/webauthn';
 import { setFlash } from '../Flash';
 import { FormError } from '../FormError';
 
-export const RegisterForm = () => {
+type RegisterFormProps = {
+  initialToken?: string;
+};
+
+export const RegisterForm = (props: RegisterFormProps) => {
   const { formError, setFormError, getFieldError, clearErrors, handleError } = createFormErrors();
   const { isSubmitting, withSubmitting } = createSubmitting();
 
@@ -35,7 +39,7 @@ export const RegisterForm = () => {
     }
 
     try {
-      const credential = await registerPasskey(start.data.publicKey as Record<string, unknown>);
+      const credential = await registerPasskey(start.data.publicKey);
       const finish = await client.api.auth.register.finish.post({
         authCeremonyId: start.data.authCeremonyId,
         token,
@@ -55,7 +59,7 @@ export const RegisterForm = () => {
       setFlash('登録しました');
       window.location.href = '/song-types';
     } catch (error) {
-      setFormError(error instanceof Error ? error.message : 'パスキー登録に失敗しました');
+      setFormError(passkeyErrorMessage(error, 'パスキー登録に失敗しました'));
     }
   });
 
@@ -68,6 +72,7 @@ export const RegisterForm = () => {
           type="text"
           class="input"
           name="token"
+          value={props.initialToken ?? ''}
           required
           classList={{ 'input-error': !!getFieldError('token') }}
         />

--- a/src/admin/src/pages/auth/login.astro
+++ b/src/admin/src/pages/auth/login.astro
@@ -1,10 +1,13 @@
 ---
 import { LoginForm } from '../../components/auth/LoginForm';
 import SimpleLayout from '../../layouts/SimpleLayout.astro';
+import { resolveAuthReturnTo } from '../../utils/auth-redirect';
+
+const returnTo = resolveAuthReturnTo(Astro.url.searchParams.get('return_to'));
 ---
 
 <SimpleLayout pageTitle="ログイン">
   <div class="flex min-h-[70vh] items-center justify-center">
-    <LoginForm client:load />
+    <LoginForm returnTo={returnTo} client:load />
   </div>
 </SimpleLayout>

--- a/src/admin/src/pages/auth/register.astro
+++ b/src/admin/src/pages/auth/register.astro
@@ -1,10 +1,12 @@
 ---
 import { RegisterForm } from '../../components/auth/RegisterForm';
 import SimpleLayout from '../../layouts/SimpleLayout.astro';
+
+const token = Astro.url.searchParams.get('token') ?? '';
 ---
 
 <SimpleLayout pageTitle="登録">
   <div class="flex min-h-[70vh] items-center justify-center">
-    <RegisterForm client:load />
+    <RegisterForm initialToken={token} client:load />
   </div>
 </SimpleLayout>

--- a/src/admin/src/server/routes/auth.ts
+++ b/src/admin/src/server/routes/auth.ts
@@ -6,6 +6,7 @@ import {
   authenticateServiceRegisterFinish,
   authenticateServiceRegisterStart,
 } from '../../generated';
+import type { LoginFinishRequest, RegisterFinishRequest } from '../../generated';
 import { client } from '../client';
 import { SESSION_TTL_SECONDS } from '../constants';
 import { resolveApiResponse } from '../errors';
@@ -14,6 +15,8 @@ import { storeSessionCredential } from '../session';
 const generateRandomBytes = (): string => {
   return randomBytes(32).toString('base64url');
 };
+
+const webAuthnCredentialSchema = t.Record(t.String(), t.Any());
 
 const setAuthCookies = async (
   session: { set: (value: Record<string, unknown>) => Promise<unknown> | unknown } | undefined,
@@ -55,8 +58,9 @@ export const auth = new Elysia({ prefix: '/auth' })
   .post(
     '/login/finish',
     async ({ body: { authCeremonyId, credential }, cookie: { session, csrf } }) => {
+      const body = { authCeremonyId, credential } satisfies LoginFinishRequest;
       const data = resolveApiResponse(
-        await authenticateServiceLoginFinish({ client: client, body: { authCeremonyId, credential } }),
+        await authenticateServiceLoginFinish({ client: client, body: body }),
       );
 
       const sessionId = generateRandomBytes();
@@ -69,7 +73,7 @@ export const auth = new Elysia({ prefix: '/auth' })
     {
       body: t.Object({
         authCeremonyId: t.String(),
-        credential: t.Record(t.String(), t.Any()),
+        credential: webAuthnCredentialSchema,
       }),
     },
   )
@@ -91,8 +95,9 @@ export const auth = new Elysia({ prefix: '/auth' })
   .post(
     '/register/finish',
     async ({ body: { authCeremonyId, token, credential }, cookie: { session, csrf } }) => {
+      const body = { authCeremonyId, token, credential } satisfies RegisterFinishRequest;
       const data = resolveApiResponse(
-        await authenticateServiceRegisterFinish({ client: client, body: { authCeremonyId, token, credential } }),
+        await authenticateServiceRegisterFinish({ client: client, body: body }),
       );
 
       const sessionId = generateRandomBytes();
@@ -106,7 +111,7 @@ export const auth = new Elysia({ prefix: '/auth' })
       body: t.Object({
         authCeremonyId: t.String(),
         token: t.String(),
-        credential: t.Record(t.String(), t.Any()),
+        credential: webAuthnCredentialSchema,
       }),
     },
   );

--- a/src/admin/src/utils/auth-redirect.test.ts
+++ b/src/admin/src/utils/auth-redirect.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'bun:test';
+import { DEFAULT_AUTH_RETURN_TO, resolveAuthReturnTo } from './auth-redirect';
+
+describe('resolveAuthReturnTo', () => {
+  it('return_to がない場合は既定の遷移先を返す', () => {
+    expect(resolveAuthReturnTo(null)).toBe(DEFAULT_AUTH_RETURN_TO);
+    expect(resolveAuthReturnTo('')).toBe(DEFAULT_AUTH_RETURN_TO);
+  });
+
+  it('同一 origin のパスを返す', () => {
+    expect(resolveAuthReturnTo('/songs?sort=title')).toBe('/songs?sort=title');
+  });
+
+  it('外部 URL と protocol-relative URL は既定の遷移先へ丸める', () => {
+    expect(resolveAuthReturnTo('https://example.com/songs')).toBe(DEFAULT_AUTH_RETURN_TO);
+    expect(resolveAuthReturnTo('//example.com/songs')).toBe(DEFAULT_AUTH_RETURN_TO);
+  });
+});

--- a/src/admin/src/utils/auth-redirect.ts
+++ b/src/admin/src/utils/auth-redirect.ts
@@ -1,0 +1,11 @@
+export const DEFAULT_AUTH_RETURN_TO = '/song-types';
+
+export const resolveAuthReturnTo = (returnTo: string | null | undefined): string => {
+  const path = returnTo?.trim();
+
+  if (!path || !path.startsWith('/') || path.startsWith('//')) {
+    return DEFAULT_AUTH_RETURN_TO;
+  }
+
+  return path;
+};

--- a/src/admin/src/utils/webauthn.test.ts
+++ b/src/admin/src/utils/webauthn.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'bun:test';
+import { passkeyErrorMessage } from './webauthn';
+
+describe('passkeyErrorMessage', () => {
+  it('DOMException.name をフォーム共通の日本語メッセージへ変換する', () => {
+    expect(passkeyErrorMessage(new DOMException('', 'NotAllowedError'), '失敗しました')).toBe(
+      'パスキー操作がキャンセルされたか、許可されませんでした',
+    );
+    expect(passkeyErrorMessage(new DOMException('', 'SecurityError'), '失敗しました')).toBe(
+      'この環境ではパスキーを利用できません',
+    );
+  });
+
+  it('未定義の例外名は fallback を返す', () => {
+    expect(passkeyErrorMessage(new DOMException('', 'UnknownError'), '失敗しました')).toBe('失敗しました');
+  });
+});

--- a/src/admin/src/utils/webauthn.ts
+++ b/src/admin/src/utils/webauthn.ts
@@ -1,3 +1,8 @@
+import type { LoginFinishRequest, LoginStartResponse, RegisterFinishRequest, RegisterStartResponse } from '../generated';
+
+export type WebAuthnPublicKeyOptions = LoginStartResponse['publicKey'] | RegisterStartResponse['publicKey'];
+export type WebAuthnCredential = LoginFinishRequest['credential'] | RegisterFinishRequest['credential'];
+
 type RegistrationOptionsJson = {
   challenge: string;
   rp: PublicKeyCredentialRpEntity;
@@ -47,7 +52,12 @@ const encodeBase64Url = (value: ArrayBuffer | Uint8Array): string => {
   return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/u, '');
 };
 
-const toRegistrationOptions = (publicKey: Record<string, unknown>): PublicKeyCredentialCreationOptions => {
+type PasskeyAuthenticationOptions = {
+  mediation?: CredentialMediationRequirement;
+  signal?: AbortSignal;
+};
+
+const toRegistrationOptions = (publicKey: WebAuthnPublicKeyOptions): PublicKeyCredentialCreationOptions => {
   const options = publicKey as unknown as RegistrationOptionsJson;
   const excludeCredentials = options.excludeCredentials ?? [];
 
@@ -74,7 +84,7 @@ const toRegistrationOptions = (publicKey: Record<string, unknown>): PublicKeyCre
   } satisfies PublicKeyCredentialCreationOptions;
 };
 
-const toAuthenticationOptions = (publicKey: Record<string, unknown>): PublicKeyCredentialRequestOptions => {
+const toAuthenticationOptions = (publicKey: WebAuthnPublicKeyOptions): PublicKeyCredentialRequestOptions => {
   const options = publicKey as unknown as AuthenticationOptionsJson;
   const allowCredentials = options.allowCredentials ?? [];
 
@@ -94,11 +104,11 @@ const toAuthenticationOptions = (publicKey: Record<string, unknown>): PublicKeyC
   } satisfies PublicKeyCredentialRequestOptions;
 };
 
-type JsonCredential = {
+type JsonCredential = WebAuthnCredential & {
   id: string;
   rawId: string;
   type: string;
-  response: Record<string, unknown>;
+  response: WebAuthnCredential;
   clientExtensionResults: AuthenticationExtensionsClientOutputs;
   authenticatorAttachment?: string | null;
 };
@@ -140,7 +150,42 @@ const credentialToJson = (credential: PublicKeyCredential): JsonCredential => {
   throw new Error('未対応の credential response です');
 };
 
-export const registerPasskey = async (publicKey: Record<string, unknown>): Promise<JsonCredential> => {
+export const passkeyErrorMessage = (error: unknown, fallbackMessage: string): string => {
+  if (typeof DOMException !== 'undefined' && error instanceof DOMException) {
+    switch (error.name) {
+      case 'AbortError':
+        return 'パスキー操作を中断しました';
+      case 'InvalidStateError':
+        return 'このパスキーはすでに登録されています';
+      case 'NotAllowedError':
+        return 'パスキー操作がキャンセルされたか、許可されませんでした';
+      case 'NotSupportedError':
+        return 'このブラウザまたは端末はパスキーに対応していません';
+      case 'SecurityError':
+        return 'この環境ではパスキーを利用できません';
+      case 'TimeoutError':
+        return 'パスキー操作がタイムアウトしました';
+      default:
+        return fallbackMessage;
+    }
+  }
+
+  return error instanceof Error ? error.message : fallbackMessage;
+};
+
+export const isPasskeyConditionalMediationAvailable = async (): Promise<boolean> => {
+  if (
+    typeof window === 'undefined'
+    || typeof window.PublicKeyCredential === 'undefined'
+    || typeof window.PublicKeyCredential.isConditionalMediationAvailable !== 'function'
+  ) {
+    return false;
+  }
+
+  return await window.PublicKeyCredential.isConditionalMediationAvailable();
+};
+
+export const registerPasskey = async (publicKey: WebAuthnPublicKeyOptions): Promise<JsonCredential> => {
   if (typeof window.PublicKeyCredential === 'undefined') {
     throw new Error('このブラウザはパスキー登録に対応していません');
   }
@@ -156,13 +201,22 @@ export const registerPasskey = async (publicKey: Record<string, unknown>): Promi
   return credentialToJson(credential);
 };
 
-export const authenticatePasskey = async (publicKey: Record<string, unknown>): Promise<JsonCredential> => {
+export const authenticatePasskey = async (
+  publicKey: WebAuthnPublicKeyOptions,
+  options: PasskeyAuthenticationOptions = {},
+): Promise<JsonCredential> => {
   if (typeof window.PublicKeyCredential === 'undefined') {
     throw new Error('このブラウザはパスキーログインに対応していません');
   }
 
-  const credential = await navigator.credentials.get({
+  const requestOptions: CredentialRequestOptions & { signal?: AbortSignal } = {
     publicKey: toAuthenticationOptions(publicKey),
+    mediation: options.mediation,
+    signal: options.signal,
+  };
+
+  const credential = await navigator.credentials.get({
+    ...requestOptions,
   });
 
   if (!(credential instanceof PublicKeyCredential)) {


### PR DESCRIPTION
## 概要

管理画面のパスキー登録・ログイン体験を改善します。
WebAuthn エラー表示を共通化し、招待リンクの token 初期入力、ログイン後の return_to 遷移、conditional UI 起動、generated contract 型の利用を追加します。

## やったこと

- WebAuthn の DOMException.name をフォーム共通の日本語メッセージへ変換
- 登録ページの token query を登録フォーム初期値に反映
- ログインページの return_to query を優先し、不正な外部 URL は既定遷移先へ丸める helper を追加
- login email input に username webauthn autocomplete を追加
- email 入力済み時に AbortController 付き conditional mediation を開始
- generated contract 型を webauthn.ts / BFF finish body で参照し、二段 cast と重複 schema を削減
- auth redirect と WebAuthn エラーメッセージの unit test を追加

## やってないこと

- usernameless login の API 契約変更は行っていません
- WebAuthn publicKey / credential の詳細スキーマ化は行っていません

## 関連

- docs/exec-plans/active/20260524-passkey-improvements-pr-plan.md の PR 9