### PR TITLE
楽曲詳細のメディア表示形式を調整

### DIFF
--- a/src/contracts/generated/oas/IsekaiObservatory.Viewer.v1.yaml
+++ b/src/contracts/generated/oas/IsekaiObservatory.Viewer.v1.yaml
@@ -427,6 +427,9 @@ components:
               type:
                 name: 動画
                 value: 1
+              format:
+                name: MV
+                value: 1
               publishedAt: '2024-03-01'
     SongDetailMediaSummary:
       type: object
@@ -434,6 +437,7 @@ components:
         - mediaId
         - title
         - type
+        - format
         - publishedAt
       properties:
         mediaId:
@@ -442,6 +446,8 @@ components:
           $ref: '#/components/schemas/mediaTitle'
         type:
           $ref: '#/components/schemas/MediaType'
+        format:
+          $ref: '#/components/schemas/MediaFormat'
         publishedAt:
           $ref: '#/components/schemas/mediaPublishedAt'
       examples:
@@ -449,6 +455,9 @@ components:
           title: 描き続けた君へ MV
           type:
             name: 動画
+            value: 1
+          format:
+            name: MV
             value: 1
           publishedAt: '2024-03-01'
     SongDetailResponse:
@@ -479,6 +488,9 @@ components:
                 title: 描き続けた君へ MV
                 type:
                   name: 動画
+                  value: 1
+                format:
+                  name: MV
                   value: 1
                 publishedAt: '2024-03-01'
     SongListItem:

--- a/src/contracts/src/viewer/songs/domain.tsp
+++ b/src/contracts/src/viewer/songs/domain.tsp
@@ -94,12 +94,14 @@ scalar mediaPublishedAt extends string;
   mediaId: "11111111-1111-1111-1111-111111111111",
   title: "描き続けた君へ MV",
   type: #{ name: "動画", value: MediaTypeValue.video },
+  format: #{ name: "MV", value: MediaFormatValue.mv },
   publishedAt: "2024-03-01",
 })
 model SongDetailMediaSummary {
   mediaId: mediaId;
   title: mediaTitle;
   type: MediaType;
+  format: MediaFormat;
   publishedAt: mediaPublishedAt;
 }
 
@@ -117,6 +119,7 @@ model SongDetailMediaSummary {
       mediaId: "11111111-1111-1111-1111-111111111111",
       title: "描き続けた君へ MV",
       type: #{ name: "動画", value: MediaTypeValue.video },
+      format: #{ name: "MV", value: MediaFormatValue.mv },
       publishedAt: "2024-03-01",
     }
   ],

--- a/src/contracts/src/viewer/songs/transport.tsp
+++ b/src/contracts/src/viewer/songs/transport.tsp
@@ -51,6 +51,7 @@ model SongListResponse {
         mediaId: "11111111-1111-1111-1111-111111111111",
         title: "描き続けた君へ MV",
         type: #{ name: "動画", value: MediaTypeValue.video },
+        format: #{ name: "MV", value: MediaFormatValue.mv },
         publishedAt: "2024-03-01",
       }
     ],

