### PR TITLE
ログイン開始のユーザー列挙を防ぐ

### DIFF
--- a/src/server/packages/Auth/Application/Admin/UseCase/Login/LoginStartUseCase.php
+++ b/src/server/packages/Auth/Application/Admin/UseCase/Login/LoginStartUseCase.php
@@ -19,7 +19,6 @@ use Support\Contracts\Uuid\UuidGeneratorInterface;
 use Support\Domain\Error\DomainError;
 use Support\Domain\Error\DomainValidationError;
 use Support\Domain\Error\EntityRuleViolationError;
-use Support\UseCase\Error\AuthenticationError;
 use Support\UseCase\Error\InvalidInputError;
 use Support\UseCase\Error\UseCaseError;
 
@@ -45,27 +44,28 @@ readonly class LoginStartUseCase
             return new Err($this->handleError($emailResult->unwrapErr()));
         }
 
-        $adminUser = $this->adminUserRepository->findByEmail($emailResult->unwrap());
+        $email = $emailResult->unwrap();
+        $adminUser = $this->adminUserRepository->findByEmail($email);
+        $passkeys = is_null($adminUser)
+            ? []
+            : $this->passkeyRepository->findByAdminUserId($adminUser->adminUserId->value);
 
-        if (is_null($adminUser)) {
-            return new Err(new AuthenticationError());
-        }
-
-        $passkeys = $this->passkeyRepository->findByAdminUserId($adminUser->adminUserId->value);
-
-        if ($passkeys === []) {
-            return new Err(new AuthenticationError());
-        }
+        // ユーザー列挙を防ぐため、メールの実在やパスキー登録の有無に依らず常に同一形状の
+        // ceremony を返す。実在ユーザーのみ本物の adminUserId を束縛し、それ以外はダミーの
+        // adminUserId にすることで finish 時に必ず認証失敗となる (応答は区別できない)。
+        $adminUserId = is_null($adminUser) || $passkeys === []
+            ? $this->uuidGenerator->generate()
+            : $adminUser->adminUserId->value;
 
         $authCeremonyId = $this->uuidGenerator->generate();
-        $startResult = $this->passkeyAuthenticator->startAuthentication($passkeys);
+        $startResult = $this->passkeyAuthenticator->startAuthentication();
 
         $this->ceremonyStore->put(new PasskeyCeremonyState(
             $authCeremonyId,
             PasskeyCeremonyType::Login,
-            $adminUser->email->value,
+            $email->value,
             null,
-            $adminUser->adminUserId->value,
+            $adminUserId,
             $startResult->optionsJson,
         ));
 

--- a/src/server/packages/Auth/Domain/Services/PasskeyAuthenticatorInterface.php
+++ b/src/server/packages/Auth/Domain/Services/PasskeyAuthenticatorInterface.php
@@ -24,8 +24,9 @@ interface PasskeyAuthenticatorInterface
     public function finishRegistration(array $credential, string $optionsJson): PasskeyRegistrationResult;
 
     /**
-     * ユーザー列挙を防ぐため allowCredentials は含めない (discoverable credential を利用)。
-     * 入力メールの実在有無に依らず同一形状のオプションを返す。
+     * ユーザー列挙を防ぐため allowCredentials は空配列で返し資格情報を列挙しない
+     * (discoverable credential を利用)。入力メールの実在有無に依らず同一形状の
+     * オプションを返す。
      */
     public function startAuthentication(): PasskeyStartResult;
 

--- a/src/server/packages/Auth/Domain/Services/PasskeyAuthenticatorInterface.php
+++ b/src/server/packages/Auth/Domain/Services/PasskeyAuthenticatorInterface.php
@@ -24,9 +24,10 @@ interface PasskeyAuthenticatorInterface
     public function finishRegistration(array $credential, string $optionsJson): PasskeyRegistrationResult;
 
     /**
-     * @param list<AdminUserPasskey> $passkeys
+     * ユーザー列挙を防ぐため allowCredentials は含めない (discoverable credential を利用)。
+     * 入力メールの実在有無に依らず同一形状のオプションを返す。
      */
-    public function startAuthentication(array $passkeys): PasskeyStartResult;
+    public function startAuthentication(): PasskeyStartResult;
 
     /**
      * @param array<string, mixed> $credential

--- a/src/server/packages/Auth/Infrastructures/PasskeyAuthenticator.php
+++ b/src/server/packages/Auth/Infrastructures/PasskeyAuthenticator.php
@@ -136,23 +136,20 @@ readonly class PasskeyAuthenticator implements PasskeyAuthenticatorInterface
         );
     }
 
-    /**
-     * @param list<AdminUserPasskey> $passkeys
-     */
     #[Override]
