### PR TITLE
更新 UseCase で存在確認するよう修正

### DIFF
--- a/src/server/packages/Media/Application/Admin/UseCase/Update/UpdateUseCase.php
+++ b/src/server/packages/Media/Application/Admin/UseCase/Update/UpdateUseCase.php
@@ -6,6 +6,7 @@ namespace Media\Application\Admin\UseCase\Update;
 
 use AdminUser\Domain\Models\Permission;
 use LogicException;
+use Media\Domain\Models\MediaId;
 use Media\Domain\Models\MediaRepositoryInterface;
 use Media\Domain\Services\MediaIntegrityService;
 use ResultType\Err;
@@ -20,6 +21,7 @@ use Support\UseCase\AuditLog\AuditLogRecorderInterface;
 use Support\UseCase\AuditLog\AuditTargetType;
 use Support\UseCase\Authorizer\UseCaseAuthorizer;
 use Support\UseCase\Error\InvalidInputError;
+use Support\UseCase\Error\NotFoundError;
 use Support\UseCase\Error\UseCaseError;
 
 readonly class UpdateUseCase
@@ -47,32 +49,38 @@ readonly class UpdateUseCase
      */
     private function updateMedia(UpdateInputData $inputData): Result
     {
-        return $this->transaction->scope(function () use ($inputData): Result {
-            $result = $this->service->prepareForUpdate(
-                $inputData->mediaId,
-                $inputData->title,
-                $inputData->url,
-                $inputData->publishedAt,
-                $inputData->typeValue,
-                $inputData->formatValue,
-                $inputData->isDisplay,
-            );
+        return MediaId::create($inputData->mediaId)
+            ->mapErr(fn (EntityRuleViolationError $e): UseCaseError => new InvalidInputError([$e->field => [$e->message]]))
+            ->andThen(fn (MediaId $mediaId): Result => $this->transaction->scope(function () use ($inputData, $mediaId): Result {
+                if (is_null($this->repository->find($mediaId))) {
+                    return new Err(new NotFoundError('Media', $mediaId->value));
+                }
 
-            if ($result->isErr()) {
-                return new Err($this->handleError($result->unwrapErr()));
-            }
+                $result = $this->service->prepareForUpdate(
+                    $inputData->mediaId,
+                    $inputData->title,
+                    $inputData->url,
+                    $inputData->publishedAt,
+                    $inputData->typeValue,
+                    $inputData->formatValue,
+                    $inputData->isDisplay,
+                );
 
-            $media = $this->repository->save($result->unwrap());
+                if ($result->isErr()) {
+                    return new Err($this->handleError($result->unwrapErr()));
+                }
 
-            $this->recorder->record(
-                AuditAction::Update,
-                AuditTargetType::Media,
-                $media->mediaId,
-                $media->toArray(),
-            );
+                $media = $this->repository->save($result->unwrap());
 
-            return new Ok(new UpdateOutputData($media));
-        });
+                $this->recorder->record(
+                    AuditAction::Update,
+                    AuditTargetType::Media,
+                    $media->mediaId,
+                    $media->toArray(),
+                );
+
+                return new Ok(new UpdateOutputData($media));
+            }));
     }
 
     private function handleError(DomainError $error): UseCaseError

--- a/src/server/packages/Person/Application/Admin/UseCase/Update/UpdateUseCase.php
+++ b/src/server/packages/Person/Application/Admin/UseCase/Update/UpdateUseCase.php
@@ -6,6 +6,7 @@ namespace Person\Application\Admin\UseCase\Update;
 
 use AdminUser\Domain\Models\Permission;
 use LogicException;
+use Person\Domain\Models\PersonId;
 use Person\Domain\Models\PersonRepositoryInterface;
 use Person\Domain\Services\PersonIntegrityService;
 use ResultType\Err;
@@ -22,6 +23,7 @@ use Support\UseCase\AuditLog\AuditTargetType;
 use Support\UseCase\Authorizer\UseCaseAuthorizer;
 use Support\UseCase\Error\BusinessLogicError;
 use Support\UseCase\Error\InvalidInputError;
+use Support\UseCase\Error\NotFoundError;
 use Support\UseCase\Error\UseCaseError;
 
 readonly class UpdateUseCase
