### PR TITLE
WebAuthn の RP 設定を明示し origin を fail-fast 検証する

### DIFF
--- a/src/server/.env.example
+++ b/src/server/.env.example
@@ -73,3 +73,10 @@ ROOT_CA=/etc/ssl/certs/ca-certificates.crt
 
 AUTH_JWT_ALG=HS256
 AUTH_JWT_KEY=
+
+# Passkey (WebAuthn) の RP 設定。RP ID と origin は資格情報をドメインに束縛する
+# セキュリティの要のため、各環境で必ず正しい値を設定すること。
+# RP ID は origin のホスト名 (またはその登録可能な親ドメイン) と一致させる。
+AUTH_PASSKEY_RP_NAME=IsekaiObservatory
+AUTH_PASSKEY_RP_ID=local.admin.isekaijoucho.fan
+AUTH_PASSKEY_ORIGIN=https://local.admin.isekaijoucho.fan

--- a/src/server/packages/Auth/Infrastructures/PasskeyAuthenticator.php
+++ b/src/server/packages/Auth/Infrastructures/PasskeyAuthenticator.php
@@ -13,6 +13,7 @@ use Cose\Algorithms;
 use InvalidArgumentException;
 use Override;
 use ParagonIE\ConstantTime\Base64UrlSafe;
+use RuntimeException;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
@@ -55,6 +56,9 @@ readonly class PasskeyAuthenticator implements PasskeyAuthenticatorInterface
         string $displayName,
         array $excludePasskeys = [],
     ): PasskeyStartResult {
+        // origin 設定の不備をセレモニー開始時点で fail-fast する (finish 側は例外が握り潰されるため)
+        $this->host();
+
         $excludeCredentials = array_map(
             fn (AdminUserPasskey $passkey): PublicKeyCredentialDescriptor => $this->toDescriptor($passkey),
             $excludePasskeys,
@@ -138,6 +142,9 @@ readonly class PasskeyAuthenticator implements PasskeyAuthenticatorInterface
     #[Override]
     public function startAuthentication(array $passkeys): PasskeyStartResult
     {
+        // origin 設定の不備をセレモニー開始時点で fail-fast する (finish 側は例外が握り潰されるため)
+        $this->host();
+
         $descriptors = array_map($this->toDescriptor(...), $passkeys);
 
         $timeout = config('auth.passkey.timeout_ms');
@@ -250,6 +257,13 @@ readonly class PasskeyAuthenticator implements PasskeyAuthenticatorInterface
 
     private function host(): string
     {
-        return parse_url(config()->string('auth.passkey.origin'), PHP_URL_HOST) ?: '';
+        $origin = config()->string('auth.passkey.origin');
+        $host = parse_url($origin, PHP_URL_HOST);
+
+        if (! is_string($host) || $host === '') {
+            throw new RuntimeException(sprintf('auth.passkey.origin からホストを取得できません: [%s]', $origin));
+        }
+
+        return $host;
     }
 }

--- a/src/server/tests/Unit/Auth/Infrastructures/PasskeyAuthenticatorTest.php
+++ b/src/server/tests/Unit/Auth/Infrastructures/PasskeyAuthenticatorTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Auth\Infrastructures;
+
+use Auth\Domain\Services\PasskeyStartResult;
+use Auth\Infrastructures\PasskeyAuthenticator;
+use Auth\Infrastructures\PasskeyCredentialRecordConverter;
+use PHPUnit\Framework\Attributes\Test;
+use RuntimeException;
+use Tests\TestCase;
+
+class PasskeyAuthenticatorTest extends TestCase
+{
+    private function authenticator(): PasskeyAuthenticator
+    {
+        return new PasskeyAuthenticator(new PasskeyCredentialRecordConverter());
+    }
+
+    #[Test]
+    public function startAuthenticationFailsFastWhenOriginHasNoHost(): void
+    {
+        config()->set('auth.passkey.origin', 'not-a-valid-origin');
+
+        $this->expectException(RuntimeException::class);
+
+        $this->authenticator()->startAuthentication([]);
+    }
+
+    #[Test]
+    public function startRegistrationFailsFastWhenOriginHasNoHost(): void
+    {
+        config()->set('auth.passkey.origin', '');
+
+        $this->expectException(RuntimeException::class);
+
+        $this->authenticator()->startRegistration('user-handle', 'user@example.com', 'ユーザー');
+    }
+
+    #[Test]
+    public function startAuthenticationSucceedsWithValidOrigin(): void
+    {
+        config()->set([
+            'auth.passkey.origin' => 'https://admin.example.com',
+            'auth.passkey.rp_id' => 'admin.example.com',
+        ]);
+
+        $result = $this->authenticator()->startAuthentication([]);
+
+        $this->assertInstanceOf(PasskeyStartResult::class, $result);
+    }
+}


### PR DESCRIPTION
## 概要

RP ID / origin は資格情報をドメインに束縛する WebAuthn の要だが、`.env.example` に記載が無く既定値もローカル向け (`local.admin.isekaijoucho.fan`) のため、本番で env 未設定だと誤った RP ID / origin で動くフットガンになっていた。また origin から host を取得できない場合に空文字で処理が進み、誤設定が検知しづらかった。設定の明示と fail-fast 検証を入れる。

## やったこと

- `.env.example` に `AUTH_PASSKEY_RP_NAME` / `AUTH_PASSKEY_RP_ID` / `AUTH_PASSKEY_ORIGIN` を明示 (RP ID と origin ホストを一致させる旨のコメント付き)
- `PasskeyAuthenticator::host()` を、origin から host を取得できない場合に `RuntimeException` を投げるよう変更
- セレモニー開始 (`startRegistration` / `startAuthentication`) で origin 設定を早期検証。finish 側は UseCase の `catch (Throwable)` に握り潰され誤設定が静かな失敗になるため、例外が握り潰されない入口で fail-fast させる
- `PasskeyAuthenticatorTest` を追加 (不正 origin で fail-fast / 正常 origin で成功)

## やってないこと

- `auth.passkey.origins` の配列 (複数 origin) 対応 (現状単一 origin で要件を満たすため見送り)
- RP ID と origin ホストの「親子関係」整合チェック (RP ID は登録可能な親ドメインも許容され、単純一致では誤検知となるため見送り)

## 検証

- `api:ecs` / `api:phpstan` / `api:arkitect` green
- Auth Feature 19 件 + 新規 Unit 3 件 green

## 関連

- 当初のセキュリティレビュー (#1 レート制限 #773 / #3 共有ストア #774 / #4 CSRF #775) の続き