### PR TITLE
Viewer drawer の fragment 読み込みを調整

### DIFF
--- a/src/viewer/src/components/viewer/DetailDrawer.tsx
+++ b/src/viewer/src/components/viewer/DetailDrawer.tsx
@@ -92,7 +92,6 @@ const fetchTargetFragment = (target: DrawerTarget): Promise<string> => {
 export const DetailDrawer = () => {
   const [stack, setStack] = createSignal<DrawerTarget[]>([]);
   const [content, setContent] = createSignal('');
-  const [isLoading, setIsLoading] = createSignal(false);
   const [shareLabel, setShareLabel] = createSignal('共有');
   let loadSequence = 0;
   let bodyRef: HTMLDivElement | undefined;
@@ -105,7 +104,6 @@ export const DetailDrawer = () => {
   const loadTarget = async (target: DrawerTarget, commitStack: () => void) => {
     const sequence = loadSequence + 1;
     loadSequence = sequence;
-    setIsLoading(true);
 
     try {
       const html = await fetchTargetFragment(target);
@@ -121,10 +119,6 @@ export const DetailDrawer = () => {
         window.location.href = target.pathname;
       }
       return false;
-    } finally {
-      if (sequence === loadSequence) {
-        setIsLoading(false);
-      }
     }
   };
 
@@ -144,7 +138,6 @@ export const DetailDrawer = () => {
     loadSequence += 1;
     setStack([]);
     setContent('');
-    setIsLoading(false);
     setShareLabel('共有');
   };
 
@@ -267,7 +260,7 @@ export const DetailDrawer = () => {
                 </button>
               </div>
             </div>
-            <div class={`detail-body ${isLoading() ? 'detail-body-loading' : ''}`} aria-busy={isLoading()} ref={bodyRef}>
+            <div class="detail-body" ref={bodyRef}>
               <Show when={content()}>
                 <div innerHTML={content()}></div>
               </Show>

--- a/src/viewer/src/components/viewer/DetailDrawer.tsx
+++ b/src/viewer/src/components/viewer/DetailDrawer.tsx
@@ -188,22 +188,6 @@ export const DetailDrawer = () => {
     void openDrawer(drawerTarget.pathname);
   };
 
-  const prefetchDrawerTarget = (eventTarget: EventTarget | null) => {
-    const target = resolveAnchorTarget(eventTarget);
-    if (!target) return;
-
-    void fetchTargetFragment(target).catch(() => undefined);
-  };
-
-  const handleDocumentPointerOver = (event: PointerEvent) => {
-    if (event.pointerType === 'touch') return;
-    prefetchDrawerTarget(event.target);
-  };
-
-  const handleDocumentFocusIn = (event: FocusEvent) => {
-    prefetchDrawerTarget(event.target);
-  };
-
   const handleKeyDown = (event: KeyboardEvent) => {
     if (event.key === 'Escape' && current()) {
       closeDrawer();
@@ -212,14 +196,10 @@ export const DetailDrawer = () => {
 
   onMount(() => {
     document.addEventListener('click', handleDocumentClick);
-    document.addEventListener('pointerover', handleDocumentPointerOver);
-    document.addEventListener('focusin', handleDocumentFocusIn);
     window.addEventListener('keydown', handleKeyDown);
 
     return () => {
       document.removeEventListener('click', handleDocumentClick);
-      document.removeEventListener('pointerover', handleDocumentPointerOver);
-      document.removeEventListener('focusin', handleDocumentFocusIn);
       window.removeEventListener('keydown', handleKeyDown);
     };
   });

--- a/src/viewer/src/components/viewer/DetailDrawer.tsx
+++ b/src/viewer/src/components/viewer/DetailDrawer.tsx
@@ -10,6 +10,10 @@ interface DrawerTarget {
   pathname: string;
 }
 
+const maxCachedFragments = 8;
+const fragmentHtmlCache = new Map<string, string>();
+const fragmentRequestCache = new Map<string, Promise<string>>();
+
 const resolveDrawerTarget = (pathname: string): DrawerTarget | null => {
   const patterns = [
     { fragment: '/fragments/songs/', kind: 'song' as const, prefix: '/songs/' },
@@ -32,11 +36,65 @@ const resolveDrawerTarget = (pathname: string): DrawerTarget | null => {
   return null;
 };
 
+const resolveAnchorTarget = (eventTarget: EventTarget | null): DrawerTarget | null => {
+  if (!(eventTarget instanceof Element)) return null;
+
+  const anchor = eventTarget.closest('a[href]');
+  if (!(anchor instanceof HTMLAnchorElement)) return null;
+  if (anchor.dataset.drawerBypass === 'true') return null;
+  if (anchor.target && anchor.target !== '_self') return null;
+
+  const url = new URL(anchor.href, window.location.origin);
+  if (url.origin !== window.location.origin) return null;
+
+  return resolveDrawerTarget(url.pathname);
+};
+
+const fetchTargetFragment = (target: DrawerTarget): Promise<string> => {
+  const cachedHtml = fragmentHtmlCache.get(target.fragmentPath);
+  if (cachedHtml !== undefined) {
+    fragmentHtmlCache.delete(target.fragmentPath);
+    fragmentHtmlCache.set(target.fragmentPath, cachedHtml);
+    return Promise.resolve(cachedHtml);
+  }
+
+  const cachedRequest = fragmentRequestCache.get(target.fragmentPath);
+  if (cachedRequest) return cachedRequest;
+
+  const request = fetch(target.fragmentPath)
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error(`Failed to fetch ${target.fragmentPath}: ${response.status}`);
+      }
+
+      return response.text();
+    })
+    .then((html) => {
+      fragmentHtmlCache.set(target.fragmentPath, html);
+      if (fragmentHtmlCache.size > maxCachedFragments) {
+        const oldestKey = fragmentHtmlCache.keys().next().value;
+        if (oldestKey !== undefined) {
+          fragmentHtmlCache.delete(oldestKey);
+        }
+      }
+      fragmentRequestCache.delete(target.fragmentPath);
+      return html;
+    })
+    .catch((error: unknown) => {
+      fragmentRequestCache.delete(target.fragmentPath);
+      throw error;
+    });
+
+  fragmentRequestCache.set(target.fragmentPath, request);
+  return request;
+};
+
 export const DetailDrawer = () => {
   const [stack, setStack] = createSignal<DrawerTarget[]>([]);
   const [content, setContent] = createSignal('');
   const [isLoading, setIsLoading] = createSignal(false);
   const [shareLabel, setShareLabel] = createSignal('共有');
+  let loadSequence = 0;
   let bodyRef: HTMLDivElement | undefined;
 
   const current = createMemo(() => {
@@ -44,41 +102,46 @@ export const DetailDrawer = () => {
     return items[items.length - 1] ?? null;
   });
 
-  const loadTarget = async (target: DrawerTarget) => {
+  const loadTarget = async (target: DrawerTarget, commitStack: () => void) => {
+    const sequence = loadSequence + 1;
+    loadSequence = sequence;
     setIsLoading(true);
 
     try {
-      const response = await fetch(target.fragmentPath);
-      if (!response.ok) {
-        window.location.href = target.pathname;
-        return;
-      }
+      const html = await fetchTargetFragment(target);
+      if (sequence !== loadSequence) return false;
 
-      const html = await response.text();
+      commitStack();
       setContent(html);
       bodyRef?.scrollTo({ top: 0, behavior: 'auto' });
       setShareLabel('共有');
+      return true;
     } catch {
-      window.location.href = target.pathname;
+      if (sequence === loadSequence) {
+        window.location.href = target.pathname;
+      }
+      return false;
     } finally {
-      setIsLoading(false);
+      if (sequence === loadSequence) {
+        setIsLoading(false);
+      }
     }
   };
 
   const openDrawer = async (pathname: string) => {
     const target = resolveDrawerTarget(pathname);
     if (!target) return false;
+    if (current()?.pathname === target.pathname) return true;
 
-    setStack((prev) => {
+    return loadTarget(target, () => setStack((prev) => {
       const last = prev[prev.length - 1];
       if (last?.pathname === target.pathname) return prev;
       return [...prev, target];
-    });
-    await loadTarget(target);
-    return true;
+    }));
   };
 
   const closeDrawer = () => {
+    loadSequence += 1;
     setStack([]);
     setContent('');
     setIsLoading(false);
@@ -94,8 +157,7 @@ export const DetailDrawer = () => {
 
     const nextStack = prev.slice(0, -1);
     const target = nextStack[nextStack.length - 1];
-    setStack(nextStack);
-    await loadTarget(target);
+    await loadTarget(target, () => setStack(nextStack));
   };
 
   const handleShare = async () => {
@@ -126,22 +188,27 @@ export const DetailDrawer = () => {
     if (event.button !== 0) return;
     if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
 
-    const target = event.target;
-    if (!(target instanceof Element)) return;
-
-    const anchor = target.closest('a[href]');
-    if (!(anchor instanceof HTMLAnchorElement)) return;
-    if (anchor.dataset.drawerBypass === 'true') return;
-    if (anchor.target && anchor.target !== '_self') return;
-
-    const url = new URL(anchor.href, window.location.origin);
-    if (url.origin !== window.location.origin) return;
-
-    const drawerTarget = resolveDrawerTarget(url.pathname);
+    const drawerTarget = resolveAnchorTarget(event.target);
     if (!drawerTarget) return;
 
     event.preventDefault();
-    void openDrawer(url.pathname);
+    void openDrawer(drawerTarget.pathname);
+  };
+
+  const prefetchDrawerTarget = (eventTarget: EventTarget | null) => {
+    const target = resolveAnchorTarget(eventTarget);
+    if (!target) return;
+
+    void fetchTargetFragment(target).catch(() => undefined);
+  };
+
+  const handleDocumentPointerOver = (event: PointerEvent) => {
+    if (event.pointerType === 'touch') return;
+    prefetchDrawerTarget(event.target);
+  };
+
+  const handleDocumentFocusIn = (event: FocusEvent) => {
+    prefetchDrawerTarget(event.target);
   };
 
   const handleKeyDown = (event: KeyboardEvent) => {
@@ -152,10 +219,14 @@ export const DetailDrawer = () => {
 
   onMount(() => {
     document.addEventListener('click', handleDocumentClick);
+    document.addEventListener('pointerover', handleDocumentPointerOver);
+    document.addEventListener('focusin', handleDocumentFocusIn);
     window.addEventListener('keydown', handleKeyDown);
 
     return () => {
       document.removeEventListener('click', handleDocumentClick);
+      document.removeEventListener('pointerover', handleDocumentPointerOver);
+      document.removeEventListener('focusin', handleDocumentFocusIn);
       window.removeEventListener('keydown', handleKeyDown);
     };
   });
@@ -196,12 +267,9 @@ export const DetailDrawer = () => {
                 </button>
               </div>
             </div>
-            <div class={`detail-body ${isLoading() ? 'detail-body-loading' : ''}`} ref={bodyRef}>
-              <Show when={content()} fallback={<div class="drawer-loading">Loading…</div>}>
+            <div class={`detail-body ${isLoading() ? 'detail-body-loading' : ''}`} aria-busy={isLoading()} ref={bodyRef}>
+              <Show when={content()}>
                 <div innerHTML={content()}></div>
-              </Show>
-              <Show when={isLoading() && content()}>
-                <div class="drawer-loading-overlay">Loading…</div>
               </Show>
             </div>
           </aside>

--- a/src/viewer/src/styles/viewer.css
+++ b/src/viewer/src/styles/viewer.css
@@ -1122,31 +1122,6 @@ image-slot:hover {
   opacity: 0.72;
 }
 
-.drawer-loading {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 240px;
-  font-family: "JetBrains Mono", monospace;
-  font-size: 12px;
-  color: var(--fg-muted);
-  letter-spacing: 0.12em;
-}
-
-.drawer-loading-overlay {
-  position: absolute;
-  top: 16px;
-  right: 20px;
-  padding: 6px 10px;
-  font-family: "JetBrains Mono", monospace;
-  font-size: 10px;
-  color: var(--fg-muted);
-  letter-spacing: 0.12em;
-  pointer-events: none;
-  background: color-mix(in oklab, var(--bg-elev) 92%, transparent);
-  border: 1px solid var(--line);
-}
-
 .detail-title {
   margin: 10px 0 4px;
   font-family: "Noto Serif JP", "Shippori Mincho", serif;

--- a/src/viewer/src/styles/viewer.css
+++ b/src/viewer/src/styles/viewer.css
@@ -1118,10 +1118,6 @@ image-slot:hover {
   overflow-y: auto;
 }
 
-.detail-body-loading .detail-page-content {
-  opacity: 0.72;
-}
-
 .detail-title {
   margin: 10px 0 4px;
   font-family: "Noto Serif JP", "Shippori Mincho", serif;


### PR DESCRIPTION
## 概要

Viewer の詳細 drawer で fragment 取得中に Loading 表示が出る挙動を抑えます。
クリック前の先読みと小さなメモリキャッシュで、drawer 表示時の待ち時間を軽減します。

## やったこと

- drawer 対象リンクの解決処理を共通化
- fragment の取得結果と取得中 Promise を drawer 側で再利用するように変更
- hover / focus 時に fragment を先読みするように変更
- HTML キャッシュを最大 8 件に制限
- Loading 表示用の drawer CSS を削除

## やってないこと

- Viewer の API 取得処理で発生している既存の build / 型検査エラーの修正
- fragment の永続キャッシュ化

## 関連

- 特になし