-    public function startAuthentication(array $passkeys): PasskeyStartResult
+    public function startAuthentication(): PasskeyStartResult
     {
         // origin 設定の不備をセレモニー開始時点で fail-fast する (finish 側は例外が握り潰されるため)
         $this->host();
 
-        $descriptors = array_map($this->toDescriptor(...), $passkeys);
-
         $timeout = config('auth.passkey.timeout_ms');
 
+        // ユーザー列挙を防ぐため allowCredentials は空にする。登録時に residentKey を
+        // 必須にしているため、discoverable credential でログインが成立する。
         $options = PublicKeyCredentialRequestOptions::create(
             random_bytes(32),
             config()->string('auth.passkey.rp_id'),
-            $descriptors,
+            [],
             PublicKeyCredentialRequestOptions::USER_VERIFICATION_REQUIREMENT_REQUIRED,
             is_int($timeout) && $timeout > 0 ? $timeout : 60000,
         );

--- a/src/server/tests/Feature/Api/Admin/V1/Auth/LoginTest.php
+++ b/src/server/tests/Feature/Api/Admin/V1/Auth/LoginTest.php
@@ -56,8 +56,7 @@ class LoginTest extends DatabaseTestCase
             ->assertJson(
                 fn (AssertableJson $json) => $json->whereType('authCeremonyId', 'string')
                     ->where('publicKey.challenge', 'login-challenge')
-                    ->where('publicKey.allowCredentials.0.id', 'credential-id')
-                    ->where('publicKey.allowCredentials.0.transports', ['internal'])
+                    ->where('publicKey.allowCredentials', [])
                     ->etc(),
             );
 
@@ -66,20 +65,28 @@ class LoginTest extends DatabaseTestCase
     }
 
     #[Test]
-    public function startFailsWithUnknownEmail(): void
+    public function startReturnsUniformCeremonyForUnknownEmail(): void
     {
+        // ユーザー列挙を防ぐため、未登録メールでも登録済みと同一形状の 200 を返す
         $this->bindPasskeyAuthenticator();
 
         $this->postJson(route(AuthRouteMap::LoginStart), [
             'email' => 'unknown@example.com',
-        ])->assertStatus(401);
+        ])->assertStatus(200)
+            ->assertJson(
+                fn (AssertableJson $json) => $json->whereType('authCeremonyId', 'string')
+                    ->where('publicKey.challenge', 'login-challenge')
+                    ->where('publicKey.allowCredentials', [])
+                    ->etc(),
+            );
 
         $this->assertSame(0, AuthRefreshToken::query()->count());
     }
 
     #[Test]
-    public function startFailsWhenUserHasNoPasskey(): void
+    public function startReturnsUniformCeremonyWhenUserHasNoPasskey(): void
     {
+        // 登録済みでもパスキー未登録なら、未登録メールと区別できない 200 を返す
         $this->bindPasskeyAuthenticator();
         $this->app->make(AdminUserRepository::class)->register(
             $this->createAdminUser($this->generateUuid(), 'example@example.com'),
@@ -87,7 +94,13 @@ class LoginTest extends DatabaseTestCase
 
         $this->postJson(route(AuthRouteMap::LoginStart), [
             'email' => 'example@example.com',
-        ])->assertStatus(401);
+        ])->assertStatus(200)
+            ->assertJson(
+                fn (AssertableJson $json) => $json->whereType('authCeremonyId', 'string')
+                    ->where('publicKey.challenge', 'login-challenge')
+                    ->where('publicKey.allowCredentials', [])
+                    ->etc(),
+            );
 
         $this->assertSame(0, AuthRefreshToken::query()->count());
     }
@@ -103,7 +116,7 @@ class LoginTest extends DatabaseTestCase
         foreach (range(1, 2) as $ignored) {
             $this->postJson(route(AuthRouteMap::LoginStart), [
                 'email' => 'throttle@example.com',
-            ])->assertStatus(401);
+            ])->assertStatus(200);
         }
 
         $this->postJson(route(AuthRouteMap::LoginStart), [
@@ -146,6 +159,23 @@ class LoginTest extends DatabaseTestCase
         $this->assertIsArray($snapshot);
         $this->assertArrayHasKey('refresh_token_id', $snapshot);
         $this->assertArrayHasKey('admin_user_passkey_id', $snapshot);
+    }
+
+    #[Test]
+    public function finishFailsForUnknownEmailCeremonyWithoutAuthenticating(): void
+    {
+        // ダミー ceremony では認証できない (列挙対策が認証バイパスを生まないこと)
+        $this->bindPasskeyAuthenticator();
+
+        $authCeremonyId = $this->startLogin('unknown@example.com');
+
+        $this->postJson(route(AuthRouteMap::LoginFinish), [
+            'authCeremonyId' => $authCeremonyId,
+            'credential' => ['id' => 'credential-id'],
+        ])->assertStatus(401);
+
+        $this->assertSame(0, AuthRefreshToken::query()->count());
+        $this->assertAuditLogCount(0);
     }
 
     #[Test]
@@ -299,15 +329,11 @@ class LoginTest extends DatabaseTestCase
                 throw new RuntimeException('unused');
             }
 