--- a/src/server/app/Http/Presenters/Api/Viewer/V1/Song/GetPresenter.php
+++ b/src/server/app/Http/Presenters/Api/Viewer/V1/Song/GetPresenter.php
@@ -33,7 +33,7 @@ class GetPresenter
     }
 
     /**
-     * @return array{songId: string, title: string, description: string, type: array{name: string, value: 1|2}, counts: array{mediaCount: int}, lyricists: array<string>, composers: array<string>, arrangers: array<string>, media: array<array{mediaId: string, title: string, type: array{name: string, value: int}, publishedAt: string}>}
+     * @return array{songId: string, title: string, description: string, type: array{name: string, value: 1|2}, counts: array{mediaCount: int}, lyricists: array<string>, composers: array<string>, arrangers: array<string>, media: array<array{mediaId: string, title: string, type: array{name: string, value: int}, format: array{name: string, value: int}, publishedAt: string}>}
      */
     private function toArray(SongDetail $song): array
     {
@@ -58,7 +58,7 @@ class GetPresenter
     }
 
     /**
-     * @return array{mediaId: string, title: string, type: array{name: string, value: int}, publishedAt: string}
+     * @return array{mediaId: string, title: string, type: array{name: string, value: int}, format: array{name: string, value: int}, publishedAt: string}
      */
     private function toMediaArray(SongDetailMediaSummary $media): array
     {
@@ -68,6 +68,10 @@ class GetPresenter
             'type' => [
                 'name' => $media->type->getName(),
                 'value' => $media->type->value,
+            ],
+            'format' => [
+                'name' => $media->format->getName(),
+                'value' => $media->format->value,
             ],
             'publishedAt' => $media->publishedAt->format('Y-m-d'),
         ];

--- a/src/server/packages/Song/Application/Viewer/Query/SongDetailMediaSummary.php
+++ b/src/server/packages/Song/Application/Viewer/Query/SongDetailMediaSummary.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Song\Application\Viewer\Query;
 
 use DateTimeImmutable;
+use Media\Domain\Models\MediaFormat;
 use Media\Domain\Models\MediaType;
 
 readonly class SongDetailMediaSummary
@@ -13,6 +14,7 @@ readonly class SongDetailMediaSummary
         public string $mediaId,
         public string $title,
         public MediaType $type,
+        public MediaFormat $format,
         public DateTimeImmutable $publishedAt,
     ) {
     }

--- a/src/server/packages/Song/Infrastructures/Viewer/SongQueryService.php
+++ b/src/server/packages/Song/Infrastructures/Viewer/SongQueryService.php
@@ -10,6 +10,7 @@ use App\Models\Song\SongPerson;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Media\Domain\Models\MediaFormat;
 use Media\Domain\Models\MediaType;
 use Override;
 use Song\Application\Viewer\Query\SongDetail;
@@ -118,7 +119,7 @@ readonly class SongQueryService implements SongQueryServiceInterface
                     ->whereHas('media', fn (Builder $mediaQuery) => $mediaQuery->where('is_display', true))
                     ->orderBy('order_no'),
                 'songMediaLinks.media' => fn (BelongsTo $query) => $query
-                    ->select(['media_id', 'title', 'type', 'published_at']),
+                    ->select(['media_id', 'title', 'type', 'format', 'published_at']),
             ])
             ->first();
 
@@ -132,6 +133,7 @@ readonly class SongQueryService implements SongQueryServiceInterface
                 $this->converter->toUuid($link->media->media_id),
                 $link->media->title,
                 MediaType::from($link->media->type),
+                MediaFormat::from($link->media->format),
                 $link->media->published_at->toDateTimeImmutable(),
             ))
             ->values()

--- a/src/server/tests/Feature/Api/Viewer/V1/Song/GetSongTest.php
+++ b/src/server/tests/Feature/Api/Viewer/V1/Song/GetSongTest.php
@@ -117,6 +117,10 @@ class GetSongTest extends DatabaseTestCase
                                 'name' => '動画',
                                 'value' => 1,
                             ],
+                            'format' => [
+                                'name' => 'MV',
+                                'value' => 1,
+                            ],
                             'publishedAt' => '2024-03-01',
                         ],
                         [
@@ -125,6 +129,10 @@ class GetSongTest extends DatabaseTestCase
                             'type' => [
                                 'name' => '記事',
                                 'value' => 2,
+                            ],
+                            'format' => [
+                                'name' => 'その他',
+                                'value' => 99,
                             ],
                             'publishedAt' => '2024-05-01',
                         ],

--- a/src/viewer/src/components/viewer/details/MediaDetailContent.astro
+++ b/src/viewer/src/components/viewer/details/MediaDetailContent.astro
@@ -28,8 +28,9 @@ const formatPublishedAt = (value: string): string =>
 <div class="detail-page-content media-detail-content">
   {/* <MVThumb color={tileColor} label={`${media.type.name}`} /> */}
 
