### PR TITLE
管理画面に認証 middleware を追加

### DIFF
--- a/src/admin/src/middleware.ts
+++ b/src/admin/src/middleware.ts
@@ -1,0 +1,41 @@
+import type { APIContext, MiddlewareHandler, MiddlewareNext } from 'astro';
+import { defineMiddleware } from 'astro:middleware';
+import { getSessionCredential } from './server/session';
+import { createLoginRedirectPath, isAuthRequiredPath } from './utils/auth-redirect';
+
+type AdminMiddlewareProps = Record<string, unknown>;
+type AdminMiddlewareParams = Record<string, string | undefined>;
+type AdminMiddlewareContext = APIContext<AdminMiddlewareProps, AdminMiddlewareParams>;
+type AstroCookies = AdminMiddlewareContext['cookies'];
+
+const AUTH_COOKIE_NAMES = ['session', 'csrf'] as const satisfies readonly string[];
+
+const clearAuthCookies = (cookies: AstroCookies): void => {
+  for (const cookieName of AUTH_COOKIE_NAMES) {
+    cookies.delete(cookieName, { path: '/' });
+  }
+};
+
+const requireAuth: MiddlewareHandler = async (
+  context: AdminMiddlewareContext,
+  next: MiddlewareNext,
+): Promise<Response> => {
+  const { pathname, search } = context.url;
+
+  if (!isAuthRequiredPath(pathname)) {
+    return next();
+  }
+
+  const sessionId = context.cookies.get('session')?.value;
+  const credential = sessionId ? await getSessionCredential(sessionId) : null;
+
+  if (credential) {
+    return next();
+  }
+
+  clearAuthCookies(context.cookies);
+
+  return context.redirect(createLoginRedirectPath(`${pathname}${search}`));
+};
+
+export const onRequest: MiddlewareHandler = defineMiddleware(requireAuth);

--- a/src/admin/src/utils/auth-redirect.test.ts
+++ b/src/admin/src/utils/auth-redirect.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'bun:test';
-import { DEFAULT_AUTH_RETURN_TO, resolveAuthReturnTo } from './auth-redirect';
+import {
+  createLoginRedirectPath,
+  DEFAULT_AUTH_RETURN_TO,
+  isAuthRequiredPath,
+  resolveAuthReturnTo,
+} from './auth-redirect';
 
 describe('resolveAuthReturnTo', () => {
   it('return_to がない場合は既定の遷移先を返す', () => {
@@ -14,5 +19,32 @@ describe('resolveAuthReturnTo', () => {
   it('外部 URL と protocol-relative URL は既定の遷移先へ丸める', () => {
     expect(resolveAuthReturnTo('https://example.com/songs')).toBe(DEFAULT_AUTH_RETURN_TO);
     expect(resolveAuthReturnTo('//example.com/songs')).toBe(DEFAULT_AUTH_RETURN_TO);
+  });
+});
+
+describe('isAuthRequiredPath', () => {
+  it('管理画面のページは認証必須にする', () => {
+    expect(isAuthRequiredPath('/')).toBe(true);
+    expect(isAuthRequiredPath('/songs')).toBe(true);
+    expect(isAuthRequiredPath('/songs/1')).toBe(true);
+    expect(isAuthRequiredPath('/exports/songs.json')).toBe(true);
+  });
+
+  it('API、認証ページ、静的アセットは認証対象から外す', () => {
+    expect(isAuthRequiredPath('/api')).toBe(false);
+    expect(isAuthRequiredPath('/api/songs')).toBe(false);
+    expect(isAuthRequiredPath('/auth/login')).toBe(false);
+    expect(isAuthRequiredPath('/auth/recovery')).toBe(false);
+    expect(isAuthRequiredPath('/_astro/app.js')).toBe(false);
+    expect(isAuthRequiredPath('/favicon.svg')).toBe(false);
+  });
+});
+
+describe('createLoginRedirectPath', () => {
+  it('現在のパスとクエリを return_to に入れたログイン URL を返す', () => {
+    const redirectUrl = new URL(createLoginRedirectPath('/songs?keyword=a b'), 'https://admin.example.test');
+
+    expect(redirectUrl.pathname).toBe('/auth/login');
+    expect(redirectUrl.searchParams.get('return_to')).toBe('/songs?keyword=a b');
   });
 });

--- a/src/admin/src/utils/auth-redirect.ts
+++ b/src/admin/src/utils/auth-redirect.ts
@@ -1,4 +1,7 @@
 export const DEFAULT_AUTH_RETURN_TO = '/song-types';
+const PUBLIC_ROUTE_PREFIXES = ['/api/', '/auth/', '/_astro/'] as const satisfies readonly string[];
+const PUBLIC_ROUTE_PATHS = ['/api', '/auth', '/favicon.svg'] as const satisfies readonly string[];
+const PUBLIC_ROUTE_PATH_SET: ReadonlySet<string> = new Set(PUBLIC_ROUTE_PATHS);
 
 export const resolveAuthReturnTo = (returnTo: string | null | undefined): string => {
   const path = returnTo?.trim();
@@ -8,4 +11,24 @@ export const resolveAuthReturnTo = (returnTo: string | null | undefined): string
   }
 
   return path;
+};
+
+export const isAuthRequiredPath = (pathname: string): boolean => {
+  if (PUBLIC_ROUTE_PATH_SET.has(pathname)) {
+    return false;
+  }
+
+  if (PUBLIC_ROUTE_PREFIXES.some(prefix => pathname.startsWith(prefix))) {
+    return false;
+  }
+
+  return true;
+};
+
+export const createLoginRedirectPath = (returnTo: string): string => {
+  const searchParams = new URLSearchParams({
+    return_to: returnTo,
+  });
+
+  return `/auth/login?${searchParams.toString()}`;
 };


### PR DESCRIPTION
## 概要

管理画面のページアクセス時に session cookie を確認し、未認証の場合はログイン画面へ戻り先付きで遷移させます。

## やったこと

- Astro middleware で管理画面ページの認証必須化を追加
- API、認証ページ、Astro アセット、favicon を認証対象外にする公開パス判定を追加
- 未認証時に session / csrf cookie を削除し、現在パスを return_to に含めてログインへリダイレクト
- 認証リダイレクト utility のテストを追加

## やってないこと

- 特になし

## 関連

- 特になし