@@ -49,26 +51,32 @@ readonly class UpdateUseCase
      */
     private function updatePerson(UpdateInputData $inputData): Result
     {
-        return $this->transaction->scope(function () use ($inputData): Result {
-            $result = $this->service->prepareForUpdate($inputData->personId, $inputData->name, $inputData->orderNo);
+        return PersonId::create($inputData->personId)
+            ->mapErr(fn (EntityRuleViolationError $e): UseCaseError => new InvalidInputError([$e->field => [$e->message]]))
+            ->andThen(fn (PersonId $personId): Result => $this->transaction->scope(function () use ($inputData, $personId): Result {
+                if (is_null($this->repository->find($personId))) {
+                    return new Err(new NotFoundError('Person', $personId->value));
+                }
 
-            if ($result->isErr()) {
-                return new Err($this->handleError($result->unwrapErr()));
-            }
+                $result = $this->service->prepareForUpdate($inputData->personId, $inputData->name, $inputData->orderNo);
 
-            $person = $result->unwrap();
+                if ($result->isErr()) {
+                    return new Err($this->handleError($result->unwrapErr()));
+                }
 
-            $this->repository->save($person);
+                $person = $result->unwrap();
 
-            $this->recorder->record(
-                AuditAction::Update,
-                AuditTargetType::Person,
-                $person->personId,
-                $person->toArray(),
-            );
+                $this->repository->save($person);
 
-            return new Ok(new UpdateOutputData($person));
-        });
+                $this->recorder->record(
+                    AuditAction::Update,
+                    AuditTargetType::Person,
+                    $person->personId,
+                    $person->toArray(),
+                );
+
+                return new Ok(new UpdateOutputData($person));
+            }));
     }
 
     private function handleError(DomainError $error): UseCaseError

--- a/src/server/packages/Song/Application/Admin/UseCase/Update/UpdateUseCase.php
+++ b/src/server/packages/Song/Application/Admin/UseCase/Update/UpdateUseCase.php
@@ -10,6 +10,7 @@ use ResultType\Err;
 use ResultType\Ok;
 use ResultType\Result;
 use Song\Application\Admin\Assemble\SongAssembler;
+use Song\Domain\Models\SongId;
 use Song\Domain\Models\SongRepositoryInterface;
 use Song\Domain\Services\SongIntegrityService;
 use Support\Contracts\TransactionInterface;
@@ -23,6 +24,7 @@ use Support\UseCase\AuditLog\AuditTargetType;
 use Support\UseCase\Authorizer\UseCaseAuthorizer;
 use Support\UseCase\Error\BusinessLogicError;
 use Support\UseCase\Error\InvalidInputError;
+use Support\UseCase\Error\NotFoundError;
 use Support\UseCase\Error\UseCaseError;
 
 readonly class UpdateUseCase
@@ -51,35 +53,41 @@ readonly class UpdateUseCase
      */
     private function updateSong(UpdateInputData $inputData): Result
     {
-        return $this->transaction->scope(function () use ($inputData): Result {
-            $result = $this->service->prepareForUpdate(
-                $inputData->songId,
-                $inputData->title,
-                $inputData->description,
-                $inputData->lyricsLink,
-                $inputData->typeValue,
-                $inputData->isDisplay,
-                $inputData->orderNo,
-                $inputData->tags,
-                $inputData->persons,
-                $inputData->media,
-            );
+        return SongId::create($inputData->songId)
+            ->mapErr(fn (EntityRuleViolationError $e): UseCaseError => new InvalidInputError([$e->field => [$e->message]]))
+            ->andThen(fn (SongId $songId): Result => $this->transaction->scope(function () use ($inputData, $songId): Result {
+                if (is_null($this->repository->find($songId))) {
+                    return new Err(new NotFoundError('Song', $songId->value));
+                }
 
-            if ($result->isErr()) {
-                return new Err($this->handleError($result->unwrapErr()));
-            }
+                $result = $this->service->prepareForUpdate(
+                    $inputData->songId,
+                    $inputData->title,
+                    $inputData->description,
+                    $inputData->lyricsLink,
+                    $inputData->typeValue,
+                    $inputData->isDisplay,
+                    $inputData->orderNo,
+                    $inputData->tags,
+                    $inputData->persons,
+                    $inputData->media,
+                );
 
-            $song = $this->repository->save($result->unwrap());
+                if ($result->isErr()) {
+                    return new Err($this->handleError($result->unwrapErr()));
+                }
 
-            $this->recorder->record(
-                AuditAction::Update,
-                AuditTargetType::Song,
-                $song->songId,
-                $song->toArray(),
-            );
+                $song = $this->repository->save($result->unwrap());
 
-            return new Ok(new UpdateOutputData($this->assembler->assemble($song)));
-        });
+                $this->recorder->record(
+                    AuditAction::Update,
+                    AuditTargetType::Song,
+                    $song->songId,
+                    $song->toArray(),
+                );
+
+                return new Ok(new UpdateOutputData($this->assembler->assemble($song)));
+            }));
     }
 
     private function handleError(DomainError $error): UseCaseError

