### PR TITLE
viewer ビルド時の API 同時実行数を制限

### DIFF
--- a/src/pnpm-lock.yaml
+++ b/src/pnpm-lock.yaml
@@ -225,6 +225,9 @@ importers:
       daisyui:
         specifier: catalog:ui
         version: 5.5.20
+      p-limit:
+        specifier: 7.3.0
+        version: 7.3.0
       solid-js:
         specifier: catalog:astro
         version: 1.9.13

--- a/src/viewer/package.json
+++ b/src/viewer/package.json
@@ -30,6 +30,7 @@
     "@tailwindcss/vite": "catalog:ui",
     "astro": "catalog:astro",
     "daisyui": "catalog:ui",
+    "p-limit": "7.3.0",
     "solid-js": "catalog:astro",
     "tailwindcss": "catalog:ui",
     "wrangler": "4.98.0"

--- a/src/viewer/src/features/media/api.ts
+++ b/src/viewer/src/features/media/api.ts
@@ -14,7 +14,7 @@ async function all(): Promise<Media[]> {
     });
 
     if (!data) {
-      throw new Error(`mediaServiceListMedia failed: HTTP ${response.status} ${JSON.stringify(error)}`);
+      throw new Error(`mediaServiceListMedia failed: HTTP ${response?.status ?? 'unknown'} ${JSON.stringify(error)}`);
     }
 
     media.push(...data.media);
@@ -36,7 +36,7 @@ async function get(mediaId: string): Promise<MediaDetail> {
     });
 
     if (!data) {
-      throw new Error(`mediaServiceGetMedia failed: HTTP ${response.status} ${JSON.stringify(error)}`);
+      throw new Error(`mediaServiceGetMedia failed: HTTP ${response?.status ?? 'unknown'} ${JSON.stringify(error)}`);
     }
 
     return data.media;

--- a/src/viewer/src/features/media/api.ts
+++ b/src/viewer/src/features/media/api.ts
@@ -1,5 +1,6 @@
 import { mediaServiceGetMedia, mediaServiceListMedia } from '../../generated/sdk.gen.js';
 import { apiClient } from '../../shared/api/client.js';
