### PR TITLE
Viewer にサイトポリシー・お問い合わせページを追加

### DIFF
--- a/src/viewer/src/components/common/Footer.astro
+++ b/src/viewer/src/components/common/Footer.astro
@@ -7,6 +7,9 @@
           <img src="/logo-light.svg" alt="" class="footer-logo footer-logo-light" />
           <div class="footer-brand-mark">ヰ世界観測所</div>
         </div>
+        <p class="footer-disclaimer">
+          当サイトは非公式ファンサイトです。<br />ヰ世界情緒および関係各社とは一切関係ありません。<br />当サイトで扱う楽曲・画像・映像などの著作権等はすべて各権利者に帰属します。
+        </p>
       </div>
       <div class="footer-col">
         <h4>Archive</h4>
@@ -31,14 +34,10 @@
       <div class="footer-col">
         <h4>About</h4>
         <ul>
-          <li>このサイトについて</li>
-          <li>お問い合わせ</li>
-          <li>クレジット</li>
+          <li><a href="/site-policy">サイトポリシー</a></li>
+          <li><a href="/contact">お問い合わせ</a></li>
         </ul>
       </div>
-    </div>
-    <div class="footer-bottom">
-      <div>UNOFFICIAL FAN SITE</div>
     </div>
   </div>
 </footer>

--- a/src/viewer/src/pages/contact.astro
+++ b/src/viewer/src/pages/contact.astro
@@ -1,0 +1,18 @@
+---
+import SectionHead from '../components/viewer/SectionHead.astro';
+import Layout from '../layouts/Layout.astro';
+import { CONTACT_X_HANDLE, CONTACT_X_URL } from '../shared/contact';
+---
+
+<Layout pageTitle="お問い合わせ" pageDescription="ヰ世界観測所のお問い合わせ">
+  <section class="shell page-section">
+    <SectionHead title="お問い合わせ" />
+
+    <div class="policy-doc">
+      <p>
+        当サイトに関するお問い合わせは、
+        <a href={CONTACT_X_URL} target="_blank" rel="noopener noreferrer">X(旧 Twitter) {CONTACT_X_HANDLE}</a> までご連絡ください。
+      </p>
+    </div>
+  </section>
+</Layout>

--- a/src/viewer/src/pages/site-policy.astro
+++ b/src/viewer/src/pages/site-policy.astro
@@ -1,0 +1,46 @@
+---
+import SectionHead from '../components/viewer/SectionHead.astro';
+import Layout from '../layouts/Layout.astro';
+import { CONTACT_X_HANDLE, CONTACT_X_URL } from '../shared/contact';
+
+const LAST_UPDATED = '2026年6月14日';
+---
+
+<Layout pageTitle="サイトポリシー" pageDescription="ヰ世界観測所のサイトポリシー">
+  <section class="shell page-section">
+    <SectionHead title="サイトポリシー" />
+
+    <div class="policy-doc">
+      <div class="label-mono policy-updated">最終更新日：{LAST_UPDATED}</div>
+
+      <h2>当サイトについて</h2>
+      <p>
+        当サイトは、ヰ世界情緒に関する情報を、いちファンが個人的に整理・記録している非公式のファンサイトです。
+        ヰ世界情緒、所属事務所、その他の関係各社とは一切関係がありません。当サイトの内容について、これらの公式に問い合わせることはおやめください。
+        最新かつ正確な情報は、必ず各公式の発表・チャンネルをご確認ください。
+      </p>
+      <p>
+        当サイトで扱う楽曲・画像・映像などの著作権その他の権利は、すべて各権利者に帰属します。
+      </p>
+
+      <h2>アクセス解析ツールについて</h2>
+      <p>
+        当サイトでは、サイトの改善に役立てるため、利用状況の把握に Cloudflare Web Analytics を使用しています。
+        Cookie を使用せず、個人を特定するものではありません。
+      </p>
+
+      <h2>免責事項</h2>
+      <ul>
+        <li>当サイトに掲載する情報の正確性・最新性・完全性を保証するものではありません。</li>
+        <li>当サイトの利用、または利用できないことによって生じたいかなる損害についても、運営者は責任を負いません。</li>
+        <li>当サイトからリンクする外部サイトの内容について、運営者は責任を負いません。</li>
+      </ul>
+
+      <h2>お問い合わせ・権利者の方へ</h2>
+      <p>
+        当サイトの内容に関するお問い合わせ、および権利者の方からの掲載内容の修正・削除のご要望は、
+        <a href={CONTACT_X_URL} target="_blank" rel="noopener noreferrer">X(旧 Twitter) {CONTACT_X_HANDLE}</a> までご連絡ください。
+      </p>
+    </div>
+  </section>
+</Layout>

