### PR TITLE
passkey 設定を PasskeyConfig の DI に置き換える

### DIFF
--- a/src/server/app/Providers/Domain/AuthServiceProvider.php
+++ b/src/server/app/Providers/Domain/AuthServiceProvider.php
@@ -11,6 +11,7 @@ use Auth\Domain\Models\PasskeyCeremonyStoreInterface;
 use Auth\Domain\Models\Token\AccessToken\AccessTokenFactoryInterface;
 use Auth\Domain\Models\Token\RefreshToken\RefreshTokenRepositoryInterface;
 use Auth\Domain\Services\PasskeyAuthenticatorInterface;
+use Auth\Domain\Services\PasskeyConfig;
 use Auth\Domain\Services\PasskeyUserHandleGeneratorInterface;
 use Auth\Domain\Services\Token\AccessToken\JwtConfig;
 use Auth\Domain\Services\Token\AccessToken\JwtHandlerInterface;
@@ -58,6 +59,18 @@ class AuthServiceProvider extends ServiceProvider
                 config()->string('auth.jwt.alg'),
                 config()->string('auth.jwt.key'),
                 config()->string('app.url'),
+            ),
+        );
+
+        $this->app->bind(
+            PasskeyConfig::class,
+            fn (): PasskeyConfig => new PasskeyConfig(
+                config()->string('auth.passkey.rp_name'),
+                config()->string('auth.passkey.rp_id'),
+                config()->string('auth.passkey.origin'),
+                config()->integer('auth.passkey.timeout_ms', 60000),
+                config()->integer('auth.passkey.ceremony_ttl_seconds', 300),
+                config()->string('auth.passkey.ceremony_cache_store'),
             ),
         );
     }

--- a/src/server/packages/Auth/Domain/Services/PasskeyConfig.php
+++ b/src/server/packages/Auth/Domain/Services/PasskeyConfig.php
@@ -6,13 +6,25 @@ namespace Auth\Domain\Services;
 
 class PasskeyConfig
 {
+    private const int DEFAULT_TIMEOUT_MS = 60000;
+
     public function __construct(
         public readonly string $rpName,
         public readonly string $rpId,
         public readonly string $origin,
-        public readonly int $timeoutMs,
+        private readonly int $timeoutMs,
         public readonly int $ceremonyTtlSeconds,
         public readonly string $ceremonyCacheStore,
     ) {
+    }
+
+    /**
+     * 不正値 (0 以下) の場合は既定値にフォールバックする。
+     *
+     * @return int<1, max>
+     */
+    public function timeoutMs(): int
+    {
+        return $this->timeoutMs > 0 ? $this->timeoutMs : self::DEFAULT_TIMEOUT_MS;
     }
 }

--- a/src/server/packages/Auth/Domain/Services/PasskeyConfig.php
+++ b/src/server/packages/Auth/Domain/Services/PasskeyConfig.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth\Domain\Services;
+
+class PasskeyConfig
+{
+    public function __construct(
+        public readonly string $rpName,
+        public readonly string $rpId,
+        public readonly string $origin,
+        public readonly int $timeoutMs,
+        public readonly int $ceremonyTtlSeconds,
+        public readonly string $ceremonyCacheStore,
+    ) {
+    }
+}

--- a/src/server/packages/Auth/Infrastructures/PasskeyAuthenticator.php
+++ b/src/server/packages/Auth/Infrastructures/PasskeyAuthenticator.php
@@ -83,7 +83,7 @@ readonly class PasskeyAuthenticator implements PasskeyAuthenticatorInterface
             ),
             PublicKeyCredentialCreationOptions::ATTESTATION_CONVEYANCE_PREFERENCE_NONE,
             $excludeCredentials,
-            $this->timeoutMs(),
+            $this->config->timeoutMs(),
         );
 
         /** @var array<string, mixed> $publicKey */
@@ -150,7 +150,7 @@ readonly class PasskeyAuthenticator implements PasskeyAuthenticatorInterface
             $this->config->rpId,
             [],
             PublicKeyCredentialRequestOptions::USER_VERIFICATION_REQUIREMENT_REQUIRED,
-            $this->timeoutMs(),
+            $this->config->timeoutMs(),
         );
 
         /** @var array<string, mixed> $publicKey */
@@ -249,14 +249,6 @@ readonly class PasskeyAuthenticator implements PasskeyAuthenticatorInterface
             $passkey->credentialId,
             $passkey->transports,
         );
-    }
-
-    /**
-     * @return int<1, max>
-     */
-    private function timeoutMs(): int
-    {
-        return $this->config->timeoutMs > 0 ? $this->config->timeoutMs : 60000;
     }
 
     private function host(): string