+import { apiLimit } from '../../shared/api/concurrency.js';
 import type { Media, MediaDetail } from './types.js';
 
 async function all(): Promise<Media[]> {
@@ -28,16 +29,18 @@ async function all(): Promise<Media[]> {
 }
 
 async function get(mediaId: string): Promise<MediaDetail> {
-  const { data, error, response } = await mediaServiceGetMedia({
-    client: apiClient,
-    path: { mediaId },
+  return apiLimit(async () => {
+    const { data, error, response } = await mediaServiceGetMedia({
+      client: apiClient,
+      path: { mediaId },
+    });
+
+    if (!data) {
+      throw new Error(`mediaServiceGetMedia failed: HTTP ${response.status} ${JSON.stringify(error)}`);
+    }
+
+    return data.media;
   });
-
-  if (!data) {
-    throw new Error(`mediaServiceGetMedia failed: HTTP ${response.status} ${JSON.stringify(error)}`);
-  }
-
-  return data.media;
 }
 
 export const mediaRepository = {

--- a/src/viewer/src/features/site-stats/api.ts
+++ b/src/viewer/src/features/site-stats/api.ts
@@ -8,7 +8,7 @@ async function get(): Promise<SiteStats> {
   });
 
   if (!data) {
-    throw new Error(`siteStatsServiceGetSiteStats failed: HTTP ${response.status} ${JSON.stringify(error)}`);
+    throw new Error(`siteStatsServiceGetSiteStats failed: HTTP ${response?.status ?? 'unknown'} ${JSON.stringify(error)}`);
   }
 
   return data;

--- a/src/viewer/src/features/songs/api.ts
+++ b/src/viewer/src/features/songs/api.ts
@@ -14,7 +14,7 @@ async function all(): Promise<Song[]> {
     });
 
     if (!data) {
-      throw new Error(`songServiceListSongs failed: HTTP ${response.status} ${JSON.stringify(error)}`);
+      throw new Error(`songServiceListSongs failed: HTTP ${response?.status ?? 'unknown'} ${JSON.stringify(error)}`);
     }
 
     songs.push(...data.songs);
@@ -36,7 +36,7 @@ async function get(songId: string): Promise<SongDetail> {
     });
 
     if (!data) {
-      throw new Error(`songServiceGetSong failed: HTTP ${response.status} ${JSON.stringify(error)}`);
+      throw new Error(`songServiceGetSong failed: HTTP ${response?.status ?? 'unknown'} ${JSON.stringify(error)}`);
     }
 
     return data.song;

--- a/src/viewer/src/features/songs/api.ts
+++ b/src/viewer/src/features/songs/api.ts
@@ -1,5 +1,6 @@
 import { songServiceGetSong, songServiceListSongs } from '../../generated/sdk.gen.js';
 import { apiClient } from '../../shared/api/client.js';
+import { apiLimit } from '../../shared/api/concurrency.js';
 import type { Song, SongDetail } from './types.js';
 
 async function all(): Promise<Song[]> {
@@ -28,16 +29,18 @@ async function all(): Promise<Song[]> {
 }
 
 async function get(songId: string): Promise<SongDetail> {
-  const { data, error, response } = await songServiceGetSong({
-    client: apiClient,
-    path: { songId },
+  return apiLimit(async () => {
+    const { data, error, response } = await songServiceGetSong({
+      client: apiClient,
+      path: { songId },
+    });
+
+    if (!data) {
+      throw new Error(`songServiceGetSong failed: HTTP ${response.status} ${JSON.stringify(error)}`);
+    }
+
+    return data.song;
   });
-
-  if (!data) {
-    throw new Error(`songServiceGetSong failed: HTTP ${response.status} ${JSON.stringify(error)}`);
-  }
-
-  return data.song;
 }
 
 export const songRepository = {

--- a/src/viewer/src/shared/api/concurrency.ts
+++ b/src/viewer/src/shared/api/concurrency.ts
@@ -2,7 +2,7 @@ import pLimit from 'p-limit';
 
 // ビルド時、getStaticPaths が詳細取得 (repository.get) を一斉に並列化するため、
 // API への同時リクエスト数を制限してサーバー側の負荷 (429) を抑える。
-const MAX_CONCURRENT_REQUESTS = 1;
+const MAX_CONCURRENT_REQUESTS = 5;
 
 // 全リポジトリで共有し、ビルド全体での同時実行数を上限に保つ。
 export const apiLimit = pLimit(MAX_CONCURRENT_REQUESTS);

--- a/src/viewer/src/shared/api/concurrency.ts
+++ b/src/viewer/src/shared/api/concurrency.ts
@@ -1,0 +1,8 @@
+import pLimit from 'p-limit';
+
+// ビルド時、getStaticPaths が詳細取得 (repository.get) を一斉に並列化するため、
+// API への同時リクエスト数を制限してサーバー側の負荷 (429) を抑える。
+const MAX_CONCURRENT_REQUESTS = 1;
+
+// 全リポジトリで共有し、ビルド全体での同時実行数を上限に保つ。
+export const apiLimit = pLimit(MAX_CONCURRENT_REQUESTS);

--- a/src/viewer/src/shared/api/concurrency.ts
+++ b/src/viewer/src/shared/api/concurrency.ts
@@ -2,7 +2,7 @@ import pLimit from 'p-limit';
 
 // ビルド時、getStaticPaths が詳細取得 (repository.get) を一斉に並列化するため、
 // API への同時リクエスト数を制限してサーバー側の負荷 (429) を抑える。
-const MAX_CONCURRENT_REQUESTS = 5;
+const MAX_CONCURRENT_REQUESTS = 2;
 
 // 全リポジトリで共有し、ビルド全体での同時実行数を上限に保つ。
 export const apiLimit = pLimit(MAX_CONCURRENT_REQUESTS);


### PR DESCRIPTION
## 概要

API サーバーが耐えきれないので同時実行数を制限した
