### PR TITLE
パスキー認証エンドポイントにレート制限を追加

### DIFF
--- a/src/admin/src/pages/api/[...slugs].ts
+++ b/src/admin/src/pages/api/[...slugs].ts
@@ -1,5 +1,21 @@
+import type { APIContext } from 'astro';
 import { app } from '../../server';
+import { CLIENT_IP_HEADER } from '../../server/constants';
 
-const handle = ({ request }: { request: Request }) => app.handle(request);
+const resolveClientAddress = (context: APIContext): string => {
+  try {
+    return context.clientAddress;
+  } catch {
+    return context.request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? 'unknown';
+  }
+};
+
+const handle = (context: APIContext): Response | Promise<Response> => {
+  // クライアントが詐称した同名ヘッダーを信頼できる実 IP で上書きしてから Elysia へ渡す
+  const headers = new Headers(context.request.headers);
+  headers.set(CLIENT_IP_HEADER, resolveClientAddress(context));
+
+  return app.handle(new Request(context.request, { headers }));
+};
 
 export const ALL = handle;

--- a/src/admin/src/pages/api/[...slugs].ts
+++ b/src/admin/src/pages/api/[...slugs].ts
@@ -3,10 +3,13 @@ import { app } from '../../server';
 import { CLIENT_IP_HEADER } from '../../server/constants';
 
 const resolveClientAddress = (context: APIContext): string => {
+  // Astro アダプタが信頼できるプロキシ設定に基づいて解決した実 IP のみを採用する。
+  // 解決できない場合にクライアント送信の x-forwarded-for を信用すると、攻撃者が
+  // キーを自由に分散させてレート制限を無効化できるため、固定値に倒す。
   try {
     return context.clientAddress;
   } catch {
-    return context.request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? 'unknown';
+    return 'unknown';
   }
 };
 

--- a/src/admin/src/server/constants.ts
+++ b/src/admin/src/server/constants.ts
@@ -4,3 +4,21 @@
  * 1日 - TODO: 調整する
  */
 export const SESSION_TTL_SECONDS = 60 * 60 * 24;
+
+/**
+ * Astro 側で解決したクライアント実 IP を Elysia へ受け渡すための内部ヘッダー名。
+ *
+ * 公開境界である Astro ルートで信頼できる値に上書きしてから渡すため、
+ * クライアントが送ってきた同名ヘッダーは無視される。
+ */
+export const CLIENT_IP_HEADER = 'x-client-ip';
+
+/**
+ * 認証系エンドポイントの IP 単位レート制限 (公開境界での多層防御の外側)。
+ */
+export const AUTH_RATE_LIMITS = {
+  loginStart: { limit: 20, windowSeconds: 60 },
+  loginFinish: { limit: 20, windowSeconds: 60 },
+  registerStart: { limit: 10, windowSeconds: 60 },
+  registerFinish: { limit: 10, windowSeconds: 60 },
+} as const;

