### PR TITLE
CSRF トークン比較を定数時間にする

### DIFF
--- a/src/admin/src/server/csrf.test.ts
+++ b/src/admin/src/server/csrf.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'bun:test';
+import { isCsrfTokenMatch } from './csrf';
+
+describe('isCsrfTokenMatch', () => {
+  it('一致するトークンで true を返す', () => {
+    expect(isCsrfTokenMatch('csrf-token-value', 'csrf-token-value')).toBe(true);
+  });
+
+  it('同じ長さの異なるトークンで false を返す', () => {
+    expect(isCsrfTokenMatch('csrf-token-aaaa', 'csrf-token-bbbb')).toBe(false);
+  });
+
+  it('長さの異なるトークンでも例外を投げず false を返す', () => {
+    expect(isCsrfTokenMatch('short', 'a-much-longer-csrf-token-value')).toBe(false);
+  });
+
+  it('空文字と非空文字で false を返す', () => {
+    expect(isCsrfTokenMatch('', 'non-empty')).toBe(false);
+  });
+});

--- a/src/admin/src/server/csrf.ts
+++ b/src/admin/src/server/csrf.ts
@@ -1,0 +1,14 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
+
+/**
+ * CSRF トークンを定数時間で比較する。
+ *
+ * 単純な `===` / `!==` は一致した先頭文字数に比例して処理時間が変わり、
+ * トークンを 1 文字ずつ推測されうる。長さの差による早期 return (長さオラクル) も
+ * 避けるため、固定長の SHA-256 ハッシュへ変換してから timingSafeEqual で比較する。
+ */
+export const isCsrfTokenMatch = (expected: string, actual: string): boolean => {
+  const hash = (value: string): Buffer => createHash('sha256').update(value).digest();
+
+  return timingSafeEqual(hash(expected), hash(actual));
+};

--- a/src/admin/src/server/middleware.ts
+++ b/src/admin/src/server/middleware.ts
@@ -1,4 +1,5 @@
 import { Elysia, t } from 'elysia';
+import { isCsrfTokenMatch } from './csrf';
 import { ApiError } from './errors';
 import {
   acquireSessionRefreshLock,
@@ -36,7 +37,7 @@ export const authGuard = new Elysia({ name: 'authGuard' })
       throw new ApiError(401, {});
     }
 
-    if (credential.csrfToken !== headers['x-csrf-token']) {
+    if (!isCsrfTokenMatch(credential.csrfToken, headers['x-csrf-token'])) {
       throw new ApiError(403, {});
     }
 

--- a/src/admin/src/server/routes/auth.test.ts
+++ b/src/admin/src/server/routes/auth.test.ts
@@ -138,7 +138,7 @@ describe('POST /auth/login/start', () => {
       email: 'user@example.com',
     });
     expect(response.headers.getSetCookie()).toHaveLength(0);
-    expect(Object.keys(credentials)).toHaveLength(0);
+    expect(Object.keys(credentials).filter(key => key.startsWith('session:'))).toHaveLength(0);
   });
 });
 
@@ -200,7 +200,7 @@ describe('POST /auth/login/finish', () => {
     );
 
     expect(response.status).toBe(401);
-    expect(Object.keys(credentials)).toHaveLength(0);
+    expect(Object.keys(credentials).filter(key => key.startsWith('session:'))).toHaveLength(0);
   });
 });
 
@@ -236,7 +236,7 @@ describe('POST /auth/register/start', () => {
       name: '新規ユーザー',
     });
     expect(response.headers.getSetCookie()).toHaveLength(0);
-    expect(Object.keys(credentials)).toHaveLength(0);
+    expect(Object.keys(credentials).filter(key => key.startsWith('session:'))).toHaveLength(0);
   });
 });
 
@@ -301,6 +301,6 @@ describe('POST /auth/register/finish', () => {
     );
 
     expect(response.status).toBe(400);
-    expect(Object.keys(credentials)).toHaveLength(0);
+    expect(Object.keys(credentials).filter(key => key.startsWith('session:'))).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## 概要

BFF のセッション認証で CSRF トークンを単純な `!==` で比較していたため、一致した先頭文字数に応じて処理時間が変わり、タイミング攻撃でトークンを推測されうる状態だった。定数時間比較に修正する。

## やったこと

- CSRF トークン比較を `isCsrfTokenMatch` (`server/csrf.ts`) に切り出し、固定長の SHA-256 ハッシュへ変換してから `timingSafeEqual` で比較。長さの差による早期 return (長さオラクル) も回避
- `authGuard` ミドルウェアの比較を `isCsrfTokenMatch` に置き換え
- `csrf.test.ts` で一致 / 同長不一致 / 長さ差 / 空文字 のケースを検証
- あわせて #773 のレート制限導入で壊れていた BFF テスト (`auth.test.ts`) を修正。モック redis の `set` がレート制限キーを保存するため、全キー件数で「セッション未保存」を検証していたアサーションが落ちていた。`session:` プレフィックスで絞るよう修正 (成功系テストと同様)

## やってないこと

- セッション ID 自体の比較 (cookie 値) は Redis のキー参照で存在確認しており、推測可能性は CSRF トークンと別問題のため対象外
- レート制限のモック redis を `incr`/`expire`/`nx` まで忠実化する変更 (現状の単発リクエストテストでは `set` が常に 'OK' を返し未到達のため不要)

## 検証

- BFF テスト全 18 件 green (CSRF 4 件追加、#773 回帰の 4 件修正を含む)
- admin lint:check green

## 関連

- #773 (パスキー認証エンドポイントのレート制限) のテスト回帰を本 PR で修正