--- a/src/server/tests/Feature/Api/Admin/V1/Media/UpdateMediaTest.php
+++ b/src/server/tests/Feature/Api/Admin/V1/Media/UpdateMediaTest.php
@@ -96,6 +96,22 @@ class UpdateMediaTest extends DatabaseTestCase
     }
 
     #[Test]
+    public function updateFailsWhenMediaDoesNotExist(): void
+    {
+        $mediaId = $this->generateUuid();
+
+        $this->withAuth()
+            ->putJson(route(MediaRouteMap::Update, $mediaId), [
+                'title' => 'テストメディア',
+                'url' => 'https://example.com/media',
+                'publishedAt' => '2024-04-02',
+                'typeValue' => MediaType::Video->value,
+                'formatValue' => MediaFormat::Mv->value,
+                'isDisplay' => true,
+            ])->assertStatus(404);
+    }
+
+    #[Test]
     public function emptyParameters(): void
     {
         $uuid = $this->generateUuid();

--- a/src/server/tests/Feature/Api/Admin/V1/Person/UpdatePersonTest.php
+++ b/src/server/tests/Feature/Api/Admin/V1/Person/UpdatePersonTest.php
@@ -63,6 +63,18 @@ class UpdatePersonTest extends DatabaseTestCase
     }
 
     #[Test]
+    public function updateFailsWhenPersonDoesNotExist(): void
+    {
+        $personId = $this->generateUuid();
+
+        $this->withAuth()
+            ->putJson(route(PersonRouteMap::Update, $personId), [
+                'name' => 'テスト人物',
+                'orderNo' => 20,
+            ])->assertStatus(404);
+    }
+
+    #[Test]
     public function updateFailsWhenNameAlreadyExists(): void
     {
         $targetId = $this->generateUuid();

--- a/src/server/tests/Feature/Api/Admin/V1/Song/UpdateSongTest.php
+++ b/src/server/tests/Feature/Api/Admin/V1/Song/UpdateSongTest.php
@@ -254,6 +254,25 @@ class UpdateSongTest extends DatabaseTestCase
     }
 
     #[Test]
+    public function updateFailsWhenSongDoesNotExist(): void
+    {
+        $songId = $this->generateUuid();
+
+        $this->withAuth()
+            ->putJson(route(SongRouteMap::Update, $songId), [
+                'title' => 'テスト楽曲',
+                'description' => 'テスト楽曲説明',
+                'lyricsLink' => null,
+                'typeValue' => SongType::Original->value,
+                'isDisplay' => true,
+                'orderNo' => 1,
+                'persons' => [],
+                'tags' => [],
+                'media' => [],
+            ])->assertStatus(404);
+    }
+
+    #[Test]
     public function updateFailsWithNotExistsSongTag(): void
     {
         $songId = $this->generateUuid();

--- a/src/server/tests/Integration/Media/Application/Admin/UseCase/UpdateUseCaseTest.php
+++ b/src/server/tests/Integration/Media/Application/Admin/UseCase/UpdateUseCaseTest.php
@@ -12,6 +12,7 @@ use Media\Domain\Models\MediaType;
 use PHPUnit\Framework\Attributes\Test;
 use Support\UseCase\AuditLog\AuditAction;
 use Support\UseCase\AuditLog\AuditTargetType;
+use Support\UseCase\Error\NotFoundError;
 use Tests\Support\Concerns\AssertsAuditLog;
 use Tests\Support\DatabaseTestCase;
 use Tests\Support\Domain\EntityFactory;
@@ -68,6 +69,28 @@ class UpdateUseCaseTest extends DatabaseTestCase
         $this->assertSame(MediaType::SocialPost->value, $log['snapshot']['type']);
         $this->assertSame(MediaFormat::StreamArchive->value, $log['snapshot']['format']);
         $this->assertFalse($log['snapshot']['is_display']);
+    }
+
+    #[Test]
+    public function updateFailsWhenMediaDoesNotExist(): void
+    {
+        $mediaId = $this->generateUuid();
+
+        $result = $this->getInstance()->handle(
+            new UpdateInputData(
+                $mediaId,
+                'テストメディア',
+                'https://example.com/media',
+                '2024-04-02',
+                MediaType::Video->value,
+                MediaFormat::Mv->value,
+                true,
+            ),
+        );
+
+        $this->assertTrue($result->isErr());
+        $this->assertInstanceOf(NotFoundError::class, $result->unwrapErr());
+        $this->assertDatabaseMissing(ModelsMedia::class, ['title' => 'テストメディア']);
     }
 
     private function getInstance(): UpdateUseCase