-            public function startAuthentication(array $passkeys): PasskeyStartResult
+            public function startAuthentication(): PasskeyStartResult
             {
-                /** @var list<AdminUserPasskey> $passkeys */
                 return new PasskeyStartResult('{"challenge":"login-challenge"}', [
                     'challenge' => 'login-challenge',
-                    'allowCredentials' => array_map(
-                        fn (AdminUserPasskey $passkey): array => ['type' => 'public-key', 'id' => $passkey->credentialId, 'transports' => $passkey->transports],
-                        $passkeys,
-                    ),
+                    'allowCredentials' => [],
                 ]);
             }
 

--- a/src/server/tests/Feature/Api/Admin/V1/Auth/RegisterFinishTest.php
+++ b/src/server/tests/Feature/Api/Admin/V1/Auth/RegisterFinishTest.php
@@ -166,7 +166,7 @@ class RegisterFinishTest extends DatabaseTestCase
                 return new PasskeyRegistrationResult('credential-id', 'public-key', 'user-handle', '00000000-0000-0000-0000-000000000000', ['internal'], true, false, 123);
             }
 
-            public function startAuthentication(array $passkeys): PasskeyStartResult
+            public function startAuthentication(): PasskeyStartResult
             {
                 throw new RuntimeException('unused');
             }

--- a/src/server/tests/Feature/Api/Admin/V1/Auth/RegisterStartTest.php
+++ b/src/server/tests/Feature/Api/Admin/V1/Auth/RegisterStartTest.php
@@ -126,7 +126,7 @@ class RegisterStartTest extends DatabaseTestCase
                 throw new RuntimeException('unused');
             }
 
-            public function startAuthentication(array $passkeys): PasskeyStartResult
+            public function startAuthentication(): PasskeyStartResult
             {
                 throw new RuntimeException('unused');
             }

--- a/src/server/tests/Unit/Auth/Infrastructures/PasskeyAuthenticatorTest.php
+++ b/src/server/tests/Unit/Auth/Infrastructures/PasskeyAuthenticatorTest.php
@@ -25,7 +25,7 @@ class PasskeyAuthenticatorTest extends TestCase
 
         $this->expectException(RuntimeException::class);
 
-        $this->authenticator()->startAuthentication([]);
+        $this->authenticator()->startAuthentication();
     }
 
     #[Test]
@@ -46,7 +46,7 @@ class PasskeyAuthenticatorTest extends TestCase
             'auth.passkey.rp_id' => 'admin.example.com',
         ]);
 
-        $result = $this->authenticator()->startAuthentication([]);
+        $result = $this->authenticator()->startAuthentication();
 
         $this->assertInstanceOf(PasskeyStartResult::class, $result);
     }


### PR DESCRIPTION
## 概要

`login/start` がメールの実在有無で `200` / `401` を返し分け、さらに実在ユーザーのレスポンスには `allowCredentials` として資格情報 ID が列挙されていたため、登録済み管理者メールを外部から判別できる状態だった (ユーザー列挙)。実在有無に依らず応答を完全に均一化して緩和する。

## やったこと

- 実在 / 非実在・パスキー登録有無に依らず、常に同一形状の `200` ceremony を返すようにした。実在ユーザーのみ本物の `adminUserId` を ceremony に束縛し、それ以外はダミーの `adminUserId` にすることで finish 時に必ず認証失敗となる (start / finish いずれの応答も区別できない)
- `startAuthentication` から `allowCredentials` を外した。登録時に `residentKey` を必須にしているため discoverable credential でログインが成立し、未認証の相手に資格情報 ID を開示しなくなる (プライバシー面の改善も兼ねる)
- 引数 `$passkeys` が不要になったため `startAuthentication()` に簡素化 (インターフェースも更新)
- 列挙対策が認証バイパスを生まないこと (ダミー ceremony では認証できないこと) を検証するテストを追加。既存テストも均一応答に合わせて更新

## やってないこと

- タイミング差の完全な平準化 (実在パスは DB ヒットで処理時間が変わりうるが、レスポンス形状オラクルに比べ攻撃難度が高く「緩和」の範囲外。レート制限済み)
- ログインフローの大幅な再設計 (email-first の導線は維持。allowCredentials 省略により内部的に discoverable credential を使う形になるが、フロントは契約変更なしで動作)

## 検証

- `api:ecs` / `api:phpstan` / `api:arkitect` green
- 全テスト 481 passed / 3 skipped (列挙均一化・認証バイパス無しの新規テスト含む)

## 関連

- 当初セキュリティレビューの #2 (ユーザー列挙)。#1 レート制限 (#773) と合わせて緩和