### PR TITLE
管理画面のデータ取得をクライアント側に統一

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -17,7 +17,7 @@ pre-commit:
     admin-lint:
       root: "src/admin/"
       glob: "src/**/*.{ts,tsx,js,jsx,mjs,astro}"
-      run: mise run admin:lint -- {staged_files}
+      run: mise run admin:lint
 
     admin-style:
       root: "src/admin/"

--- a/src/admin/src/components/admin-user/List.tsx
+++ b/src/admin/src/components/admin-user/List.tsx
@@ -1,0 +1,64 @@
+import { createResource, For, Match, Switch } from 'solid-js';
+import { client } from '../../utils/client';
+import { formatter } from '../../utils/date';
+import { ListState } from '../ListState';
+
+export const AdminUserList = () => {
+  const [data, { refetch }] = createResource(async () => {
+    const { data, status } = await client.api['admin-users'].get();
+
+    if (status === 401) {
+      window.location.href = '/auth/login';
+      return;
+    }
+
+    return data;
+  });
+
+  return (
+    <div class="rounded-box border border-base-300 bg-base-100 overflow-x-auto">
+      <table class="table table-zebra">
+        <thead>
+          <tr>
+            <th>名前</th>
+            <th>メールアドレス</th>
+            <th>役割</th>
+            <th>作成日</th>
+          </tr>
+        </thead>
+        <tbody>
+          <Switch>
+            <Match when={data.loading}>
+              <ListState state="loading" colSpan={4} />
+            </Match>
+            <Match when={!data()}>
+              <ListState
+                state="error"
+                colSpan={4}
+                message="データの取得に失敗しました。再度お試しください。"
+                onRetry={() => refetch()}
+              />
+            </Match>
+            <Match when={data() && data()!.adminUsers.length === 0}>
+              <ListState state="empty" colSpan={4} message="管理ユーザーはありません。" />
+            </Match>
+            <Match when={data()}>
+              {result => (
+                <For each={result().adminUsers}>
+                  {adminUser => (
+                    <tr>
+                      <td>{adminUser.name}</td>
+                      <td>{adminUser.email}</td>
+                      <td>{adminUser.role.name}</td>
+                      <td>{formatter.format(new Date(adminUser.createdAt))}</td>
+                    </tr>
+                  )}
+                </For>
+              )}
+            </Match>
+          </Switch>
+        </tbody>
+      </table>
+    </div>
+  );
+};

--- a/src/admin/src/components/media/CreateForm.tsx
+++ b/src/admin/src/components/media/CreateForm.tsx
@@ -1,0 +1,160 @@
+import { Show } from 'solid-js';
+import type { MediaFormatValue, MediaTypeValue } from '../../generated';
+import { client } from '../../utils/client';
+import { createFormErrors } from '../../utils/form-error';
+import { createSubmitting } from '../../utils/use-submitting';
+import { setFlash } from '../Flash';
+import { FormError } from '../FormError';
+
+const MEDIA_TYPE_OPTIONS: Array<{ value: MediaTypeValue; label: string }> = [
+  { value: 1, label: '動画' },
+  { value: 2, label: '記事' },
+  { value: 3, label: 'SNS投稿' },
+  { value: 4, label: '公式ページ' },
+  { value: 99, label: 'その他' },
+];
+
+const MEDIA_FORMAT_OPTIONS: Array<{ value: MediaFormatValue; label: string }> = [
+  { value: 1, label: 'MV' },
+  { value: 2, label: '音源動画' },
+  { value: 3, label: '配信アーカイブ' },
+  { value: 4, label: 'ショート動画' },
+  { value: 5, label: 'ライブ切り抜き' },
+  { value: 99, label: 'その他' },
+];
+
+const getListUrl = () => {
+  const back = new URLSearchParams(window.location.search).get('back') ?? '';
+
+  if (!back.startsWith('?')) {
+    return '/media';
+  }
+
+  try {
+    const query = new URLSearchParams(back.slice(1)).toString();
+    return query ? `/media?${query}` : '/media';
+  } catch {
+    return '/media';
+  }
+};
+
+export const CreateForm = () => {
+  const listUrl = getListUrl();
+  const { formError, getFieldError, clearErrors, handleError } = createFormErrors();
+  const { isSubmitting, withSubmitting } = createSubmitting();
+
+  const handleSubmit = withSubmitting(async (e: Event) => {
+    e.preventDefault();
+    clearErrors();
+
+    const form = e.currentTarget as HTMLFormElement;
+    const formData = new FormData(form);
+
+    const { data, error, status } = await client.api.media.post({
+      title: formData.get('title')?.toString() ?? '',
+      url: formData.get('url')?.toString() ?? '',
+      publishedAt: formData.get('publishedAt')?.toString() ?? '',
+      typeValue: Number(formData.get('typeValue')) as MediaTypeValue,
+      formatValue: Number(formData.get('formatValue')) as MediaFormatValue,
+      isDisplay: formData.get('isDisplay') === 'true',
+    });
+
+    if (data) {
+      setFlash('作成しました');
+      window.location.href = listUrl;
+      return;
+    }
+
+    handleError(status, error);
+  });
+
+  return (
+    <>
+      <a href={listUrl} class="btn btn-ghost btn-sm mb-4">
+        ← 一覧に戻る
+      </a>
+      <FormError message={formError()} onClose={clearErrors} />
+      <div class="max-w-4xl space-y-6">
+        <form onSubmit={handleSubmit}>
+          <fieldset class="fieldset bg-base-200 border-base-300 rounded-box border p-6">
+            <legend class="px-2 text-sm font-semibold text-base-content/70">基本情報</legend>
+            <label class="label">タイトル</label>
+            <input
+              type="text"
+              class="input w-full"
+              name="title"
+              required
+              classList={{ 'input-error': !!getFieldError('title') }}
+            />
+            <Show when={getFieldError('title')}>{message => <p class="mt-1 text-xs text-error">{message()}</p>}</Show>
+
+            <label class="label">URL</label>
+            <input
+              type="url"
+              class="input w-full"
+              name="url"
+              required
+              classList={{ 'input-error': !!getFieldError('url') }}
+            />
+            <Show when={getFieldError('url')}>{message => <p class="mt-1 text-xs text-error">{message()}</p>}</Show>
+
+            <label class="label">公開日</label>
+            <input
+              type="date"
+              class="input w-full"
+              name="publishedAt"
+              required
+              classList={{ 'input-error': !!getFieldError('publishedAt') }}
+            />
+            <Show when={getFieldError('publishedAt')}>{message => <p class="mt-1 text-xs text-error">{message()}</p>}</Show>
+
+            <div class="grid gap-4 md:grid-cols-2">
+              <div>
+                <label class="label">種別</label>
+                <select
+                  class="select w-full"
+                  name="typeValue"
+                  required
+                  classList={{ 'select-error': !!getFieldError('typeValue') }}
+                >
+                  {MEDIA_TYPE_OPTIONS.map(option => <option value={option.value}>{option.label}</option>)}
+                </select>
+                <Show when={getFieldError('typeValue')}>{message => <p class="mt-1 text-xs text-error">{message()}</p>}</Show>
+              </div>
+
+              <div>
+                <label class="label">形式</label>
+                <select
+                  class="select w-full"
+                  name="formatValue"
+                  required
+                  classList={{ 'select-error': !!getFieldError('formatValue') }}
+                >
+                  {MEDIA_FORMAT_OPTIONS.map(option => <option value={option.value}>{option.label}</option>)}
+                </select>
+                <Show when={getFieldError('formatValue')}>{message => <p class="mt-1 text-xs text-error">{message()}</p>}</Show>
+              </div>
+            </div>
+
+            <label class="label">表示設定</label>
+            <select
+              class="select w-full"
+              name="isDisplay"
+              classList={{ 'select-error': !!getFieldError('isDisplay') }}
+            >
+              <option value="true">表示する</option>
+              <option value="false">表示しない</option>
+            </select>
+            <Show when={getFieldError('isDisplay')}>{message => <p class="mt-1 text-xs text-error">{message()}</p>}</Show>
+
+            <div class="mt-6 flex justify-end">
+              <button class="btn btn-primary" disabled={isSubmitting()}>
+                {isSubmitting() ? '作成中...' : '作成'}
+              </button>
+            </div>
+          </fieldset>
+        </form>
+      </div>
+    </>
+  );
+};

--- a/src/admin/src/components/media/EditableForm.tsx
+++ b/src/admin/src/components/media/EditableForm.tsx
@@ -1,4 +1,4 @@
-import { Show, onMount } from 'solid-js';
+import { createResource, Match, Show, Switch } from 'solid-js';
 import type { Media, MediaFormatValue, MediaReferencedSong, MediaTypeValue } from '../../generated';
 import { client } from '../../utils/client';
 import { createFormErrors } from '../../utils/form-error';
@@ -23,30 +23,44 @@ const MEDIA_FORMAT_OPTIONS: Array<{ value: MediaFormatValue; label: string }> = 
   { value: 99, label: 'その他' },
 ];
 