--- a/src/server/tests/Integration/Person/Application/Admin/UseCase/Update/UpdateUseCaseTest.php
+++ b/src/server/tests/Integration/Person/Application/Admin/UseCase/Update/UpdateUseCaseTest.php
@@ -10,6 +10,7 @@ use Person\Domain\Models\PersonRepositoryInterface;
 use PHPUnit\Framework\Attributes\Test;
 use Support\UseCase\AuditLog\AuditAction;
 use Support\UseCase\AuditLog\AuditTargetType;
+use Support\UseCase\Error\NotFoundError;
 use Tests\Support\Concerns\AssertsAuditLog;
 use Tests\Support\DatabaseTestCase;
 use Tests\Support\Domain\EntityFactory;
@@ -41,6 +42,20 @@ class UpdateUseCaseTest extends DatabaseTestCase
         $log = $this->findAuditLog(AuditAction::Update, AuditTargetType::Person, $personId);
         $this->assertSame('テスト人物', $log['snapshot']['name']);
         $this->assertSame(20, $log['snapshot']['order_no']);
+    }
+
+    #[Test]
+    public function updateFailsWhenPersonDoesNotExist(): void
+    {
+        $personId = $this->generateUuid();
+
+        $result = $this->getInstance()->handle(new UpdateInputData($personId, 'テスト人物', 20));
+
+        $this->assertTrue($result->isErr());
+        $this->assertInstanceOf(NotFoundError::class, $result->unwrapErr());
+
+        $persons = $this->app->make(PersonRepositoryInterface::class)->all();
+        $this->assertCount(0, $persons);
     }
 
     private function getInstance(): UpdateUseCase

--- a/src/server/tests/Integration/Song/Application/Admin/UseCase/UpdateUseCaseTest.php
+++ b/src/server/tests/Integration/Song/Application/Admin/UseCase/UpdateUseCaseTest.php
@@ -11,6 +11,7 @@ use Song\Application\Admin\UseCase\Update\UpdateUseCase;
 use Song\Domain\Models\SongType;
 use Support\UseCase\AuditLog\AuditAction;
 use Support\UseCase\AuditLog\AuditTargetType;
+use Support\UseCase\Error\NotFoundError;
 use Tests\Support\Concerns\AssertsAuditLog;
 use Tests\Support\DatabaseTestCase;
 use Tests\Support\Domain\EntityFactory;
@@ -88,6 +89,30 @@ class UpdateUseCaseTest extends DatabaseTestCase
         $log = $this->findAuditLog(AuditAction::Update, AuditTargetType::Song, $songId);
         $this->assertSame('テスト楽曲', $log['snapshot']['title']);
         $this->assertCount(2, $log['snapshot']['persons']);
+    }
+
+    #[Test]
+    public function updateFailsWhenSongDoesNotExist(): void
+    {
+        $songId = $this->generateUuid();
+
+        $result = $this->getInstance()->handle(
+            new UpdateInputData(
+                $songId,
+                'テスト楽曲',
+                'テスト楽曲説明',
+                null,
+                SongType::Original->value,
+                true,
+                1,
+                [],
+                [],
+            ),
+        );
+
+        $this->assertTrue($result->isErr());
+        $this->assertInstanceOf(NotFoundError::class, $result->unwrapErr());
+        $this->assertDatabaseMissing(Song::class, ['title' => 'テスト楽曲']);
     }
 
     private function getInstance(): UpdateUseCase