--- a/src/admin/src/server/rate-limit.ts
+++ b/src/admin/src/server/rate-limit.ts
@@ -18,15 +18,24 @@ const resolveClientIp = (request: Request): string => {
 /**
  * クライアント実 IP 単位の固定ウィンドウレート制限。
  *
- * 上限を超えた場合は 429 を投げる。Redis の INCR + EXPIRE で実装し、
- * 複数インスタンス構成でもカウンタを共有する。
+ * 上限を超えた場合は 429 を投げる。複数インスタンス構成でもカウンタを共有する。
+ * 初回リクエストで必ず TTL 付きでキーを作成するため、INCR と EXPIRE の間で
+ * プロセスが落ちてカウンタが永続化する事故を防ぐ。
  */
 export const enforceAuthRateLimit = async (request: Request, scope: string, config: RateLimitConfig): Promise<void> => {
   const key = createRateLimitKey(scope, resolveClientIp(request));
-  const count = await redis.incr(key);
 
-  if (count === 1) {
-    await redis.expire(key, config.windowSeconds);
+  const created = await redis.set(key, 1, { nx: true, ex: config.windowSeconds });
+
+  let count = 1;
+
+  if (created !== 'OK') {
+    count = await redis.incr(key);
+
+    // SET と INCR の間でキーが失効していた場合の TTL 補填
+    if (count === 1) {
+      await redis.expire(key, config.windowSeconds);
+    }
   }
 
   if (count > config.limit) {

--- a/src/admin/src/server/rate-limit.ts
+++ b/src/admin/src/server/rate-limit.ts
@@ -1,0 +1,35 @@
+import { CLIENT_IP_HEADER } from './constants';
+import { ApiError } from './errors';
+import { redis } from './redis';
+
+type RateLimitConfig = {
+  limit: number;
+  windowSeconds: number;
+};
+
+const createRateLimitKey = (scope: string, clientIp: string): string => {
+  return `rate-limit:auth:${scope}:${clientIp}`;
+};
+
+const resolveClientIp = (request: Request): string => {
+  return request.headers.get(CLIENT_IP_HEADER) ?? 'unknown';
+};
+
+/**
+ * クライアント実 IP 単位の固定ウィンドウレート制限。
+ *
+ * 上限を超えた場合は 429 を投げる。Redis の INCR + EXPIRE で実装し、
+ * 複数インスタンス構成でもカウンタを共有する。
+ */
+export const enforceAuthRateLimit = async (request: Request, scope: string, config: RateLimitConfig): Promise<void> => {
+  const key = createRateLimitKey(scope, resolveClientIp(request));
+  const count = await redis.incr(key);
+
+  if (count === 1) {
+    await redis.expire(key, config.windowSeconds);
+  }
+
+  if (count > config.limit) {
+    throw new ApiError(429, {});
+  }
+};

--- a/src/admin/src/server/routes/auth.ts
+++ b/src/admin/src/server/routes/auth.ts
@@ -8,8 +8,9 @@ import {
 } from '../../generated';
 import type { LoginFinishRequest, RegisterFinishRequest } from '../../generated';
 import { client } from '../client';
-import { SESSION_TTL_SECONDS } from '../constants';
+import { AUTH_RATE_LIMITS, SESSION_TTL_SECONDS } from '../constants';
 import { resolveApiResponse } from '../errors';
+import { enforceAuthRateLimit } from '../rate-limit';
 import { storeSessionCredential } from '../session';
 
 const generateRandomBytes = (): string => {
@@ -50,6 +51,7 @@ export const auth = new Elysia({ prefix: '/auth' })
       return resolveApiResponse(await authenticateServiceLoginStart({ client: client, body: { email } }));
     },
     {
+      beforeHandle: ({ request }) => enforceAuthRateLimit(request, 'login/start', AUTH_RATE_LIMITS.loginStart),
       body: t.Object({
         email: t.String(),
       }),
@@ -71,6 +73,7 @@ export const auth = new Elysia({ prefix: '/auth' })
       await setAuthCookies(session, csrf, sessionId, csrfToken);
     },
     {
+      beforeHandle: ({ request }) => enforceAuthRateLimit(request, 'login/finish', AUTH_RATE_LIMITS.loginFinish),
       body: t.Object({
         authCeremonyId: t.String(),
         credential: webAuthnCredentialSchema,
@@ -85,6 +88,7 @@ export const auth = new Elysia({ prefix: '/auth' })
       );
     },
     {
+      beforeHandle: ({ request }) => enforceAuthRateLimit(request, 'register/start', AUTH_RATE_LIMITS.registerStart),
       body: t.Object({
         token: t.String(),
         email: t.String(),
@@ -108,6 +112,7 @@ export const auth = new Elysia({ prefix: '/auth' })
       await setAuthCookies(session, csrf, sessionId, csrfToken);
     },
     {
+      beforeHandle: ({ request }) => enforceAuthRateLimit(request, 'register/finish', AUTH_RATE_LIMITS.registerFinish),
       body: t.Object({
         authCeremonyId: t.String(),
         token: t.String(),

--- a/src/server/app/Providers/AppServiceProvider.php
+++ b/src/server/app/Providers/AppServiceProvider.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace App\Providers;
 
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\ServiceProvider;
 
@@ -14,5 +17,51 @@ class AppServiceProvider extends ServiceProvider
         $url = config()->string('app.url');
 
         URL::forceScheme(str_starts_with($url, 'https') ? 'https' : 'http');
+
+        $this->registerPasskeyRateLimiters();
+    }
+
+    /**
+     * 認証系エンドポイントのレート制限。
+     *
+     * BFF 経由だと送信元 IP が単一に集約されるため、IP ではなく
+     * メール / ceremony / refresh token といった資源キーで絞る。
+     */
+    private function registerPasskeyRateLimiters(): void
+    {
+        RateLimiter::for(
+            'passkey-login-start',
+            fn (Request $request): Limit => $this->limit('login')->by('login-start:' . $this->emailKey($request)),
+        );
+
+        RateLimiter::for(
+            'passkey-login-finish',
+            fn (Request $request): Limit => $this->limit('login')->by('login-finish:' . $request->string('authCeremonyId')->toString()),
+        );
+
+        RateLimiter::for(
+            'passkey-register-start',
+            fn (Request $request): Limit => $this->limit('register')->by('register-start:' . $this->emailKey($request)),
+        );
+
+        RateLimiter::for(
+            'passkey-register-finish',
+            fn (Request $request): Limit => $this->limit('register')->by('register-finish:' . $request->string('authCeremonyId')->toString()),
+        );
+
+        RateLimiter::for(
+            'passkey-refresh',
+            fn (Request $request): Limit => $this->limit('refresh')->by('refresh:' . $request->string('refreshTokenId')->toString()),
+        );
+    }
+
+    private function limit(string $name): Limit
+    {
+        return Limit::perMinute(config()->integer('auth.passkey.rate_limit.' . $name));
+    }
+
+    private function emailKey(Request $request): string
+    {
+        return $request->string('email')->lower()->trim()->toString();
     }
 }

--- a/src/server/app/Providers/AppServiceProvider.php
+++ b/src/server/app/Providers/AppServiceProvider.php
@@ -24,8 +24,20 @@ class AppServiceProvider extends ServiceProvider
     /**
      * 認証系エンドポイントのレート制限。
      *
-     * BFF 経由だと送信元 IP が単一に集約されるため、IP ではなく
-     * メール / ceremony / refresh token といった資源キーで絞る。
+     * BFF 経由だと送信元 IP が単一に集約されるため、IP ではなく攻撃者が
+     * 差し替えられない「標的の資源キー」で絞る。
+     *
+     * - start 系は標的アカウントの email をキーにする (攻撃者は被害者の email を
+     *   使わざるを得ないため有効)。
+     * - refresh は標的トークンの refreshTokenId をキーにする (secret 総当たりは
+     *   id を固定して試すしかなく、失敗時はトークン未消費なので上限が効く)。
+     *
+     * finish 系は ceremony が単回消費 (pull で削除) のため同一 id で叩き直せず、
+     * 認証自体も公開鍵暗号で守られるため throttle を持たない。finish への大量
+     * リクエスト (DoS) は公開境界である BFF 側の実 IP 単位制限で抑制する。
+     *
+     * email / authCeremonyId / refreshTokenId は OpenAPI スキーマで必須かつ
+     * 形式検証されるため、この limiter に到達する時点で空文字にはならない。
      */
     private function registerPasskeyRateLimiters(): void
     {
@@ -35,18 +47,8 @@ class AppServiceProvider extends ServiceProvider
         );
 
         RateLimiter::for(
-            'passkey-login-finish',
-            fn (Request $request): Limit => $this->limit('login')->by('login-finish:' . $request->string('authCeremonyId')->toString()),
-        );
-
-        RateLimiter::for(
             'passkey-register-start',
             fn (Request $request): Limit => $this->limit('register')->by('register-start:' . $this->emailKey($request)),
-        );
-
-        RateLimiter::for(
-            'passkey-register-finish',
-            fn (Request $request): Limit => $this->limit('register')->by('register-finish:' . $request->string('authCeremonyId')->toString()),
         );
 
         RateLimiter::for(

--- a/src/server/config/auth.php
+++ b/src/server/config/auth.php
@@ -129,5 +129,18 @@ return [
         'timeout_ms' => (int)env('AUTH_PASSKEY_TIMEOUT_MS', 60000),
         'ceremony_ttl_seconds' => (int)env('AUTH_PASSKEY_CEREMONY_TTL_SECONDS', 300),
         'ceremony_cache_store' => env('AUTH_PASSKEY_CEREMONY_CACHE_STORE', 'file'),
+
+        /*
+        | 認証系エンドポイントのレート制限 (1 分あたりの試行回数)
+        |
+        | API は通常 BFF 経由で呼ばれ送信元 IP が単一になるため、IP ではなく
+        | メールや ceremony / refresh token といった資源キーで制限する。
+        | 公開境界 (BFF) 側の IP 単位制限と合わせた多層防御の内側を担う。
+        */
+        'rate_limit' => [
+            'login' => (int)env('AUTH_PASSKEY_RATE_LIMIT_LOGIN', 10),
+            'register' => (int)env('AUTH_PASSKEY_RATE_LIMIT_REGISTER', 5),
+            'refresh' => (int)env('AUTH_PASSKEY_RATE_LIMIT_REFRESH', 30),
+        ],
     ],
 ];

--- a/src/server/routes/admin.php
+++ b/src/server/routes/admin.php
@@ -60,17 +60,21 @@ Route::middleware(AdminOpenApiValidator::class)->group(function () {
     Route::prefix('admin')->group(function () {
         Route::prefix('v1')->group(function () {
             Route::prefix('auth')->group(function () {
-                Route::post('/login/start', [LoginStartController::class, 'handle'])->name(AuthRouteMap::LoginStart);
-                Route::post('/login/finish', [LoginFinishController::class, 'handle'])->name(AuthRouteMap::LoginFinish);
-                Route::post('/refresh', [RefreshController::class, 'handle'])->name(AuthRouteMap::Refresh);
-                Route::post(
-                    '/register/start',
-                    [RegisterStartController::class, 'handle'],
-                )->name(AuthRouteMap::RegisterStart);
-                Route::post(
-                    '/register/finish',
-                    [RegisterFinishController::class, 'handle'],
-                )->name(AuthRouteMap::RegisterFinish);
+                Route::post('/login/start', [LoginStartController::class, 'handle'])
+                    ->middleware('throttle:passkey-login-start')
+                    ->name(AuthRouteMap::LoginStart);
+                Route::post('/login/finish', [LoginFinishController::class, 'handle'])
+                    ->middleware('throttle:passkey-login-finish')
+                    ->name(AuthRouteMap::LoginFinish);
+                Route::post('/refresh', [RefreshController::class, 'handle'])
+                    ->middleware('throttle:passkey-refresh')
+                    ->name(AuthRouteMap::Refresh);
+                Route::post('/register/start', [RegisterStartController::class, 'handle'])
+                    ->middleware('throttle:passkey-register-start')
+                    ->name(AuthRouteMap::RegisterStart);
+                Route::post('/register/finish', [RegisterFinishController::class, 'handle'])
+                    ->middleware('throttle:passkey-register-finish')
+                    ->name(AuthRouteMap::RegisterFinish);
             });
 
             Route::middleware(Authenticate::class)->group(function () {

--- a/src/server/routes/admin.php
+++ b/src/server/routes/admin.php
@@ -63,18 +63,14 @@ Route::middleware(AdminOpenApiValidator::class)->group(function () {
                 Route::post('/login/start', [LoginStartController::class, 'handle'])
                     ->middleware('throttle:passkey-login-start')
                     ->name(AuthRouteMap::LoginStart);
-                Route::post('/login/finish', [LoginFinishController::class, 'handle'])
-                    ->middleware('throttle:passkey-login-finish')
-                    ->name(AuthRouteMap::LoginFinish);
+                Route::post('/login/finish', [LoginFinishController::class, 'handle'])->name(AuthRouteMap::LoginFinish);
                 Route::post('/refresh', [RefreshController::class, 'handle'])
                     ->middleware('throttle:passkey-refresh')
                     ->name(AuthRouteMap::Refresh);
                 Route::post('/register/start', [RegisterStartController::class, 'handle'])
                     ->middleware('throttle:passkey-register-start')
                     ->name(AuthRouteMap::RegisterStart);
-                Route::post('/register/finish', [RegisterFinishController::class, 'handle'])
-                    ->middleware('throttle:passkey-register-finish')
-                    ->name(AuthRouteMap::RegisterFinish);
+                Route::post('/register/finish', [RegisterFinishController::class, 'handle'])->name(AuthRouteMap::RegisterFinish);
             });
 
             Route::middleware(Authenticate::class)->group(function () {

--- a/src/server/tests/Feature/Api/Admin/V1/Auth/LoginTest.php
+++ b/src/server/tests/Feature/Api/Admin/V1/Auth/LoginTest.php
@@ -95,6 +95,8 @@ class LoginTest extends DatabaseTestCase
     #[Test]
     public function startIsRateLimitedPerEmail(): void
     {
+        // レートリミッター用キャッシュが他テストから持ち越されないようにする
+        $this->app->make('cache')->flush();
         config()->set('auth.passkey.rate_limit.login', 2);
         $this->bindPasskeyAuthenticator();
 

--- a/src/server/tests/Feature/Api/Admin/V1/Auth/LoginTest.php
+++ b/src/server/tests/Feature/Api/Admin/V1/Auth/LoginTest.php
@@ -93,6 +93,25 @@ class LoginTest extends DatabaseTestCase
     }
 
     #[Test]
+    public function startIsRateLimitedPerEmail(): void
+    {
+        config()->set('auth.passkey.rate_limit.login', 2);
+        $this->bindPasskeyAuthenticator();
+
+        foreach (range(1, 2) as $ignored) {
+            $this->postJson(route(AuthRouteMap::LoginStart), [
+                'email' => 'throttle@example.com',
+            ])->assertStatus(401);
+        }
+
+        $this->postJson(route(AuthRouteMap::LoginStart), [
+            'email' => 'throttle@example.com',
+        ])->assertStatus(429);
+
+        $this->assertSame(0, AuthRefreshToken::query()->count());
+    }
+
+    #[Test]
     public function canFinishLoginAndUpdatesPasskeyAndAuditLog(): void
     {
         CarbonImmutable::setTestNow('2026-01-02 03:04:05');


### PR DESCRIPTION
## 概要

パスキー認証エンドポイントにレート制限を追加します。
BFF 側ではクライアント実 IP 単位、API 側では email / ceremony / refresh token 単位で過剰リクエストを抑制します。

## やったこと

- Astro で解決したクライアント実 IP を内部ヘッダーとして Elysia に渡すようにした
- 管理画面 BFF の login/register start/finish に Redis ベースの固定ウィンドウレート制限を追加した
- Laravel 側の passkey auth route に throttle middleware と設定値を追加した
- login start が email 単位で rate limit される feature test を追加した

## やってないこと

- WebAuthn origin / RP ID 設定の fail-fast 化
- ceremony cache や登録トークン取り扱いの改善

## 関連

- 特になし