-interface Props {
-  data?: { media: Media; songs: MediaReferencedSong[] };
-  status: number;
+interface DetailViewProps {
+  mediaId: string;
 }
 
-export const EditableForm = (props: Props) => {
-  const normalizeDateInputValue = (value: unknown): string => {
-    if (value instanceof Date) {
-      return Number.isNaN(value.getTime()) ? '' : value.toISOString().slice(0, 10);
-    }
+interface EditableFormProps {
+  data: { media: Media; songs: MediaReferencedSong[] };
+}
 
-    if (typeof value !== 'string') {
-      return '';
-    }
+interface FetchOkState {
+  status: 'ok';
+  data: { media: Media; songs: MediaReferencedSong[] };
+}
 
-    if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
-      return value;
-    }
+interface FetchErrorState {
+  status: 'error';
+}
 
-    const parsed = new Date(value);
+type FetchState = FetchOkState | FetchErrorState;
 
-    return Number.isNaN(parsed.getTime()) ? '' : parsed.toISOString().slice(0, 10);
-  };
+const normalizeDateInputValue = (value: unknown): string => {
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? '' : value.toISOString().slice(0, 10);
+  }
 
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return value;
+  }
+
+  const parsed = new Date(value);
+
+  return Number.isNaN(parsed.getTime()) ? '' : parsed.toISOString().slice(0, 10);
+};
+
+const getListUrl = () => {
   const back = new URLSearchParams(window.location.search).get('back') ?? '';
   const listQuery = (() => {
     if (!back.startsWith('?')) return '';
@@ -57,7 +71,68 @@ export const EditableForm = (props: Props) => {
       return '';
     }
   })();
-  const listUrl = `/media${listQuery}`;
+
+  return `/media${listQuery}`;
+};
+
+export const DetailView = (props: DetailViewProps) => {
+  const listUrl = getListUrl();
+
+  const [resource, { refetch }] = createResource(async (): Promise<FetchState> => {
+    const { data, status } = await client.api.media({ mediaId: props.mediaId }).get();
+
+    if (status === 401) {
+      window.location.href = '/auth/login';
+      return { status: 'error' };
+    }
+
+    if (status === 404) {
+      setFlash('データがありません', 'error');
+      window.location.href = listUrl;
+      return { status: 'error' };
+    }
+
+    if (status === 422) {
+      setFlash('不正なリクエストです', 'error');
+      window.location.href = listUrl;
+      return { status: 'error' };
+    }
+
+    if (!data) {
+      return { status: 'error' };
+    }
+
+    return { status: 'ok', data };
+  });
+
+  const loadedData = () => {
+    const state = resource();
+    return state?.status === 'ok' ? state.data : undefined;
+  };
+
+  return (
+    <Switch>
+      <Match when={resource.loading}>
+        <div class="flex items-center justify-center gap-3 py-10 text-base-content/70" role="status" aria-live="polite">
+          <span class="loading loading-spinner loading-md" aria-hidden="true" />
+          <span>読み込み中...</span>
+        </div>
+      </Match>
+      <Match when={resource()?.status === 'error'}>
+        <div class="flex flex-col items-start gap-3">
+          <p class="text-error">データの取得に失敗しました。</p>
+          <button type="button" class="btn btn-outline btn-sm" onClick={() => refetch()}>再試行</button>
+        </div>
+      </Match>
+      <Match when={loadedData()}>
+        {data => <EditableForm data={data()} />}
+      </Match>
+    </Switch>
+  );
+};
+
+const EditableForm = (props: EditableFormProps) => {
+  const listUrl = getListUrl();
 
   const { formError, setFormError, getFieldError, clearErrors, handleError } = createFormErrors();
   const { isSubmitting, withSubmitting } = createSubmitting();
@@ -73,7 +148,7 @@ export const EditableForm = (props: Props) => {
     const form = (e.target as HTMLButtonElement).form as HTMLFormElement;
     const formData = new FormData(form);
 
-    const mediaId = props.data?.media.mediaId;
+    const mediaId = props.data.media.mediaId;
 
     if (!mediaId) {
       setFormError('更新対象のメディアIDを取得できませんでした');
@@ -113,7 +188,7 @@ export const EditableForm = (props: Props) => {
 
     clearErrors();
 
-    const mediaId = props.data?.media.mediaId;
+    const mediaId = props.data.media.mediaId;
 
     if (!mediaId) {
       setFormError('削除対象のメディアIDを取得できませんでした');
@@ -131,20 +206,8 @@ export const EditableForm = (props: Props) => {
     window.location.href = listUrl;
   });
 
-  onMount(() => {
-    if (props.status === 404) {
-      setFlash('データがありません', 'error');
-      window.location.href = listUrl;
-    } else if (props.status === 422) {
-      setFlash('不正なリクエストです', 'error');
-      window.location.href = listUrl;
-    } else if (!props.data) {
-      setFormError('予期しないエラーが発生しました');
-    }
-  });
-
   return (
-    <Show when={props.data} fallback={<p>読み込み中...</p>}>
+    <>
       <a href={listUrl} class="btn btn-ghost btn-sm mb-4">
         ← 一覧に戻る
       </a>
@@ -158,7 +221,7 @@ export const EditableForm = (props: Props) => {
               type="text"
               class="input w-full"
               name="title"
-              value={props.data?.media.title}
+              value={props.data.media.title}
               classList={{ 'input-error': !!getFieldError('title') }}
             />
             <Show when={getFieldError('title')}>{message => <p class="mt-1 text-xs text-error">{message()}</p>}</Show>
@@ -168,7 +231,7 @@ export const EditableForm = (props: Props) => {
               type="url"
               class="input w-full"
               name="url"
-              value={props.data?.media.url}
+              value={props.data.media.url}
               classList={{ 'input-error': !!getFieldError('url') }}
             />
             <Show when={getFieldError('url')}>{message => <p class="mt-1 text-xs text-error">{message()}</p>}</Show>
@@ -178,7 +241,7 @@ export const EditableForm = (props: Props) => {
               type="date"
               class="input w-full"
               name="publishedAt"
-              value={normalizeDateInputValue(props.data?.media.publishedAt)}
+              value={normalizeDateInputValue(props.data.media.publishedAt)}
               required
               classList={{ 'input-error': !!getFieldError('publishedAt') }}
             />
@@ -190,7 +253,7 @@ export const EditableForm = (props: Props) => {
                 <select
                   class="select w-full"
                   name="typeValue"
-                  value={props.data?.media.type.value}
+                  value={props.data.media.type.value}
                   classList={{ 'select-error': !!getFieldError('typeValue') }}
                 >
                   {MEDIA_TYPE_OPTIONS.map(option => <option value={option.value}>{option.label}</option>)}
@@ -203,7 +266,7 @@ export const EditableForm = (props: Props) => {
                 <select
                   class="select w-full"
                   name="formatValue"
-                  value={props.data?.media.format.value}
+                  value={props.data.media.format.value}
                   classList={{ 'select-error': !!getFieldError('formatValue') }}
                 >
                   {MEDIA_FORMAT_OPTIONS.map(option => <option value={option.value}>{option.label}</option>)}
@@ -216,7 +279,7 @@ export const EditableForm = (props: Props) => {
             <select
               class="select w-full"
               name="isDisplay"
-              value={String(props.data?.media.isDisplay)}
+              value={String(props.data.media.isDisplay)}
               classList={{ 'select-error': !!getFieldError('isDisplay') }}
             >
               <option value="true">表示する</option>
@@ -235,7 +298,7 @@ export const EditableForm = (props: Props) => {
         <fieldset class="fieldset bg-base-200 border-base-300 rounded-box border p-6">
           <legend class="px-2 text-sm font-semibold text-base-content/70">参照中の楽曲</legend>
           <Show
-            when={(props.data?.songs.length ?? 0) > 0}
+            when={props.data.songs.length > 0}
             fallback={<p class="text-sm text-base-content/60">参照中の楽曲はありません。</p>}
           >
             <div class="overflow-x-auto">
@@ -249,7 +312,7 @@ export const EditableForm = (props: Props) => {
                   </tr>
                 </thead>
                 <tbody>
-                  {props.data?.songs.map(song => (
+                  {props.data.songs.map(song => (
                     <tr>
                       <td>{song.title}</td>
                       <td>{song.songOrderNo}</td>
@@ -277,6 +340,6 @@ export const EditableForm = (props: Props) => {
           </div>
         </fieldset>
       </div>
-    </Show>
+    </>
   );
 };

--- a/src/admin/src/components/media/EditableForm.tsx
+++ b/src/admin/src/components/media/EditableForm.tsx
@@ -118,7 +118,7 @@ export const DetailView = (props: DetailViewProps) => {
           <span>読み込み中...</span>
         </div>
       </Match>
-      <Match when={resource()?.status === 'error'}>
+      <Match when={resource.error || resource()?.status === 'error'}>
         <div class="flex flex-col items-start gap-3">
           <p class="text-error">データの取得に失敗しました。</p>
           <button type="button" class="btn btn-outline btn-sm" onClick={() => refetch()}>再試行</button>

--- a/src/admin/src/components/media/SearchList.tsx
+++ b/src/admin/src/components/media/SearchList.tsx
@@ -239,9 +239,9 @@ export const SearchList = () => {
       </form>
 
       <div class="mb-4 flex justify-end">
-        <button type="button" class="btn btn-primary btn-sm" disabled>
+        <a href={`/media/create?back=${encodeURIComponent(window.location.search)}`} class="btn btn-primary btn-sm">
           新規作成
-        </button>
+        </a>
       </div>
 
       <div class="overflow-x-auto rounded-box border border-base-300 bg-base-100">

--- a/src/admin/src/components/person/EditableForm.tsx
+++ b/src/admin/src/components/person/EditableForm.tsx
@@ -1,4 +1,4 @@
-import { Show, onMount } from 'solid-js';
+import { createResource, Match, Show, Switch } from 'solid-js';
 import type { Person } from '../../generated';
 import { client } from '../../utils/client';
 import { createFormErrors } from '../../utils/form-error';
@@ -6,12 +6,26 @@ import { createSubmitting } from '../../utils/use-submitting';
 import { setFlash } from '../Flash';
 import { FormError } from '../FormError';
 
-interface Props {
-  data?: { person: Person };
-  status: number;
+interface DetailViewProps {
+  personId: string;
 }
 
-export const EditableForm = (props: Props) => {
+interface EditableFormProps {
+  data: { person: Person };
+}
+
+interface FetchOkState {
+  status: 'ok';
+  data: { person: Person };
+}
+
+interface FetchErrorState {
+  status: 'error';
+}
+
+type FetchState = FetchOkState | FetchErrorState;
+
+const getListUrl = () => {
   const back = new URLSearchParams(window.location.search).get('back') ?? '';
   const listQuery = (() => {
     if (!back.startsWith('?')) return '';
@@ -22,7 +36,68 @@ export const EditableForm = (props: Props) => {
       return '';
     }
   })();
-  const listUrl = `/persons${listQuery}`;
+
+  return `/persons${listQuery}`;
+};
+
+export const DetailView = (props: DetailViewProps) => {
+  const listUrl = getListUrl();
+
+  const [resource, { refetch }] = createResource(async (): Promise<FetchState> => {
+    const { data, status } = await client.api.persons({ personId: props.personId }).get();
+
+    if (status === 401) {
+      window.location.href = '/auth/login';
+      return { status: 'error' };
+    }
+
+    if (status === 404) {
+      setFlash('データがありません', 'error');
+      window.location.href = listUrl;
+      return { status: 'error' };
+    }
+
+    if (status === 422) {
+      setFlash('不正なリクエストです', 'error');
+      window.location.href = listUrl;
+      return { status: 'error' };
+    }
+
+    if (!data) {
+      return { status: 'error' };
+    }
+
+    return { status: 'ok', data };
+  });
+
+  const loadedData = () => {
+    const state = resource();
+    return state?.status === 'ok' ? state.data : undefined;
+  };
+
+  return (
+    <Switch>
+      <Match when={resource.loading}>
+        <div class="flex items-center justify-center gap-3 py-10 text-base-content/70" role="status" aria-live="polite">
+          <span class="loading loading-spinner loading-md" aria-hidden="true" />
+          <span>読み込み中...</span>
+        </div>
+      </Match>
+      <Match when={resource()?.status === 'error'}>
+        <div class="flex flex-col items-start gap-3">
+          <p class="text-error">データの取得に失敗しました。</p>
+          <button type="button" class="btn btn-outline btn-sm" onClick={() => refetch()}>再試行</button>
+        </div>
+      </Match>
+      <Match when={loadedData()}>
+        {data => <EditableForm data={data()} />}
+      </Match>
+    </Switch>
+  );
+};
+
+const EditableForm = (props: EditableFormProps) => {
+  const listUrl = getListUrl();
 
   const { formError, setFormError, getFieldError, clearErrors, handleError } = createFormErrors();
   const { isSubmitting, withSubmitting } = createSubmitting();
@@ -38,7 +113,7 @@ export const EditableForm = (props: Props) => {
     const form = (e.target as HTMLButtonElement).form as HTMLFormElement;
     const formData = new FormData(form);
 
-    const personId = props.data?.person.personId;
+    const personId = props.data.person.personId;
 
     if (!personId) {
       setFormError('更新対象の人物IDを取得できませんでした');
@@ -74,7 +149,7 @@ export const EditableForm = (props: Props) => {
 
     clearErrors();
 
-    const personId = props.data?.person.personId;
+    const personId = props.data.person.personId;
 
     if (!personId) {
       setFormError('削除対象の人物IDを取得できませんでした');
@@ -92,20 +167,8 @@ export const EditableForm = (props: Props) => {
     window.location.href = listUrl;
   });
 
-  onMount(() => {
-    if (props.status === 404) {
-      setFlash('データがありません', 'error');
-      window.location.href = listUrl;
-    } else if (props.status === 422) {
-      setFlash('不正なリクエストです', 'error');
-      window.location.href = listUrl;
-    } else if (!props.data) {
-      setFormError('予期しないエラーが発生しました');
-    }
-  });
-
   return (
-    <Show when={props.data} fallback={<p>読み込み中...</p>}>
+    <>
       <a href={listUrl} class="btn btn-ghost btn-sm mb-4">
         ← 一覧に戻る
       </a>
@@ -119,7 +182,7 @@ export const EditableForm = (props: Props) => {
               type="text"
               class="input w-full"
               name="name"
-              value={props.data?.person.name}
+              value={props.data.person.name}
               classList={{ 'input-error': !!getFieldError('name') }}
             />
             <Show when={getFieldError('name')}>{message => <p class="mt-1 text-xs text-error">{message()}</p>}</Show>
@@ -131,7 +194,7 @@ export const EditableForm = (props: Props) => {
               name="orderNo"
               required
               min="1"
-              value={props.data?.person.orderNo}
+              value={props.data.person.orderNo}
               classList={{ 'input-error': !!getFieldError('orderNo') }}
             />
             <Show when={getFieldError('orderNo')}>{message => <p class="mt-1 text-xs text-error">{message()}</p>}</Show>
@@ -154,6 +217,6 @@ export const EditableForm = (props: Props) => {
           </div>
         </fieldset>
       </div>
-    </Show>
+    </>
   );
 };

--- a/src/admin/src/components/person/EditableForm.tsx
+++ b/src/admin/src/components/person/EditableForm.tsx
@@ -83,7 +83,7 @@ export const DetailView = (props: DetailViewProps) => {
           <span>読み込み中...</span>
         </div>
       </Match>
-      <Match when={resource()?.status === 'error'}>
+      <Match when={resource.error || resource()?.status === 'error'}>
         <div class="flex flex-col items-start gap-3">
           <p class="text-error">データの取得に失敗しました。</p>
           <button type="button" class="btn btn-outline btn-sm" onClick={() => refetch()}>再試行</button>

--- a/src/admin/src/components/recovery-code/RecoveryCodesPanel.tsx
+++ b/src/admin/src/components/recovery-code/RecoveryCodesPanel.tsx
@@ -1,4 +1,4 @@
-import { createSignal, For, Show } from 'solid-js';
+import { createResource, createSignal, For, Match, Show, Switch } from 'solid-js';
 import { client } from '../../utils/client';
 import { createFormErrors } from '../../utils/form-error';
 import { createSubmitting } from '../../utils/use-submitting';
@@ -9,6 +9,17 @@ export const RecoveryCodesPanel = () => {
   const { formError, clearErrors, handleError } = createFormErrors();
   const { isSubmitting, withSubmitting } = createSubmitting();
   const [codes, setCodes] = createSignal<string[]>([]);
+
+  const [authCheck, { refetch }] = createResource(async () => {
+    const { status } = await client.api['admin-users'].get();
+
+    if (status === 401) {
+      window.location.href = '/auth/login';
+      return false;
+    }
+
+    return status === 200;
+  });
 
   const generate = withSubmitting(async () => {
     clearErrors();
@@ -41,37 +52,53 @@ export const RecoveryCodesPanel = () => {
   };
 
   return (
-    <div class="max-w-2xl space-y-6">
-      <FormError message={formError()} onClose={clearErrors} />
+    <Switch>
+      <Match when={authCheck.loading}>
+        <div class="flex items-center justify-center gap-3 py-10 text-base-content/70" role="status" aria-live="polite">
+          <span class="loading loading-spinner loading-md" aria-hidden="true" />
+          <span>読み込み中...</span>
+        </div>
+      </Match>
+      <Match when={authCheck() === false}>
+        <div class="flex flex-col items-start gap-3">
+          <p class="text-error">データの取得に失敗しました。</p>
+          <button type="button" class="btn btn-outline btn-sm" onClick={() => refetch()}>再試行</button>
+        </div>
+      </Match>
+      <Match when={authCheck() === true}>
+        <div class="max-w-2xl space-y-6">
+          <FormError message={formError()} onClose={clearErrors} />
 
-      <div class="rounded-box border border-base-300 bg-base-200 p-6">
-        <p class="text-sm text-base-content/70">
-          リカバリーコードはパスキーを紛失した際にアカウントへのアクセスを回復するためのワンタイムコードです。
-          発行すると既存のコードは無効になります。コードは発行時に一度だけ表示され、再表示はできません。安全な場所に保管してください。
-        </p>
-        <button class="btn btn-primary mt-4" disabled={isSubmitting()} onClick={generate}>
-          {isSubmitting() ? '発行中...' : 'リカバリーコードを発行/再生成'}
-        </button>
-      </div>
-
-      <Show when={codes().length > 0}>
-        <div class="rounded-box border border-base-300 bg-base-100 p-6">
-          <p class="mb-4 text-sm font-semibold text-warning">
-            このコードは再表示できません。今すぐコピーまたはダウンロードして保管してください。
-          </p>
-          <ul class="grid grid-cols-2 gap-2 font-mono text-sm">
-            <For each={codes()}>{code => <li class="rounded bg-base-200 px-3 py-2">{code}</li>}</For>
-          </ul>
-          <div class="mt-4 flex gap-2">
-            <button class="btn btn-sm" onClick={copyAll}>
-              コピー
-            </button>
-            <button class="btn btn-sm" onClick={download}>
-              ダウンロード
+          <div class="rounded-box border border-base-300 bg-base-200 p-6">
+            <p class="text-sm text-base-content/70">
+              リカバリーコードはパスキーを紛失した際にアカウントへのアクセスを回復するためのワンタイムコードです。
+              発行すると既存のコードは無効になります。コードは発行時に一度だけ表示され、再表示はできません。安全な場所に保管してください。
+            </p>
+            <button class="btn btn-primary mt-4" disabled={isSubmitting()} onClick={generate}>
+              {isSubmitting() ? '発行中...' : 'リカバリーコードを発行/再生成'}
             </button>
           </div>
+
+          <Show when={codes().length > 0}>
+            <div class="rounded-box border border-base-300 bg-base-100 p-6">
+              <p class="mb-4 text-sm font-semibold text-warning">
+                このコードは再表示できません。今すぐコピーまたはダウンロードして保管してください。
+              </p>
+              <ul class="grid grid-cols-2 gap-2 font-mono text-sm">
+                <For each={codes()}>{code => <li class="rounded bg-base-200 px-3 py-2">{code}</li>}</For>
+              </ul>
+              <div class="mt-4 flex gap-2">
+                <button class="btn btn-sm" onClick={copyAll}>
+                  コピー
+                </button>
+                <button class="btn btn-sm" onClick={download}>
+                  ダウンロード
+                </button>
+              </div>
+            </div>
+          </Show>
         </div>
-      </Show>
-    </div>
+      </Match>
+    </Switch>
   );
 };

--- a/src/admin/src/components/recovery-code/RecoveryCodesPanel.tsx
+++ b/src/admin/src/components/recovery-code/RecoveryCodesPanel.tsx
@@ -1,4 +1,4 @@
-import { createResource, createSignal, For, Match, Show, Switch } from 'solid-js';
+import { createSignal, For, Show } from 'solid-js';
 import { client } from '../../utils/client';
 import { createFormErrors } from '../../utils/form-error';
 import { createSubmitting } from '../../utils/use-submitting';
@@ -9,17 +9,6 @@ export const RecoveryCodesPanel = () => {
   const { formError, clearErrors, handleError } = createFormErrors();
   const { isSubmitting, withSubmitting } = createSubmitting();
   const [codes, setCodes] = createSignal<string[]>([]);
-
-  const [authCheck, { refetch }] = createResource(async () => {
-    const { status } = await client.api['admin-users'].get();
-
-    if (status === 401) {
-      window.location.href = '/auth/login';
-      return false;
-    }
-
-    return status === 200;
-  });
 
   const generate = withSubmitting(async () => {
     clearErrors();
@@ -52,53 +41,37 @@ export const RecoveryCodesPanel = () => {
   };
 
   return (
-    <Switch>
-      <Match when={authCheck.loading}>
-        <div class="flex items-center justify-center gap-3 py-10 text-base-content/70" role="status" aria-live="polite">
-          <span class="loading loading-spinner loading-md" aria-hidden="true" />
-          <span>読み込み中...</span>
-        </div>
-      </Match>
-      <Match when={authCheck() === false}>
-        <div class="flex flex-col items-start gap-3">
-          <p class="text-error">データの取得に失敗しました。</p>
-          <button type="button" class="btn btn-outline btn-sm" onClick={() => refetch()}>再試行</button>
-        </div>
-      </Match>
-      <Match when={authCheck() === true}>
-        <div class="max-w-2xl space-y-6">
-          <FormError message={formError()} onClose={clearErrors} />
+    <div class="max-w-2xl space-y-6">
+      <FormError message={formError()} onClose={clearErrors} />
 
-          <div class="rounded-box border border-base-300 bg-base-200 p-6">
-            <p class="text-sm text-base-content/70">
-              リカバリーコードはパスキーを紛失した際にアカウントへのアクセスを回復するためのワンタイムコードです。
-              発行すると既存のコードは無効になります。コードは発行時に一度だけ表示され、再表示はできません。安全な場所に保管してください。
-            </p>
-            <button class="btn btn-primary mt-4" disabled={isSubmitting()} onClick={generate}>
-              {isSubmitting() ? '発行中...' : 'リカバリーコードを発行/再生成'}
+      <div class="rounded-box border border-base-300 bg-base-200 p-6">
+        <p class="text-sm text-base-content/70">
+          リカバリーコードはパスキーを紛失した際にアカウントへのアクセスを回復するためのワンタイムコードです。
+          発行すると既存のコードは無効になります。コードは発行時に一度だけ表示され、再表示はできません。安全な場所に保管してください。
+        </p>
+        <button class="btn btn-primary mt-4" disabled={isSubmitting()} onClick={generate}>
+          {isSubmitting() ? '発行中...' : 'リカバリーコードを発行/再生成'}
+        </button>
+      </div>
+
+      <Show when={codes().length > 0}>
+        <div class="rounded-box border border-base-300 bg-base-100 p-6">
+          <p class="mb-4 text-sm font-semibold text-warning">
+            このコードは再表示できません。今すぐコピーまたはダウンロードして保管してください。
+          </p>
+          <ul class="grid grid-cols-2 gap-2 font-mono text-sm">
+            <For each={codes()}>{code => <li class="rounded bg-base-200 px-3 py-2">{code}</li>}</For>
+          </ul>
+          <div class="mt-4 flex gap-2">
+            <button class="btn btn-sm" onClick={copyAll}>
+              コピー
+            </button>
+            <button class="btn btn-sm" onClick={download}>
+              ダウンロード
             </button>
           </div>
-
-          <Show when={codes().length > 0}>
-            <div class="rounded-box border border-base-300 bg-base-100 p-6">
-              <p class="mb-4 text-sm font-semibold text-warning">
-                このコードは再表示できません。今すぐコピーまたはダウンロードして保管してください。
-              </p>
-              <ul class="grid grid-cols-2 gap-2 font-mono text-sm">
-                <For each={codes()}>{code => <li class="rounded bg-base-200 px-3 py-2">{code}</li>}</For>
-              </ul>
-              <div class="mt-4 flex gap-2">
-                <button class="btn btn-sm" onClick={copyAll}>
-                  コピー
-                </button>
-                <button class="btn btn-sm" onClick={download}>
-                  ダウンロード
-                </button>
-              </div>
-            </div>
-          </Show>
         </div>
-      </Match>
-    </Switch>
+      </Show>
+    </div>
   );
 };

--- a/src/admin/src/components/release/DetailView.tsx
+++ b/src/admin/src/components/release/DetailView.tsx
@@ -1,4 +1,4 @@
-import { For, Show, createMemo, createSignal, onMount } from 'solid-js';
+import { For, Match, Show, Switch, createMemo, createResource, createSignal } from 'solid-js';
 import type {
   ReleaseDistributionTypeValue,
   ReleaseGetResponse,
@@ -30,10 +30,24 @@ type TrackEntryForm = {
   title: string;
 };
 
-interface Props {
-  data?: ReleaseGetResponse;
-  status: number;
+interface DetailViewProps {
+  releaseId: string;
 }
+
+interface ReleaseFormProps {
+  data: ReleaseGetResponse;
+}
+
+interface FetchOkState {
+  status: 'ok';
+  data: ReleaseGetResponse;
+}
+
+interface FetchErrorState {
+  status: 'error';
+}
+
+type FetchState = FetchOkState | FetchErrorState;
 
 const normalizeDateValue = (value: unknown): string => {
   if (value instanceof Date) {
@@ -58,35 +72,93 @@ const toTrackEntryForm = (song: ReleaseReferencedSong): TrackEntryForm => ({
   title: song.title,
 });
 
-export const DetailView = (props: Props) => {
-  const listUrl = (() => {
-    if (typeof window === 'undefined') {
-      return '/releases';
+const getListUrl = () => {
+  if (typeof window === 'undefined') {
+    return '/releases';
+  }
+
+  const back = new URLSearchParams(window.location.search).get('back') ?? '';
+
+  if (!back.startsWith('?')) {
+    return '/releases';
+  }
+
+  try {
+    const query = new URLSearchParams(back.slice(1)).toString();
+    return query ? `/releases?${query}` : '/releases';
+  } catch {
+    return '/releases';
+  }
+};
+
+export const DetailView = (props: DetailViewProps) => {
+  const listUrl = getListUrl();
+
+  const [resource, { refetch }] = createResource(async (): Promise<FetchState> => {
+    const { data, status } = await client.api.releases({ releaseId: props.releaseId }).get();
+
+    if (status === 401) {
+      window.location.href = '/auth/login';
+      return { status: 'error' };
     }
 
-    const back = new URLSearchParams(window.location.search).get('back') ?? '';
-
-    if (!back.startsWith('?')) {
-      return '/releases';
+    if (status === 404) {
+      setFlash('データがありません', 'error');
+      window.location.href = listUrl;
+      return { status: 'error' };
     }
 
-    try {
-      const query = new URLSearchParams(back.slice(1)).toString();
-      return query ? `/releases?${query}` : '/releases';
-    } catch {
-      return '/releases';
+    if (status === 422) {
+      setFlash('不正なリクエストです', 'error');
+      window.location.href = listUrl;
+      return { status: 'error' };
     }
-  })();
 
-  const [title, setTitle] = createSignal(props.data?.release.title ?? '');
-  const [typeValue, setTypeValue] = createSignal<ReleaseTypeValue>(props.data?.release.typeValue ?? 1);
-  const [distributionTypeValue, setDistributionTypeValue] = createSignal<ReleaseDistributionTypeValue>(
-    props.data?.release.distributionTypeValue ?? 1,
+    if (!data) {
+      return { status: 'error' };
+    }
+
+    return { status: 'ok', data };
+  });
+
+  const loadedData = () => {
+    const state = resource();
+    return state?.status === 'ok' ? state.data : undefined;
+  };
+
+  return (
+    <Switch>
+      <Match when={resource.loading}>
+        <div class="flex items-center justify-center gap-3 py-10 text-base-content/70" role="status" aria-live="polite">
+          <span class="loading loading-spinner loading-md" aria-hidden="true" />
+          <span>読み込み中...</span>
+        </div>
+      </Match>
+      <Match when={resource()?.status === 'error'}>
+        <div class="flex flex-col items-start gap-3">
+          <p class="text-error">データの取得に失敗しました。</p>
+          <button type="button" class="btn btn-outline btn-sm" onClick={() => refetch()}>再試行</button>
+        </div>
+      </Match>
+      <Match when={loadedData()}>
+        {data => <ReleaseForm data={data()} />}
+      </Match>
+    </Switch>
   );
-  const [releasedOn, setReleasedOn] = createSignal(normalizeDateValue(props.data?.release.releasedOn));
-  const [description, setDescription] = createSignal(props.data?.release.description ?? '');
-  const [isDisplay, setIsDisplay] = createSignal(props.data?.release.isDisplay ?? true);
-  const [trackEntries, setTrackEntries] = createSignal<TrackEntryForm[]>((props.data?.songs ?? []).map(toTrackEntryForm));
+};
+
+const ReleaseForm = (props: ReleaseFormProps) => {
+  const listUrl = getListUrl();
+
+  const [title, setTitle] = createSignal(props.data.release.title);
+  const [typeValue, setTypeValue] = createSignal<ReleaseTypeValue>(props.data.release.typeValue);
+  const [distributionTypeValue, setDistributionTypeValue] = createSignal<ReleaseDistributionTypeValue>(
+    props.data.release.distributionTypeValue,
+  );
+  const [releasedOn, setReleasedOn] = createSignal(normalizeDateValue(props.data.release.releasedOn));
+  const [description, setDescription] = createSignal(props.data.release.description);
+  const [isDisplay, setIsDisplay] = createSignal(props.data.release.isDisplay);
+  const [trackEntries, setTrackEntries] = createSignal<TrackEntryForm[]>(props.data.songs.map(toTrackEntryForm));
 
   const [searchTitle, setSearchTitle] = createSignal('');
   const [searchResults, setSearchResults] = createSignal<SongSummary[]>([]);
@@ -179,7 +251,7 @@ export const DetailView = (props: Props) => {
     e.preventDefault();
     clearErrors();
 
-    const releaseId = props.data?.release.releaseId;
+    const releaseId = props.data.release.releaseId;
 
     if (!releaseId) {
       setFormError('更新対象のリリースIDを取得できませんでした');
@@ -223,7 +295,7 @@ export const DetailView = (props: Props) => {
 
     clearErrors();
 
-    const releaseId = props.data?.release.releaseId;
+    const releaseId = props.data.release.releaseId;
 
     if (!releaseId) {
       setFormError('削除対象のリリースIDを取得できませんでした');
@@ -241,26 +313,8 @@ export const DetailView = (props: Props) => {
     window.location.href = listUrl;
   });
 
-  onMount(() => {
-    if (props.status === 404) {
-      setFlash('データがありません', 'error');
-      window.location.href = listUrl;
-      return;
-    }
-
-    if (props.status === 422) {
-      setFlash('不正なリクエストです', 'error');
-      window.location.href = listUrl;
-      return;
-    }
-
-    if (!props.data) {
-      setFormError('予期しないエラーが発生しました');
-    }
-  });
-
   return (
-    <Show when={props.data} fallback={<p>読み込み中...</p>}>
+    <>
       <a href={listUrl} class="btn btn-ghost btn-sm mb-4">
         ← 一覧に戻る
       </a>
@@ -492,6 +546,6 @@ export const DetailView = (props: Props) => {
           </div>
         </fieldset>
       </div>
-    </Show>
+    </>
   );
 };

--- a/src/admin/src/components/release/DetailView.tsx
+++ b/src/admin/src/components/release/DetailView.tsx
@@ -134,7 +134,7 @@ export const DetailView = (props: DetailViewProps) => {
           <span>読み込み中...</span>
         </div>
       </Match>
-      <Match when={resource()?.status === 'error'}>
+      <Match when={resource.error || resource()?.status === 'error'}>
         <div class="flex flex-col items-start gap-3">
           <p class="text-error">データの取得に失敗しました。</p>
           <button type="button" class="btn btn-outline btn-sm" onClick={() => refetch()}>再試行</button>

--- a/src/admin/src/components/song-tag/EditableForm.tsx
+++ b/src/admin/src/components/song-tag/EditableForm.tsx
@@ -1,4 +1,4 @@
-import { onMount, Show } from 'solid-js';
+import { createResource, Match, Show, Switch } from 'solid-js';
 import type { SongTag } from '../../generated';
 import { client } from '../../utils/client';
 import { createFormErrors } from '../../utils/form-error';
@@ -6,12 +6,26 @@ import { createSubmitting } from '../../utils/use-submitting';
 import { setFlash } from '../Flash';
 import { FormError } from '../FormError';
 
-interface Props {
-  data?: { tag: SongTag };
-  status: number;
+interface DetailViewProps {
+  songTagId: string;
 }
 
-export const EditableForm = (props: Props) => {
+interface EditableFormProps {
+  data: { tag: SongTag };
+}
+
+interface FetchOkState {
+  status: 'ok';
+  data: { tag: SongTag };
+}
+
+interface FetchErrorState {
+  status: 'error';
+}
+
+type FetchState = FetchOkState | FetchErrorState;
+
+const getListUrl = () => {
   const back = new URLSearchParams(window.location.search).get('back') ?? '';
   const listQuery = (() => {
     if (!back.startsWith('?')) return '';
@@ -22,7 +36,68 @@ export const EditableForm = (props: Props) => {
       return '';
     }
   })();
-  const listUrl = `/song-tags${listQuery}`;
+
+  return `/song-tags${listQuery}`;
+};
+
+export const DetailView = (props: DetailViewProps) => {
+  const listUrl = getListUrl();
+
+  const [resource, { refetch }] = createResource(async (): Promise<FetchState> => {
+    const { data, status } = await client.api['song-tags']({ songTagId: props.songTagId }).get();
+
+    if (status === 401) {
+      window.location.href = '/auth/login';
+      return { status: 'error' };
+    }
+
+    if (status === 404) {
+      setFlash('データがありません', 'error');
+      window.location.href = listUrl;
+      return { status: 'error' };
+    }
+
+    if (status === 422) {
+      setFlash('不正なリクエストです', 'error');
+      window.location.href = listUrl;
+      return { status: 'error' };
+    }
+
+    if (!data) {
+      return { status: 'error' };
+    }
+
+    return { status: 'ok', data };
+  });
+
+  const loadedData = () => {
+    const state = resource();
+    return state?.status === 'ok' ? state.data : undefined;
+  };
+
+  return (
+    <Switch>
+      <Match when={resource.loading}>
+        <div class="flex items-center justify-center gap-3 py-10 text-base-content/70" role="status" aria-live="polite">
+          <span class="loading loading-spinner loading-md" aria-hidden="true" />
+          <span>読み込み中...</span>
+        </div>
+      </Match>
+      <Match when={resource()?.status === 'error'}>
+        <div class="flex flex-col items-start gap-3">
+          <p class="text-error">データの取得に失敗しました。</p>
+          <button type="button" class="btn btn-outline btn-sm" onClick={() => refetch()}>再試行</button>
+        </div>
+      </Match>
+      <Match when={loadedData()}>
+        {data => <EditableForm data={data()} />}
+      </Match>
+    </Switch>
+  );
+};
+
+export const EditableForm = (props: EditableFormProps) => {
+  const listUrl = getListUrl();
 
   const { formError, setFormError, getFieldError, clearErrors, handleError } = createFormErrors();
   const { isSubmitting, withSubmitting } = createSubmitting();
@@ -38,7 +113,7 @@ export const EditableForm = (props: Props) => {
     const form = (e.target as HTMLButtonElement).form as HTMLFormElement;
     const formData = new FormData(form);
 
-    const songTagId = props.data?.tag.songTagId;
+    const songTagId = props.data.tag.songTagId;
 
     if (!songTagId) {
       setFormError('更新対象の楽曲タグIDを取得できませんでした');
@@ -74,7 +149,7 @@ export const EditableForm = (props: Props) => {
 
     clearErrors();
 
-    const songTagId = props.data?.tag.songTagId;
+    const songTagId = props.data.tag.songTagId;
 
     if (!songTagId) {
       setFormError('削除対象の楽曲タグIDを取得できませんでした');
@@ -92,20 +167,8 @@ export const EditableForm = (props: Props) => {
     window.location.href = listUrl;
   });
 
-  onMount(() => {
-    if (props.status === 404) {
-      setFlash('データがありません', 'error');
-      window.location.href = listUrl;
-    } else if (props.status === 422) {
-      setFlash('不正なリクエストです', 'error');
-      window.location.href = listUrl;
-    } else if (!props.data) {
-      setFormError('予期しないエラーが発生しました');
-    }
-  });
-
   return (
-    <Show when={props.data} fallback={<p>読み込み中...</p>}>
+    <>
       <a href={listUrl} class="btn btn-ghost btn-sm mb-4">
         ← 一覧に戻る
       </a>
@@ -119,7 +182,7 @@ export const EditableForm = (props: Props) => {
               type="text"
               class="input w-full"
               name="name"
-              value={props.data?.tag.name}
+              value={props.data.tag.name}
               classList={{ 'input-error': !!getFieldError('name') }}
             />
             <Show when={getFieldError('name')}>{message => <p class="mt-1 text-xs text-error">{message()}</p>}</Show>
@@ -131,7 +194,7 @@ export const EditableForm = (props: Props) => {
               name="orderNo"
               required
               min="1"
-              value={props.data?.tag.orderNo}
+              value={props.data.tag.orderNo}
               classList={{ 'input-error': !!getFieldError('orderNo') }}
             />
             <Show when={getFieldError('orderNo')}>{message => <p class="mt-1 text-xs text-error">{message()}</p>}</Show>
@@ -154,6 +217,6 @@ export const EditableForm = (props: Props) => {
           </div>
         </fieldset>
       </div>
-    </Show>
+    </>
   );
 };

--- a/src/admin/src/components/song-tag/EditableForm.tsx
+++ b/src/admin/src/components/song-tag/EditableForm.tsx
@@ -83,7 +83,7 @@ export const DetailView = (props: DetailViewProps) => {
           <span>読み込み中...</span>
         </div>
       </Match>
-      <Match when={resource()?.status === 'error'}>
+      <Match when={resource.error || resource()?.status === 'error'}>
         <div class="flex flex-col items-start gap-3">
           <p class="text-error">データの取得に失敗しました。</p>
           <button type="button" class="btn btn-outline btn-sm" onClick={() => refetch()}>再試行</button>

--- a/src/admin/src/components/song-type/List.tsx
+++ b/src/admin/src/components/song-type/List.tsx
@@ -1,0 +1,57 @@
+import { createResource, For, Match, Switch } from 'solid-js';
+import { client } from '../../utils/client';
+import { ListState } from '../ListState';
+
+export const SongTypeList = () => {
+  const [data, { refetch }] = createResource(async () => {
+    const { data, status } = await client.api['song-types'].get();
+
+    if (status === 401) {
+      window.location.href = '/auth/login';
+      return;
+    }
+
+    return data;
+  });
+
+  return (
+    <div class="rounded-box border border-base-300 bg-base-100 overflow-x-auto">
+      <table class="table table-zebra">
+        <thead>
+          <tr>
+            <th>楽曲種別名</th>
+          </tr>
+        </thead>
+        <tbody>
+          <Switch>
+            <Match when={data.loading}>
+              <ListState state="loading" colSpan={1} />
+            </Match>
+            <Match when={!data()}>
+              <ListState
+                state="error"
+                colSpan={1}
+                message="データの取得に失敗しました。再度お試しください。"
+                onRetry={() => refetch()}
+              />
+            </Match>
+            <Match when={data() && data()!.types.length === 0}>
+              <ListState state="empty" colSpan={1} message="楽曲種別はありません。" />
+            </Match>
+            <Match when={data()}>
+              {result => (
+                <For each={result().types}>
+                  {type => (
+                    <tr>
+                      <td>{type.name}</td>
+                    </tr>
+                  )}
+                </For>
+              )}
+            </Match>
+          </Switch>
+        </tbody>
+      </table>
+    </div>
+  );
+};

--- a/src/admin/src/components/song/CreateForm.tsx
+++ b/src/admin/src/components/song/CreateForm.tsx
@@ -64,7 +64,7 @@ export const CreateView = () => {
           <span>読み込み中...</span>
         </div>
       </Match>
-      <Match when={resource()?.status === 'error'}>
+      <Match when={resource.error || resource()?.status === 'error'}>
         <div class="flex flex-col items-start gap-3">
           <p class="text-error">データの取得に失敗しました。</p>
           <button type="button" class="btn btn-outline btn-sm" onClick={() => refetch()}>再試行</button>

--- a/src/admin/src/components/song/CreateForm.tsx
+++ b/src/admin/src/components/song/CreateForm.tsx
@@ -1,4 +1,4 @@
-import { createEffect, createSignal, For, Show } from 'solid-js';
+import { createResource, createSignal, For, Match, Show, Switch } from 'solid-js';
 import type { Media, Person, RequestSongPerson, SongPersonRole, SongTag, SongType, SongTypeValue } from '../../generated';
 import { client } from '../../utils/client';
 import { createFormErrors } from '../../utils/form-error';
@@ -18,17 +18,71 @@ type SongTagEntry = {
   songTagId: string;
 };
 
-interface Props {
-  data?: { persons: Person[]; types: SongType[]; tags: SongTag[]; media: Media[] };
-  status: number;
+type CreateFormData = { persons: Person[]; types: SongType[]; tags: SongTag[]; media: Media[] };
+
+interface CreateFormProps {
+  data: CreateFormData;
 }
 
-export const CreateForm = (props: Props) => {
-  const [persons] = createSignal<Person[]>(props.data?.persons ?? []);
-  const [types] = createSignal<SongType[]>(props.data?.types ?? []);
+interface FetchOkState {
+  status: 'ok';
+  data: CreateFormData;
+}
+
+interface FetchErrorState {
+  status: 'error';
+}
+
+type FetchState = FetchOkState | FetchErrorState;
+
+export const CreateView = () => {
+  const [resource, { refetch }] = createResource(async (): Promise<FetchState> => {
+    const { data, status } = await client.api.songs['create-form'].get();
+
+    if (status === 401) {
+      window.location.href = '/auth/login';
+      return { status: 'error' };
+    }
+
+    if (!data) {
+      return { status: 'error' };
+    }
+
+    return { status: 'ok', data };
+  });
+
+  const loadedData = () => {
+    const state = resource();
+    return state?.status === 'ok' ? state.data : undefined;
+  };
+
+  return (
+    <Switch>
+      <Match when={resource.loading}>
+        <div class="flex items-center justify-center gap-3 py-10 text-base-content/70" role="status" aria-live="polite">
+          <span class="loading loading-spinner loading-md" aria-hidden="true" />
+          <span>読み込み中...</span>
+        </div>
+      </Match>
+      <Match when={resource()?.status === 'error'}>
+        <div class="flex flex-col items-start gap-3">
+          <p class="text-error">データの取得に失敗しました。</p>
+          <button type="button" class="btn btn-outline btn-sm" onClick={() => refetch()}>再試行</button>
+        </div>
+      </Match>
+      <Match when={loadedData()}>
+        {data => <CreateForm data={data()} />}
+      </Match>
+    </Switch>
+  );
+};
+
+export const CreateForm = (props: CreateFormProps) => {
+  const [persons] = createSignal<Person[]>(props.data.persons);
+  const [types] = createSignal<SongType[]>(props.data.types);
   const [typeValue, setTypeValue] = createSignal<SongTypeValue | ''>('');
-  const [availableTags] = createSignal<SongTag[]>(props.data?.tags ?? []);
-  const [availableMedia, setAvailableMedia] = createSignal<Media[]>(props.data?.media ?? []);
+  const [availableTags] = createSignal<SongTag[]>(props.data.tags);
+  const [availableMedia, setAvailableMedia] = createSignal<Media[]>(props.data.media);
 
   const [lyricists, setLyricists] = createSignal<PersonEntry[]>([]);
   const [composers, setComposers] = createSignal<PersonEntry[]>([]);
@@ -45,12 +99,6 @@ export const CreateForm = (props: Props) => {
 
     return normalized === '' ? null : normalized;
   };
-
-  createEffect(() => {
-    if (props.status !== 200) {
-      handleError(props.status, undefined);
-    }
-  });
 
   const addEntry = (setter: typeof setLyricists, role: SongPersonRole) => {
     setter(prev => [...prev, { personId: '', role, orderNo: prev.length + 1 }]);

--- a/src/admin/src/components/song/EditableForm.tsx
+++ b/src/admin/src/components/song/EditableForm.tsx
@@ -97,7 +97,7 @@ export const DetailView = (props: DetailViewProps) => {
           <span>読み込み中...</span>
         </div>
       </Match>
-      <Match when={resource()?.status === 'error'}>
+      <Match when={resource.error || resource()?.status === 'error'}>
         <div class="flex flex-col items-start gap-3">
           <p class="text-error">データの取得に失敗しました。</p>
           <button type="button" class="btn btn-outline btn-sm" onClick={() => refetch()}>再試行</button>

--- a/src/admin/src/components/song/EditableForm.tsx
+++ b/src/admin/src/components/song/EditableForm.tsx
@@ -1,4 +1,4 @@
-import { createEffect, createSignal, For, Show } from 'solid-js';
+import { createResource, createSignal, For, Match, Show, Switch } from 'solid-js';
 import type { Media, Person, RequestSongPerson, Song, SongPerson, SongPersonRole, SongTag, SongType, SongTypeValue } from '../../generated';
 import { client } from '../../utils/client';
 import { createFormErrors } from '../../utils/form-error';
@@ -18,12 +18,28 @@ type SongTagEntry = {
   songTagId: string;
 };
 
-interface Props {
-  data?: { song: Song; persons: Person[]; types: SongType[]; tags: SongTag[]; media: Media[] };
-  status: number;
+interface DetailViewProps {
+  songId: string;
 }
 
-export const EditableForm = (props: Props) => {
+type EditableFormData = { song: Song; persons: Person[]; types: SongType[]; tags: SongTag[]; media: Media[] };
+
+interface EditableFormProps {
+  data: EditableFormData;
+}
+
+interface FetchOkState {
+  status: 'ok';
+  data: EditableFormData;
+}
+
+interface FetchErrorState {
+  status: 'error';
+}
+
+type FetchState = FetchOkState | FetchErrorState;
+
+const getListUrl = () => {
   const back = new URLSearchParams(window.location.search).get('back') ?? '';
   const listQuery = (() => {
     if (!back.startsWith('?')) return '';
@@ -34,20 +50,82 @@ export const EditableForm = (props: Props) => {
       return '';
     }
   })();
-  const listUrl = `/songs${listQuery}`;
 
-  const persons = props.data?.persons ?? [];
-  const types = props.data?.types ?? [];
-  const [typeValue, setTypeValue] = createSignal<SongTypeValue | ''>(props.data?.song.type.value ?? '');
-  const availableTags = props.data?.tags ?? [];
+  return `/songs${listQuery}`;
+};
+
+export const DetailView = (props: DetailViewProps) => {
+  const listUrl = getListUrl();
+
+  const [resource, { refetch }] = createResource(async (): Promise<FetchState> => {
+    const { data, status } = await client.api.songs({ songId: props.songId })['edit-form'].get();
+
+    if (status === 401) {
+      window.location.href = '/auth/login';
+      return { status: 'error' };
+    }
+
+    if (status === 404) {
+      setFlash('データがありません', 'error');
+      window.location.href = listUrl;
+      return { status: 'error' };
+    }
+
+    if (status === 422) {
+      setFlash('不正なリクエストです', 'error');
+      window.location.href = listUrl;
+      return { status: 'error' };
+    }
+
+    if (!data) {
+      return { status: 'error' };
+    }
+
+    return { status: 'ok', data };
+  });
+
+  const loadedData = () => {
+    const state = resource();
+    return state?.status === 'ok' ? state.data : undefined;
+  };
+
+  return (
+    <Switch>
+      <Match when={resource.loading}>
+        <div class="flex items-center justify-center gap-3 py-10 text-base-content/70" role="status" aria-live="polite">
+          <span class="loading loading-spinner loading-md" aria-hidden="true" />
+          <span>読み込み中...</span>
+        </div>
+      </Match>
+      <Match when={resource()?.status === 'error'}>
+        <div class="flex flex-col items-start gap-3">
+          <p class="text-error">データの取得に失敗しました。</p>
+          <button type="button" class="btn btn-outline btn-sm" onClick={() => refetch()}>再試行</button>
+        </div>
+      </Match>
+      <Match when={loadedData()}>
+        {data => <EditableForm data={data()} />}
+      </Match>
+    </Switch>
+  );
+};
+
+export const EditableForm = (props: EditableFormProps) => {
+  const listUrl = getListUrl();
+
+  const persons = props.data.persons;
+  const types = props.data.types;
+  const [typeValue, setTypeValue] = createSignal<SongTypeValue | ''>(props.data.song.type.value);
+  const availableTags = props.data.tags;
   const initialAvailableMedia = (() => {
-    const items = [...(props.data?.media ?? [])];
-    for (const item of props.data?.song.media ?? []) {
+    const items = [...props.data.media];
+    for (const item of props.data.song.media) {
       if (!items.some(media => media.mediaId === item.mediaId)) {
         items.push({
           mediaId: item.mediaId,
           title: item.title,
           url: item.url,
+          publishedAt: item.publishedAt,
           type: item.type,
           format: item.format,
           isDisplay: item.isDisplay,
@@ -60,15 +138,15 @@ export const EditableForm = (props: Props) => {
   const toEntries = (items: SongPerson[] | undefined): PersonEntry[] =>
     (items ?? []).map(item => ({ personId: item.personId, role: item.role, orderNo: item.orderNo }));
 
-  const initialEntries = toEntries(props.data?.song.persons);
+  const initialEntries = toEntries(props.data.song.persons);
   const [lyricists, setLyricists] = createSignal<PersonEntry[]>(initialEntries.filter(entry => entry.role === 1));
   const [composers, setComposers] = createSignal<PersonEntry[]>(initialEntries.filter(entry => entry.role === 2));
   const [arrangers, setArrangers] = createSignal<PersonEntry[]>(initialEntries.filter(entry => entry.role === 3));
   const [tags, setTags] = createSignal<SongTagEntry[]>(
-    (props.data?.song.tags ?? []).map(tag => ({ songTagId: tag.songTagId })),
+    props.data.song.tags.map(tag => ({ songTagId: tag.songTagId })),
   );
   const [availableMedia, setAvailableMedia] = createSignal<Media[]>(initialAvailableMedia);
-  const [mediaEntries, setMediaEntries] = createSignal<MediaEntry[]>((props.data?.song.media ?? []).map(toMediaEntry));
+  const [mediaEntries, setMediaEntries] = createSignal<MediaEntry[]>(props.data.song.media.map(toMediaEntry));
   const [tagPickerValue, setTagPickerValue] = createSignal('');
 
   const { formError, setFormError, getFieldError, clearErrors, handleError } = createFormErrors();
@@ -79,16 +157,6 @@ export const EditableForm = (props: Props) => {
 
     return normalized === '' ? null : normalized;
   };
-
-  createEffect(() => {
-    if (props.status === 404) {
-      setFlash('データがありません', 'error');
-      window.location.href = listUrl;
-    } else if (props.status === 422) {
-      setFlash('不正なリクエストです', 'error');
-      window.location.href = listUrl;
-    }
-  });
 
   const addEntry = (setter: typeof setLyricists, role: SongPersonRole) => {
     setter(prev => [...prev, { personId: '', role, orderNo: prev.length + 1 }]);
@@ -130,7 +198,7 @@ export const EditableForm = (props: Props) => {
 
     clearErrors();
 
-    const songId = props.data?.song.songId;
+    const songId = props.data.song.songId;
 
     if (!songId) {
       setFormError('削除対象の楽曲IDを取得できませんでした');
@@ -155,7 +223,7 @@ export const EditableForm = (props: Props) => {
     const form = (e.target as HTMLButtonElement).form as HTMLFormElement;
     const formData = new FormData(form);
 
-    const songId = props.data?.song.songId;
+    const songId = props.data.song.songId;
 
     if (!songId) {
       setFormError('更新対象の楽曲IDを取得できませんでした');
@@ -309,7 +377,7 @@ export const EditableForm = (props: Props) => {
   );
 
   return (
-    <Show when={props.data} fallback={<p>読み込み中...</p>}>
+    <>
       <a href={listUrl} class="btn btn-ghost btn-sm mb-4">
         ← 一覧に戻る
       </a>
@@ -327,7 +395,7 @@ export const EditableForm = (props: Props) => {
                     class="input w-full"
                     name="title"
                     required
-                    value={props.data?.song.title}
+                    value={props.data.song.title}
                     classList={{ 'input-error': !!getFieldError('title') }}
                   />
                   <Show when={getFieldError('title')}>{message => <p class="mt-1 text-xs text-error">{message()}</p>}</Show>
@@ -359,7 +427,7 @@ export const EditableForm = (props: Props) => {
                     type="text"
                     class="input w-full"
                     name="description"
-                    value={props.data?.song.description}
+                    value={props.data.song.description}
                     classList={{ 'input-error': !!getFieldError('description') }}
                   />
                   <Show when={getFieldError('description')}>
@@ -373,7 +441,7 @@ export const EditableForm = (props: Props) => {
                     type="url"
                     class="input w-full"
                     name="lyricsLink"
-                    value={props.data?.song.lyricsLink ?? ''}
+                    value={props.data.song.lyricsLink ?? ''}
                     placeholder="https://example.com/lyrics"
                     classList={{ 'input-error': !!getFieldError('lyricsLink') }}
                   />
@@ -385,10 +453,10 @@ export const EditableForm = (props: Props) => {
                 <div>
                   <label class="label">表示設定</label>
                   <select class="select select-bordered w-full" name="isDisplay">
-                    <option value="true" selected={props.data?.song.isDisplay === true}>
+                    <option value="true" selected={props.data.song.isDisplay === true}>
                       表示する
                     </option>
-                    <option value="false" selected={props.data?.song.isDisplay === false}>
+                    <option value="false" selected={props.data.song.isDisplay === false}>
                       表示しない
                     </option>
                   </select>
@@ -396,7 +464,7 @@ export const EditableForm = (props: Props) => {
 
                 <div>
                   <label class="label">表示順</label>
-                  <input type="number" class="input w-full" name="orderNo" required min="1" value={props.data?.song.orderNo} />
+                  <input type="number" class="input w-full" name="orderNo" required min="1" value={props.data.song.orderNo} />
                 </div>
               </div>
             </fieldset>
@@ -440,6 +508,6 @@ export const EditableForm = (props: Props) => {
           </button>
         </div>
       </div>
-    </Show>
+    </>
   );
 };

--- a/src/admin/src/pages/admin-users/index.astro
+++ b/src/admin/src/pages/admin-users/index.astro
@@ -1,54 +1,10 @@
 ---
+import { AdminUserList } from '../../components/admin-user/List';
 import { FlashMessage } from '../../components/Flash';
 import Layout from '../../layouts/Layout.astro';
-import { client } from '../../utils/client';
-import { formatter } from '../../utils/date';
-
-export const prerender = false;
-
-const { data, status } = await client.api['admin-users'].get({
-  headers: {
-    'x-csrf-token': Astro.cookies.get('csrf')?.value ?? '',
-    'cookie': Astro.request.headers.get('cookie') ?? '',
-  },
-});
-
-if (status === 401) {
-  return Astro.redirect('/auth/login');
-}
-
-if (!data) {
-  throw new Error();
-}
 ---
 
 <Layout pageTitle="管理ユーザー一覧">
   <FlashMessage client:only="solid-js" />
-  <!-- TODO コンポーネント化する -->
-  <div class="rounded-box border border-base-300 bg-base-100 overflow-x-auto">
-    <table class="table table-zebra">
-      <thead>
-        <tr>
-          <th>名前</th>
-          <th>メールアドレス</th>
-          <th>役割</th>
-          <th>作成日</th>
-        </tr>
-      </thead>
-      <tbody>
-        {
-          data.adminUsers.map((adminUser) => {
-            return (
-              <tr>
-                <td>{adminUser.name}</td>
-                <td>{adminUser.email}</td>
-                <td>{adminUser.role.name}</td>
-                <td>{formatter.format(new Date(adminUser.createdAt))}</td>
-              </tr>
-            );
-          })
-        }
-      </tbody>
-    </table>
-  </div>
+  <AdminUserList client:only="solid-js" />
 </Layout>

--- a/src/admin/src/pages/audit-logs/[id].astro
+++ b/src/admin/src/pages/audit-logs/[id].astro
@@ -2,8 +2,6 @@
 import { DetailView } from '../../components/audit-log/DetailView';
 import Layout from '../../layouts/Layout.astro';
 
-export const prerender = false;
-
 const { id } = Astro.params;
 
 if (typeof id !== 'string') {

--- a/src/admin/src/pages/audit-logs/index.astro
+++ b/src/admin/src/pages/audit-logs/index.astro
@@ -1,8 +1,6 @@
 ---
 import { SearchList } from '../../components/audit-log/SearchList';
 import Layout from '../../layouts/Layout.astro';
-
-export const prerender = false;
 ---
 
 <Layout pageTitle="監査ログ一覧">

--- a/src/admin/src/pages/media/[id].astro
+++ b/src/admin/src/pages/media/[id].astro
@@ -1,30 +1,16 @@
 ---
-import { EditableForm } from '../../components/media/EditableForm';
+import { DetailView } from '../../components/media/EditableForm';
 import Layout from '../../layouts/Layout.astro';
-import { client } from '../../utils/client';
-
-export const prerender = false;
 
 const { id } = Astro.params;
 
 if (typeof id !== 'string') {
   throw new Error('URL が不正');
 }
-
-const { data, status } = await client.api.media({ mediaId: id }).get({
-  headers: {
-    'x-csrf-token': Astro.cookies.get('csrf')?.value ?? '',
-    'cookie': Astro.request.headers.get('cookie') ?? '',
-  },
-});
-
-if (status === 401) {
-  return Astro.redirect('/auth/login');
-}
 ---
 
 <Layout pageTitle="メディア詳細">
   <div>
-    <EditableForm data={data ?? undefined} status={status} client:only="solid-js" />
+    <DetailView mediaId={id} client:only="solid-js" />
   </div>
 </Layout>

--- a/src/admin/src/pages/media/create/index.astro
+++ b/src/admin/src/pages/media/create/index.astro
@@ -1,0 +1,10 @@
+---
+import { FlashMessage } from '../../../components/Flash';
+import { CreateForm } from '../../../components/media/CreateForm';
+import Layout from '../../../layouts/Layout.astro';
+---
+
+<Layout pageTitle="メディア作成">
+  <FlashMessage client:only="solid-js" />
+  <CreateForm client:only="solid-js" />
+</Layout>

--- a/src/admin/src/pages/media/index.astro
+++ b/src/admin/src/pages/media/index.astro
@@ -2,8 +2,6 @@
 import { FlashMessage } from '../../components/Flash';
 import { SearchList } from '../../components/media/SearchList';
 import Layout from '../../layouts/Layout.astro';
-
-export const prerender = false;
 ---
 
 <Layout pageTitle="メディア一覧">

--- a/src/admin/src/pages/persons/[id].astro
+++ b/src/admin/src/pages/persons/[id].astro
@@ -1,34 +1,16 @@
 ---
-import { EditableForm } from '../../components/person/EditableForm';
+import { DetailView } from '../../components/person/EditableForm';
 import Layout from '../../layouts/Layout.astro';
-import { client } from '../../utils/client';
-
-export const prerender = false;
-
-interface Props {
-  id: string;
-}
 
 const { id } = Astro.params;
 
 if (typeof id !== 'string') {
   throw new Error('URL が不正');
 }
-
-const { data, status } = await client.api.persons({ personId: id }).get({
-  headers: {
-    'x-csrf-token': Astro.cookies.get('csrf')?.value ?? '',
-    'cookie': Astro.request.headers.get('cookie') ?? '',
-  },
-});
-
-if (status === 401) {
-  return Astro.redirect('/auth/login');
-}
 ---
 
 <Layout pageTitle="人物詳細">
   <div>
-    <EditableForm data={data ?? undefined} status={status} client:only="solid-js" />
+    <DetailView personId={id} client:only="solid-js" />
   </div>
 </Layout>

--- a/src/admin/src/pages/persons/create/index.astro
+++ b/src/admin/src/pages/persons/create/index.astro
@@ -1,8 +1,6 @@
 ---
 import { CreateForm } from '../../../components/person/CreateForm';
 import Layout from '../../../layouts/Layout.astro';
-
-export const prerender = false;
 ---
 
 <Layout pageTitle="人物作成">

--- a/src/admin/src/pages/persons/index.astro
+++ b/src/admin/src/pages/persons/index.astro
@@ -2,8 +2,6 @@
 import { FlashMessage } from '../../components/Flash';
 import { SearchList } from '../../components/person/SearchList';
 import Layout from '../../layouts/Layout.astro';
-
-export const prerender = false;
 ---
 
 <Layout pageTitle="人物一覧">

--- a/src/admin/src/pages/recovery-codes/index.astro
+++ b/src/admin/src/pages/recovery-codes/index.astro
@@ -2,20 +2,6 @@
 import { FlashMessage } from '../../components/Flash';
 import { RecoveryCodesPanel } from '../../components/recovery-code/RecoveryCodesPanel';
 import Layout from '../../layouts/Layout.astro';
-import { client } from '../../utils/client';
-
-export const prerender = false;
-
-const { status } = await client.api['admin-users'].get({
-  headers: {
-    'x-csrf-token': Astro.cookies.get('csrf')?.value ?? '',
-    'cookie': Astro.request.headers.get('cookie') ?? '',
-  },
-});
-
-if (status === 401) {
-  return Astro.redirect('/auth/login');
-}
 ---
 
 <Layout pageTitle="リカバリーコード">

--- a/src/admin/src/pages/recovery-codes/index.astro
+++ b/src/admin/src/pages/recovery-codes/index.astro
@@ -6,5 +6,5 @@ import Layout from '../../layouts/Layout.astro';
 
 <Layout pageTitle="リカバリーコード">
   <FlashMessage client:only="solid-js" />
-  <RecoveryCodesPanel client:load />
+  <RecoveryCodesPanel client:only="solid-js" />
 </Layout>

--- a/src/admin/src/pages/releases/[id].astro
+++ b/src/admin/src/pages/releases/[id].astro
@@ -1,28 +1,14 @@
 ---
 import { DetailView } from '../../components/release/DetailView';
 import Layout from '../../layouts/Layout.astro';
-import { client } from '../../utils/client';
-
-export const prerender = false;
 
 const { id } = Astro.params;
 
 if (typeof id !== 'string') {
   throw new Error('URL が不正');
 }
-
-const { data, status } = await client.api.releases({ releaseId: id }).get({
-  headers: {
-    'x-csrf-token': Astro.cookies.get('csrf')?.value ?? '',
-    'cookie': Astro.request.headers.get('cookie') ?? '',
-  },
-});
-
-if (status === 401) {
-  return Astro.redirect('/auth/login');
-}
 ---
 
 <Layout pageTitle="リリース詳細">
-  <DetailView data={data ?? undefined} status={status} client:only="solid-js" />
+  <DetailView releaseId={id} client:only="solid-js" />
 </Layout>

--- a/src/admin/src/pages/releases/create/index.astro
+++ b/src/admin/src/pages/releases/create/index.astro
@@ -2,8 +2,6 @@
 import { FlashMessage } from '../../../components/Flash';
 import { CreateForm } from '../../../components/release/CreateForm';
 import Layout from '../../../layouts/Layout.astro';
-
-export const prerender = false;
 ---
 
 <Layout pageTitle="リリース作成">

--- a/src/admin/src/pages/releases/index.astro
+++ b/src/admin/src/pages/releases/index.astro
@@ -2,8 +2,6 @@
 import { FlashMessage } from '../../components/Flash';
 import { SearchList } from '../../components/release/SearchList';
 import Layout from '../../layouts/Layout.astro';
-
-export const prerender = false;
 ---
 
 <Layout pageTitle="リリース一覧">

--- a/src/admin/src/pages/song-tags/[id].astro
+++ b/src/admin/src/pages/song-tags/[id].astro
@@ -1,30 +1,16 @@
 ---
-import { EditableForm } from '../../components/song-tag/EditableForm';
+import { DetailView } from '../../components/song-tag/EditableForm';
 import Layout from '../../layouts/Layout.astro';
-import { client } from '../../utils/client';
-
-export const prerender = false;
 
 const { id } = Astro.params;
 
 if (typeof id !== 'string') {
   throw new Error('URL が不正');
 }
-
-const { data, status } = await client.api['song-tags']({ songTagId: id }).get({
-  headers: {
-    'x-csrf-token': Astro.cookies.get('csrf')?.value ?? '',
-    'cookie': Astro.request.headers.get('cookie') ?? '',
-  },
-});
-
-if (status === 401) {
-  return Astro.redirect('/auth/login');
-}
 ---
 
 <Layout pageTitle="楽曲タグ詳細">
   <div>
-    <EditableForm data={data ?? undefined} status={status} client:only="solid-js" />
+    <DetailView songTagId={id} client:only="solid-js" />
   </div>
 </Layout>

--- a/src/admin/src/pages/song-tags/create/index.astro
+++ b/src/admin/src/pages/song-tags/create/index.astro
@@ -2,8 +2,6 @@
 import { FlashMessage } from '../../../components/Flash';
 import { CreateForm } from '../../../components/song-tag/CreateForm';
 import Layout from '../../../layouts/Layout.astro';
-
-export const prerender = false;
 ---
 
 <Layout pageTitle="楽曲タグ作成">

--- a/src/admin/src/pages/song-tags/index.astro
+++ b/src/admin/src/pages/song-tags/index.astro
@@ -2,8 +2,6 @@
 import { FlashMessage } from '../../components/Flash';
 import { SearchList } from '../../components/song-tag/SearchList';
 import Layout from '../../layouts/Layout.astro';
-
-export const prerender = false;
 ---
 
 <Layout pageTitle="楽曲タグ一覧">

--- a/src/admin/src/pages/song-types/index.astro
+++ b/src/admin/src/pages/song-types/index.astro
@@ -1,47 +1,10 @@
 ---
 import { FlashMessage } from '../../components/Flash';
+import { SongTypeList } from '../../components/song-type/List';
 import Layout from '../../layouts/Layout.astro';
-import { client } from '../../utils/client';
-
-export const prerender = false;
-
-const { data, error, status } = await client.api['song-types'].get({
-  headers: {
-    'x-csrf-token': Astro.cookies.get('csrf')?.value ?? '',
-    'cookie': Astro.request.headers.get('cookie') ?? '',
-  },
-});
-
-if (status === 401) {
-  return Astro.redirect('/auth/login');
-}
-
-if (error) {
-  throw new Error();
-}
 ---
 
 <Layout pageTitle="楽曲種別一覧">
   <FlashMessage client:only="solid-js" />
-  <!-- TODO コンポーネント化する -->
-  <div class="rounded-box border border-base-300 bg-base-100 overflow-x-auto">
-    <table class="table table-zebra">
-      <thead>
-        <tr>
-          <th>楽曲種別名</th>
-        </tr>
-      </thead>
-      <tbody>
-        {
-          data.types.map((type) => {
-            return (
-              <tr>
-                <td>{type.name}</td>
-              </tr>
-            );
-          })
-        }
-      </tbody>
-    </table>
-  </div>
+  <SongTypeList client:only="solid-js" />
 </Layout>

--- a/src/admin/src/pages/songs/[id].astro
+++ b/src/admin/src/pages/songs/[id].astro
@@ -1,13 +1,6 @@
 ---
-import { EditableForm } from '../../components/song/EditableForm';
+import { DetailView } from '../../components/song/EditableForm';
 import Layout from '../../layouts/Layout.astro';
-import { client } from '../../utils/client';
-
-export const prerender = false;
-
-interface Props {
-  id: string;
-}
 
 const { id } = Astro.params;
 
@@ -15,21 +8,10 @@ if (typeof id !== 'string') {
   // TODO ちゃんとしたハンドリングをする
   throw new Error('URL が不正');
 }
-
-const { data, status } = await client.api.songs({ songId: id })['edit-form'].get({
-  headers: {
-    'x-csrf-token': Astro.cookies.get('csrf')?.value ?? '',
-    'cookie': Astro.request.headers.get('cookie') ?? '',
-  },
-});
-
-if (status === 401) {
-  return Astro.redirect('/auth/login');
-}
 ---
 
 <Layout pageTitle="楽曲詳細">
   <div>
-    <EditableForm data={data ?? undefined} status={status} client:only="solid-js" />
+    <DetailView songId={id} client:only="solid-js" />
   </div>
 </Layout>

--- a/src/admin/src/pages/songs/create/index.astro
+++ b/src/admin/src/pages/songs/create/index.astro
@@ -1,24 +1,10 @@
 ---
 import { FlashMessage } from '../../../components/Flash';
-import { CreateForm } from '../../../components/song/CreateForm';
+import { CreateView } from '../../../components/song/CreateForm';
 import Layout from '../../../layouts/Layout.astro';
-import { client } from '../../../utils/client';
-
-export const prerender = false;
-
-const { data, status } = await client.api.songs['create-form'].get({
-  headers: {
-    'x-csrf-token': Astro.cookies.get('csrf')?.value ?? '',
-    'cookie': Astro.request.headers.get('cookie') ?? '',
-  },
-});
-
-if (status === 401) {
-  return Astro.redirect('/auth/login');
-}
 ---
 
 <Layout pageTitle="楽曲作成">
   <FlashMessage client:only="solid-js" />
-  <CreateForm data={data ?? undefined} status={status} client:only="solid-js" />
+  <CreateView client:only="solid-js" />
 </Layout>

--- a/src/admin/src/pages/songs/index.astro
+++ b/src/admin/src/pages/songs/index.astro
@@ -2,8 +2,6 @@
 import { FlashMessage } from '../../components/Flash';
 import { SearchList } from '../../components/song/SearchList';
 import Layout from '../../layouts/Layout.astro';
-
-export const prerender = false;
 ---
 
 <Layout pageTitle="楽曲一覧">


### PR DESCRIPTION
## 概要

管理画面ページの front matter で実行していた API リクエストを Solid コンポーネント側へ移し、SSR/front matter とクライアント側で分かれていた取得方式を統一します。

## やったこと

- 一覧・詳細・作成補助データ取得を `createResource` ベースのコンポーネント内 API 呼び出しへ移行
- `src/admin/src/pages` 配下の `client.api` 実行と `prerender = false` を削除
- 楽曲種別・管理ユーザー一覧の Solid コンポーネントを追加
- Astro 動的ルートを含むコミットで pre-commit の admin lint が失敗しないよう、lefthook の admin lint を全体実行に変更
- `mise run admin:lint` が通ることを確認

## やってないこと

- 既存の `src/server/routes/*` / `src/server/client.ts` 由来の TypeScript エラー修正

## 関連

- 特になし