--- a/src/server/tests/Unit/Song/Application/Admin/UseCase/UpdateUseCaseTest.php
+++ b/src/server/tests/Unit/Song/Application/Admin/UseCase/UpdateUseCaseTest.php
@@ -18,12 +18,14 @@ use Song\Application\Admin\UseCase\Update\UpdateInputData;
 use Song\Application\Admin\UseCase\Update\UpdateUseCase;
 use Song\Domain\Models\Persons\SongPersonRole;
 use Song\Domain\Models\Song;
+use Song\Domain\Models\SongId;
 use Song\Domain\Models\SongRepositoryInterface;
 use Song\Domain\Models\SongType;
 use Song\Domain\Services\SongIntegrityService;
 use Support\Contracts\TransactionInterface;
 use Support\Domain\Error\DomainValidationError;
 use Support\UseCase\AuditLog\AuditLogRecorderInterface;
+use Support\UseCase\Error\NotFoundError;
 use Tests\Support\Domain\EntityFactory;
 use Tests\TestCase;
 
@@ -73,6 +75,11 @@ class UpdateUseCaseTest extends TestCase
         $this->transaction->shouldReceive('scope')
             ->withArgs(fn (Closure $_) => true)
             ->andReturnUsing(fn (Closure $arg) => $arg())
+            ->once();
+
+        $this->repository->shouldReceive('find')
+            ->withArgs(fn (SongId $arg): bool => $arg->value === $songId)
+            ->andReturn($this->createSong($songId, $title, $description, $lyricsLink, SongType::from($typeValue), true, 1))
             ->once();
 
         $this->service->shouldReceive('prepareForUpdate')
@@ -156,6 +163,11 @@ class UpdateUseCaseTest extends TestCase
             ->andReturnUsing(fn (Closure $arg) => $arg())
             ->once();
 
+        $this->repository->shouldReceive('find')
+            ->withArgs(fn (SongId $arg): bool => $arg->value === $songId)
+            ->andReturn($this->createSong($songId, $title, $description, $lyricsLink, SongType::Original, true, 1))
+            ->once();
+
         $this->service->shouldReceive('prepareForUpdate')
             ->with($songId, $title, $description, $lyricsLink, $typeValue, $isDisplay, $orderNo, [], $persons, [])
             ->andReturn(new Err(new DomainValidationError([])))
@@ -176,6 +188,42 @@ class UpdateUseCaseTest extends TestCase
         );
 
         $this->assertTrue($result->isErr());
+    }
+
+    #[Test]
+    public function updateFailsIfSongDoesNotExist(): void
+    {
+        $songId = 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA';
+
+        $this->transaction->shouldReceive('scope')
+            ->withArgs(fn (Closure $_) => true)
+            ->andReturnUsing(fn (Closure $arg) => $arg())
+            ->once();
+
+        $this->repository->shouldReceive('find')
+            ->withArgs(fn (SongId $arg): bool => $arg->value === $songId)
+            ->andReturnNull()
+            ->once();
+
+        $this->service->shouldNotReceive('prepareForUpdate');
+        $this->repository->shouldNotReceive('save');
+
+        $result = $this->getInstance()->handle(
+            new UpdateInputData(
+                $songId,
+                '曲名',
+                '説明',
+                null,
+                SongType::Original->value,
+                true,
+                1,
+                [],
+                [],
+            ),
+        );
+
+        $this->assertTrue($result->isErr());
+        $this->assertInstanceOf(NotFoundError::class, $result->unwrapErr());
     }
 
     /**


### PR DESCRIPTION
## 概要

API の更新 UseCase で、対象データが存在しない場合に upsert されてしまう問題を修正します。
Media / Person / Song の更新処理で保存前に存在確認し、存在しない ID は 404 にします。

## やったこと

- Media / Person / Song の更新 UseCase に ID 検証と repository の存在確認を追加
- 存在しない更新対象では NotFoundError を返し、保存処理へ進まないように変更
- UseCase / API の not found 回帰テストを追加
- Song 更新 UseCase の unit test を存在確認込みの期待に更新

## やってないこと

- repository の save/upsert の共通仕様変更
- 未追跡の dump.sql / src/server/dump.sql の追加

## 関連

- 特になし