### PR TITLE
Auth providerのpasskey前提を明文化

### DIFF
--- a/src/server/packages/Auth/Infrastructures/Auth/AuthUser.php
+++ b/src/server/packages/Auth/Infrastructures/Auth/AuthUser.php
@@ -21,11 +21,13 @@ readonly class AuthUser extends AuthenticatableAdminUser implements Authenticata
 
     public function getAuthPasswordName()
     {
+        // Passkey authentication does not use passwords; Laravel's Authenticatable contract still requires this.
         return 'password';
     }
 
     public function getAuthPassword()
     {
+        // Passkey authentication does not use passwords; keep this empty for the framework contract.
         return '';
     }
 

--- a/src/server/packages/Auth/Infrastructures/Auth/AuthUserProvider.php
+++ b/src/server/packages/Auth/Infrastructures/Auth/AuthUserProvider.php
@@ -40,10 +40,18 @@ readonly class AuthUserProvider implements UserProvider
     }
 
     /**
-     * @param array{email: string, password: string} $credentials
+     * Passkey login only uses the email address to resolve an authenticatable user.
+     *
+     * @internal Required by Laravel's UserProvider contract.
+     *
+     * @param array{email?: mixed} $credentials
      */
     public function retrieveByCredentials(array $credentials)
     {
+        if (! isset($credentials['email']) || ! is_string($credentials['email'])) {
+            return null;
+        }
+
         return Email::create($credentials['email'])
             ->match(
                 fn (Email $email): ?AuthUser => $this->toAuthUser($this->repository->findByEmail($email)),
@@ -52,7 +60,11 @@ readonly class AuthUserProvider implements UserProvider
     }
 
     /**
-     * @param array{password?: string} $credentials
+     * Passkey authentication does not validate passwords.
+     *
+     * @internal Required by Laravel's UserProvider contract.
+     *
+     * @param array<mixed> $credentials
      */
     public function validateCredentials(Authenticatable $user, array $credentials)
     {
@@ -60,6 +72,10 @@ readonly class AuthUserProvider implements UserProvider
     }
 
     /**
+     * Passkey authentication does not store password hashes.
+     *
+     * @internal Required by Laravel's UserProvider contract.
+     *
      * @param array<mixed> $credentials
      */
     public function rehashPasswordIfRequired(Authenticatable $user, array $credentials, bool $force = false)

--- a/src/server/packages/Auth/Route/AuthRouteMap.php
+++ b/src/server/packages/Auth/Route/AuthRouteMap.php
@@ -10,7 +10,7 @@ enum AuthRouteMap: string
 
     case LoginFinish = 'login.finish';
 
-    case Refresh = 'refresh';
+    case Refresh = 'auth.refresh';
 
     case RegisterStart = 'register.start';
 

--- a/src/server/tests/Unit/Auth/Infrastructures/Auth/AuthUserProviderTest.php
+++ b/src/server/tests/Unit/Auth/Infrastructures/Auth/AuthUserProviderTest.php
@@ -74,6 +74,18 @@ class AuthUserProviderTest extends TestCase
     }
 
     #[Test]
+    public function retrieveByCredentialsWithoutEmail(): void
+    {
+        $this->repository->shouldNotReceive('findByEmail');
+
+        $result = $this->getInstance()->retrieveByCredentials([
+            'password' => 'plain-password',
+        ]);
+
+        $this->assertNull($result);
+    }
+
+    #[Test]
     public function validateCredentials(): void
     {
         $user = new AuthUser(


### PR DESCRIPTION
## 概要

Passkey 認証移行後も Laravel の認証 contract のために残している password 系メソッドの意図を明文化します。
あわせて refresh route name を auth 名前空間付きに寄せます。

## やったこと

- AuthUser / AuthUserProvider の password 系メソッドに passkey 前提のコメントと docblock を追加
- retrieveByCredentials の古い password 前提 docblock を修正し、email 欠落時に null を返す防御を追加
- AuthRouteMap::Refresh の route name を auth.refresh に変更
- email 欠落 credentials の unit test を追加

## やってないこと

- LoginStart のタイミング差緩和は低リスク改善として今回は未対応
- passkey origin / RP ID 設定の変更は PR 1 側の範囲として未対応

## 関連

- docs/exec-plans/active/20260524-passkey-improvements-pr-plan.md の PR 10