-  <div class="label-mono" style="margin-top: 28px;">
-    {formatPublishedAt(media.publishedAt)} · {media.type.name} · {media.format.name}
+  <div class="label-mono">
+    {/* {formatPublishedAt(media.publishedAt)} · {media.type.name} · {media.format.name} */}
+    {formatPublishedAt(media.publishedAt)} · {media.format.name}
     {/* API に views が無いため未提供セクションとして雛形を残す */}
     {/* {entry.views ? ` · ${entry.views} views` : ''} */}
   </div>
@@ -38,7 +39,8 @@ const formatPublishedAt = (value: string): string =>
   {/* {entry.description && <p class="detail-description" style="margin-top: 16px;">{entry.description}</p>} */}
 
   <div style="display:flex;flex-wrap:wrap;gap:12px;margin-top:32px;margin-bottom:8px;">
-    <a class="btn" href={media.url} target="_blank" rel="noopener noreferrer">{media.type.name}で開く ↗</a>
+    {/* 将来的に様々なプラットフォーム名を表示できるようにする */}
+    <a class="btn" href={media.url} target="_blank" rel="noopener noreferrer">YouTube で開く ↗</a>
   </div>
 
   {

--- a/src/viewer/src/components/viewer/details/SongDetailContent.astro
+++ b/src/viewer/src/components/viewer/details/SongDetailContent.astro
@@ -97,7 +97,7 @@ const formatPublishedAt = (value: string): string =>
 flex-shrink:0;width:38px;height:38px;" /> */}
               <div class="rel-copy">
                 <div class="rel-main">{entry.title}</div>
-                <div class="label-mono" style=" margin-top: 2px;font-size: 10px;">{formatPublishedAt(entry.publishedAt)} · {entry.type.name}</div>
+                <div class="label-mono" style=" margin-top: 2px;font-size: 10px;">{formatPublishedAt(entry.publishedAt)}{/* · {entry.type.name} */} · {entry.format.name}</div>
               </div>
               <span style="font-size:14px;color:var(--fg-faint);">→</span>
             </a>

--- a/src/viewer/src/generated/types.gen.ts
+++ b/src/viewer/src/generated/types.gen.ts
@@ -98,6 +98,7 @@ export type SongDetailMediaSummary = {
     mediaId: MediaId;
     title: MediaTitle;
     type: MediaType;
+    format: MediaFormat;
     publishedAt: MediaPublishedAt;
 };
 

--- a/src/viewer/src/shared/labels.ts
+++ b/src/viewer/src/shared/labels.ts
@@ -3,7 +3,7 @@ export function kindLabel(kind: string): string {
     {
       song: '楽曲',
       release: 'リリース',
-      media: '映像',
+      media: 'メディア',
       event: '出来事',
     }[kind] ?? kind
   );


### PR DESCRIPTION
## 概要

楽曲詳細 API の関連メディア情報にフォーマットを含め、Viewer 側のメディア表示を種別ではなくフォーマット基準に調整します。

## やったこと

- 楽曲詳細の関連メディアレスポンスに `format` を追加
- API Presenter / QueryService / Feature Test を `format` に対応
- Viewer の楽曲詳細・メディア詳細表示でメディアフォーマット名を表示
- Viewer の種別ラベルで `media` を「メディア」に変更

## やってないこと

- メディア詳細 API へのプラットフォーム名追加
- `bunx tsc --noEmit` で既存検出されている `response` undefined エラーの修正

## 関連

- 特になし

## 検証

- `docker compose exec php php artisan test tests/Feature/Api/Viewer/V1/Song/GetSongTest.php`
- `bunx tsc --noEmit` は `src/features/*/api.ts` の `response` が undefined になり得る既存エラーで失敗