--- a/src/server/packages/Auth/Infrastructures/PasskeyAuthenticator.php
+++ b/src/server/packages/Auth/Infrastructures/PasskeyAuthenticator.php
@@ -7,6 +7,7 @@ namespace Auth\Infrastructures;
 use Auth\Domain\Models\AdminUserPasskey;
 use Auth\Domain\Services\PasskeyAuthenticationResult;
 use Auth\Domain\Services\PasskeyAuthenticatorInterface;
+use Auth\Domain\Services\PasskeyConfig;
 use Auth\Domain\Services\PasskeyRegistrationResult;
 use Auth\Domain\Services\PasskeyStartResult;
 use Cose\Algorithms;
@@ -39,8 +40,10 @@ readonly class PasskeyAuthenticator implements PasskeyAuthenticatorInterface
 {
     private DenormalizerInterface&NormalizerInterface&Serializer $serializer;
 
-    public function __construct(private PasskeyCredentialRecordConverter $credentialRecordConverter)
-    {
+    public function __construct(
+        private PasskeyCredentialRecordConverter $credentialRecordConverter,
+        private PasskeyConfig $config,
+    ) {
         $serializer = new WebauthnSerializerFactory(AttestationStatementSupportManager::create())->create();
         assert($serializer instanceof Serializer);
         $this->serializer = $serializer;
@@ -63,12 +66,10 @@ readonly class PasskeyAuthenticator implements PasskeyAuthenticatorInterface
             fn (AdminUserPasskey $passkey): PublicKeyCredentialDescriptor => $this->toDescriptor($passkey),
             $excludePasskeys,
         );
-        $timeout = config('auth.passkey.timeout_ms');
-
         $options = PublicKeyCredentialCreationOptions::create(
             PublicKeyCredentialRpEntity::create(
-                config()->string('auth.passkey.rp_name'),
-                config()->string('auth.passkey.rp_id'),
+                $this->config->rpName,
+                $this->config->rpId,
             ),
             PublicKeyCredentialUserEntity::create($userName, $userHandle, $displayName),
             random_bytes(32),
@@ -82,7 +83,7 @@ readonly class PasskeyAuthenticator implements PasskeyAuthenticatorInterface
             ),
             PublicKeyCredentialCreationOptions::ATTESTATION_CONVEYANCE_PREFERENCE_NONE,
             $excludeCredentials,
-            is_int($timeout) && $timeout > 0 ? $timeout : 60000,
+            $this->timeoutMs(),
         );
 
         /** @var array<string, mixed> $publicKey */
@@ -115,7 +116,7 @@ readonly class PasskeyAuthenticator implements PasskeyAuthenticatorInterface
         );
 
         $factory = new CeremonyStepManagerFactory();
-        $factory->setAllowedOrigins([config()->string('auth.passkey.origin')]);
+        $factory->setAllowedOrigins([$this->config->origin]);
 
         $credentialRecord = AuthenticatorAttestationResponseValidator::create($factory->creationCeremony())
             ->check($response, $options, $this->host());
@@ -142,16 +143,14 @@ readonly class PasskeyAuthenticator implements PasskeyAuthenticatorInterface
         // origin 設定の不備をセレモニー開始時点で fail-fast する (finish 側は例外が握り潰されるため)
         $this->host();
 
-        $timeout = config('auth.passkey.timeout_ms');
-
         // ユーザー列挙を防ぐため allowCredentials は空にする。登録時に residentKey を
         // 必須にしているため、discoverable credential でログインが成立する。
         $options = PublicKeyCredentialRequestOptions::create(
             random_bytes(32),
-            config()->string('auth.passkey.rp_id'),
+            $this->config->rpId,
             [],
             PublicKeyCredentialRequestOptions::USER_VERIFICATION_REQUIREMENT_REQUIRED,
-            is_int($timeout) && $timeout > 0 ? $timeout : 60000,
+            $this->timeoutMs(),
         );
 
         /** @var array<string, mixed> $publicKey */
@@ -213,7 +212,7 @@ readonly class PasskeyAuthenticator implements PasskeyAuthenticatorInterface
         );
 
         $factory = new CeremonyStepManagerFactory();
-        $factory->setAllowedOrigins([config()->string('auth.passkey.origin')]);
+        $factory->setAllowedOrigins([$this->config->origin]);
 
         $credentialRecord = AuthenticatorAssertionResponseValidator::create($factory->requestCeremony())
             ->check(
@@ -252,13 +251,20 @@ readonly class PasskeyAuthenticator implements PasskeyAuthenticatorInterface
         );
     }
 