--- a/src/viewer/src/shared/contact.ts
+++ b/src/viewer/src/shared/contact.ts
@@ -1,0 +1,3 @@
+// 運営者への連絡先（サイトポリシー・お問い合わせページで共有）
+export const CONTACT_X_HANDLE = '@sayuprc';
+export const CONTACT_X_URL = 'https://x.com/sayuprc';

--- a/src/viewer/src/styles/viewer.css
+++ b/src/viewer/src/styles/viewer.css
@@ -1002,6 +1002,14 @@ image-slot:hover {
   letter-spacing: 0.1em;
 }
 
+.footer-disclaimer {
+  max-width: 320px;
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.8;
+  color: var(--fg-muted);
+}
+
 .footer-tagline {
   font-family: "Cormorant Garamond", serif;
   font-size: 14px;
@@ -1036,18 +1044,6 @@ image-slot:hover {
 
 .footer-col li:hover {
   color: var(--fg);
-}
-
-.footer-bottom {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding-top: 24px;
-  font-family: "JetBrains Mono", monospace;
-  font-size: 11px;
-  color: var(--fg-faint);
-  letter-spacing: 0.1em;
-  border-top: 1px solid var(--line-soft);
 }
 
 /* ─── Detail Panel ─── */
@@ -1368,6 +1364,10 @@ image-slot:hover {
   font-style: italic;
   letter-spacing: 0.04em;
   color: var(--fg-faint);
+}
+
+.hero-data-stat-date {
+  font-family: Spectral, serif;
 }
 
 .hero-symbol {
@@ -2653,8 +2653,7 @@ image-slot:hover {
     padding-left: 20px;
   }
 
-  .hero-actions,
-  .footer-bottom {
+  .hero-actions {
     flex-direction: column;
   }
 
@@ -2738,4 +2737,47 @@ image-slot:hover {
   .media-mosaic {
     grid-auto-rows: 116px;
   }
+}
+
+/* ポリシー文書（サイトポリシー / プライバシーポリシー） */
+
+.policy-doc {
+  max-width: 920px;
+  font-size: 15px;
+  line-height: 2;
+  color: var(--fg);
+}
+
+.policy-updated {
+  margin: 8px 0 40px;
+}
+
+.policy-doc h2 {
+  margin: 48px 0 16px;
+  font-size: 20px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.policy-doc h2:first-of-type {
+  margin-top: 0;
+}
+
+.policy-doc p {
+  margin: 0 0 18px;
+}
+
+.policy-doc ul {
+  margin: 0 0 18px;
+  padding-left: 1.4em;
+}
+
+.policy-doc li {
+  margin-bottom: 8px;
+}
+
+.policy-doc a {
+  color: var(--fg);
+  text-decoration: underline;
+  text-underline-offset: 3px;
 }


### PR DESCRIPTION
## 概要

Viewer に法務系の固定ページ（サイトポリシー・お問い合わせ）を新設し、非公式ファンサイトとしての立場・権利関係・アクセス解析の扱いを明示します。

## やったこと

- サイトポリシー `/site-policy` を新設。当サイトについて／著作権の帰属／アクセス解析ツール（Cloudflare Web Analytics）／免責事項／お問い合わせ・権利者の方へ、を記載
- お問い合わせ `/contact` を新設（X で連絡）
- フッターに非公式・権利帰属の注記（`.footer-disclaimer`）と、サイトポリシー／お問い合わせへの導線を追加
- ポリシー文書用の prose スタイル `.policy-doc` を `viewer.css` に追加

## やってないこと

- メールでのお問い合わせ窓口（当面は X のみ。将来追加する場合はプライバシー記載も併せて検討）
- アクセスログ（ホスティング事業者側）の詳細記載

## 関連

- 特になし