### PR TITLE
ci: php コンテナへの exec をランナーの UID で実行する

### DIFF
--- a/.github/workflows/admin-qa.yaml
+++ b/.github/workflows/admin-qa.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Cache node modules
         id: cache-node-modules
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: |
             src/node_modules
@@ -62,7 +62,7 @@ jobs:
 
       - name: Cache node modules
         id: cache-node-modules
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: |
             src/node_modules
@@ -94,7 +94,7 @@ jobs:
 
       - name: Cache node modules
         id: cache-node-modules
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: |
             src/node_modules
@@ -126,7 +126,7 @@ jobs:
 
       - name: Cache node modules
         id: cache-node-modules
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: |
             src/node_modules

--- a/.github/workflows/contracts-qa.yaml
+++ b/.github/workflows/contracts-qa.yaml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Cache node modules
         id: cache-node-modules
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: |
             src/node_modules
@@ -57,7 +57,7 @@ jobs:
 
       - name: Cache node modules
         id: cache-node-modules
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: |
             src/node_modules

--- a/.github/workflows/server-qa.yaml
+++ b/.github/workflows/server-qa.yaml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Cache server docker image
         id: cache-server-docker-image
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: ${{ env.SERVER_DOCKER_PATH }}
           key: ${{ env.SERVER_DOCKER_KEY_PREFIX }}${{ hashFiles('./infra/local/docker/php/Dockerfile') }}
@@ -59,7 +59,7 @@ jobs:
 
       - name: Cache openapi-generator-cli docker image
         id: cache-openapi-generator-cli-docker-image
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: ${{ env.OPENAPI_GENERATOR_CLI_DOCKER_PATH }}
           key: ${{ env.OPENAPI_GENERATOR_CLI_DOCKER_KEY_PREFIX }}${{ hashFiles('./infra/local/docker/openapi-generator/Dockerfile') }}
@@ -70,7 +70,7 @@ jobs:
 
       - name: Cache mysql docker image
         id: cache-mysql-docker-image
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: ${{ env.MYSQL_DOCKER_PATH }}
           key: ${{ env.MYSQL_DOCKER_KEY_PREFIX }}${{ hashFiles('./infra/local/docker/mysql/Dockerfile', './infra/local/docker/mysql/my.cnf', './infra/local/docker/mysql/init/*') }}
@@ -87,7 +87,7 @@ jobs:
 
       - name: Cache composer
         id: cache-composer
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: ${{ env.VENDOR_PATH }}
           key: ${{ steps.define-variables.outputs.VENDOR_KEY }}
@@ -136,7 +136,7 @@ jobs:
 
       - name: Cache composer
         id: cache-composer
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: ${{ env.VENDOR_PATH }}
           key: ${{ needs.setup.outputs.vendor-key }}
@@ -171,7 +171,7 @@ jobs:
 
       - name: Cache composer
         id: cache-composer
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: ${{ env.VENDOR_PATH }}
           key: ${{ needs.setup.outputs.vendor-key }}
@@ -206,7 +206,7 @@ jobs:
 
       - name: Cache composer
         id: cache-composer
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: ${{ env.VENDOR_PATH }}
           key: ${{ needs.setup.outputs.vendor-key }}
@@ -255,7 +255,7 @@ jobs:
 
       - name: Cache composer
         id: cache-composer
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: ${{ env.VENDOR_PATH }}
           key: ${{ needs.setup.outputs.vendor-key }}

--- a/.github/workflows/viewer-qa.yaml
+++ b/.github/workflows/viewer-qa.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Cache node modules
         id: cache-node-modules
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: |
             src/node_modules
@@ -62,7 +62,7 @@ jobs:
 
       - name: Cache node modules
         id: cache-node-modules
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: |
             src/node_modules
@@ -92,7 +92,7 @@ jobs:
 
       - name: Cache node modules
         id: cache-node-modules
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: |
             src/node_modules
@@ -122,7 +122,7 @@ jobs:
 
       - name: Cache node modules
         id: cache-node-modules
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: |
             src/node_modules

--- a/mise.ci.toml
+++ b/mise.ci.toml
@@ -10,6 +10,10 @@ OPENAPI_GENERATOR_CLI_DOCKER_PATH = "/tmp/cache/docker/openapi-generator-cli"
 OPENAPI_GENERATOR_CLI_DOCKER_KEY_PREFIX = "docker-openapi-generator-cli-"
 MYSQL_DOCKER_PATH = "/tmp/cache/docker/mysql"
 MYSQL_DOCKER_KEY_PREFIX = "docker-mysql-"
+# bind マウントした src/server の所有者はランナー(id -u/-g)。イメージに焼き込まれた
+# UID がこれと食い違うとコンテナから vendor などへ書き込めないため、exec をランナーの
+# UID:GID で実行して所有者と一致させる。
+PHP_EXEC_USER = "--user {{ exec(command='id -u') | trim }}:{{ exec(command='id -g') | trim }}"
 
 [tasks."build:php"]
 description = "CI 向けに PHP イメージをビルドして GHCR にプッシュする"
@@ -57,13 +61,13 @@ run = "docker compose up -d php mysql"
 
 [tasks."api:composer:install"]
 description = "CI 環境で composer install を実行する"
-run = "docker compose exec -T php composer install -n --prefer-dist"
+run = "docker compose exec ${PHP_EXEC_USER} -T php composer install -n --prefer-dist"
 
 [tasks."setup:env"]
 description = "CI 環境の環境変数をセットアップする"
 run = '''
 cp src/server/.env.example src/server/.env
-docker compose exec -T php php artisan key:generate
+docker compose exec ${PHP_EXEC_USER} -T php php artisan key:generate
 '''
 
 [tasks.migrate]


### PR DESCRIPTION
## 概要

Server QA の `Composer install` が `vendor does not exist and could not be created` で失敗していた問題を修正します。CI のコンテナ実行ユーザーを bind マウント所有者（ランナー）に合わせ、書き込みできるようにします。

## やったこと

- `PHP_EXEC_USER` env を導入し、`docker compose exec` をランナーの `UID:GID` で実行するようにした
  - `mise.toml`: 既定は空（ローカルはイメージ既定ユーザーのまま＝挙動不変）。`docker compose exec` 系タスクを `docker compose exec ${PHP_EXEC_USER} …` に統一
  - `mise.ci.toml`: `--user {{ exec(command='id -u') | trim }}:{{ exec(command='id -g') | trim }}` を設定。CI 上書きの `api:composer:install` / `setup:env` にも適用
- `api:generate:*` は既に `-u {{vars.uid}}:{{vars.gid}}` で UID 安全なため対象外

### 背景

CI のサーバーイメージはビルド時の UID が焼き込まれ、その UID でコンテナが動く。一方 `compose.yaml` は `./src/server`（所有者＝ランナー）を `/var/www/html` に bind マウントしている。両 UID が食い違うとコンテナから `vendor` などへ書き込めず `composer install` が失敗する。これまでは composer キャッシュのヒットで `Composer install` ステップごとスキップされ表面化していなかったが、#838 の Dockerfile 変更（`intl` 追加）でイメージが再ビルドされた際に顕在化した。

## やってないこと

- イメージの UID 焼き込みをやめる設計変更（option 2）やビルドキャッシュの見直し（option 3）。今回は影響を最小化するため exec 側の `--user` 指定にとどめた
- `docker compose run` を使うローカル専用の `api:composer:install` は対象外（CI では上書き済み）

## 関連

- 失敗を顕在化させた PR: #838