+    /**
+     * @return int<1, max>
+     */
+    private function timeoutMs(): int
+    {
+        return $this->config->timeoutMs > 0 ? $this->config->timeoutMs : 60000;
+    }
+
     private function host(): string
     {
-        $origin = config()->string('auth.passkey.origin');
-        $host = parse_url($origin, PHP_URL_HOST);
+        $host = parse_url($this->config->origin, PHP_URL_HOST);
 
         if (! is_string($host) || $host === '') {
-            throw new RuntimeException(sprintf('auth.passkey.origin からホストを取得できません: [%s]', $origin));
+            throw new RuntimeException(sprintf('auth.passkey.origin からホストを取得できません: [%s]', $this->config->origin));
         }
 
         return $host;

--- a/src/server/packages/Auth/Infrastructures/PasskeyCeremonyStore.php
+++ b/src/server/packages/Auth/Infrastructures/PasskeyCeremonyStore.php
@@ -6,6 +6,7 @@ namespace Auth\Infrastructures;
 
 use Auth\Domain\Models\PasskeyCeremonyState;
 use Auth\Domain\Models\PasskeyCeremonyStoreInterface;
+use Auth\Domain\Services\PasskeyConfig;
 use Illuminate\Cache\Repository;
 use Illuminate\Contracts\Cache\Factory as CacheFactory;
 use Illuminate\Contracts\Cache\LockTimeoutException;
@@ -13,20 +14,21 @@ use Override;
 
 readonly class PasskeyCeremonyStore implements PasskeyCeremonyStoreInterface
 {
-    public function __construct(private CacheFactory $cache)
-    {
+    public function __construct(
+        private CacheFactory $cache,
+        private PasskeyConfig $config,
+    ) {
     }
 
     #[Override]
     public function put(PasskeyCeremonyState $state): void
     {
-        $ttl = config()->integer('auth.passkey.ceremony_ttl_seconds', 300);
         $store = $this->store();
 
         $store->put(
             $this->key($state->authCeremonyId),
             $state->toArray(),
-            $ttl,
+            $this->config->ceremonyTtlSeconds,
         );
     }
 
@@ -75,7 +77,7 @@ readonly class PasskeyCeremonyStore implements PasskeyCeremonyStoreInterface
 
     private function store(): Repository
     {
-        $store = $this->cache->store(config()->string('auth.passkey.ceremony_cache_store'));
+        $store = $this->cache->store($this->config->ceremonyCacheStore);
         assert($store instanceof Repository);
 
         return $store;

--- a/src/server/tests/Unit/Auth/Infrastructures/PasskeyAuthenticatorTest.php
+++ b/src/server/tests/Unit/Auth/Infrastructures/PasskeyAuthenticatorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Auth\Infrastructures;
 
+use Auth\Domain\Services\PasskeyConfig;
 use Auth\Domain\Services\PasskeyStartResult;
 use Auth\Infrastructures\PasskeyAuthenticator;
 use Auth\Infrastructures\PasskeyCredentialRecordConverter;
@@ -15,7 +16,8 @@ class PasskeyAuthenticatorTest extends TestCase
 {
     private function authenticator(): PasskeyAuthenticator
     {
-        return new PasskeyAuthenticator(new PasskeyCredentialRecordConverter());
+        // config() の上書きを反映するため、設定後に毎回コンテナから解決する
+        return new PasskeyAuthenticator(new PasskeyCredentialRecordConverter(), $this->app->make(PasskeyConfig::class));
     }
 
     #[Test]


### PR DESCRIPTION
## 概要

`PasskeyAuthenticator` / `PasskeyCeremonyStore` が `config()` グローバルヘルパーを直接参照していたため、設定アクセスを型付きの `PasskeyConfig` 値オブジェクトに集約して DI で注入する形にする。`config()` の参照は合成ルートである ServiceProvider に閉じ込める (既存の `JwtConfig` と同じパターン)。

## やったこと

- `PasskeyConfig` 値オブジェクトを追加 (`rpName` / `rpId` / `origin` / `timeoutMs` / `ceremonyTtlSeconds` / `ceremonyCacheStore`)
- `AuthServiceProvider` で `config()` から `PasskeyConfig` を構築して bind (JwtConfig と同じく transient bind なので、テストの `config()->set()` 上書きも次回解決時に反映される)
- `PasskeyAuthenticator` / `PasskeyCeremonyStore` を `PasskeyConfig` 注入に変更し、`config()` 参照を撤去 (`packages/Auth` から `config()` が消えた)
- `PasskeyAuthenticator` の timeout 既定値ロジックを `timeoutMs()` に集約
- 単体テストは `config()` 上書きを反映するため、設定後にコンテナから `PasskeyConfig` を解決するよう更新

## やってないこと

- ServiceProvider 内の `config()` 参照の撤去 (合成ルートでの設定読み取りは妥当なため対象外。JwtConfig も同じ)
- レート制限値 (`auth.passkey.rate_limit.*`) の集約 (AppServiceProvider の `RateLimiter::for` 内で読んでおり、これも合成ルートのため現状維持)

## 検証

- `api:ecs` / `api:phpstan` / `api:arkitect` green
- 全テスト 481 passed / 3 skipped