### PR TITLE
楽曲一覧の表示を改善

### DIFF
--- a/src/viewer/src/components/viewer/SongTile.astro
+++ b/src/viewer/src/components/viewer/SongTile.astro
@@ -1,52 +1,52 @@
 ---
+import { youtubeThumbnailFromUrl, youtubeThumbnailSrcset } from '../../features/media/labels';
+import type { SongMedia } from '../../features/songs/types';
+
 interface Props {
   songId: string;
   title: string;
-  typeName: string;
   mediaCount: number;
   index: number;
+  media?: SongMedia[];
   aspectRatio?: string;
 }
 
-const { songId, title, typeName, mediaCount, index, aspectRatio = '1 / 1' } = Astro.props;
+const { mediaCount, index, media = [], aspectRatio = '16 / 9' } = Astro.props;
 
-const palettes = [
-  ['#b9414f', '#2f6f8f'],
-  ['#9b6a2f', '#496f48'],
-  ['#6a61a8', '#b95d5a'],
-  ['#2f7f73', '#a25878'],
-  ['#7f6540', '#365f8c'],
-  ['#7d5069', '#617745'],
-];
+// プラットフォームとサムネイルは状態として保持せず url から導出する。
+// メディアがあれば最初にサムネイルを導出できたものを採用する。
+const thumbnailUrl = media.reduce<string | null>((found, entry) => found ?? youtubeThumbnailFromUrl(entry.url), null);
 
-function splitGraphemes(value: string): string[] {
-  if (typeof Intl.Segmenter === 'function') {
-    const segmenter = new Intl.Segmenter('ja', { granularity: 'grapheme' });
-
-    return Array.from(segmenter.segment(value), segment => segment.segment);
-  }
-
-  return Array.from(value.normalize('NFC'));
-}
-
-const hash = Array.from(songId).reduce((total, char) => total + char.charCodeAt(0), 0);
-const [colorA, colorB] = palettes[hash % palettes.length];
 const sequence = String(index + 1).padStart(2, '0');
-const initials = splitGraphemes(title.replace(/\s/g, '')).slice(0, 2).join('');
 ---
 
-<div
-  class="song-tile"
-  style={`--song-tile-color-a:${colorA};--song-tile-color-b:${colorB};--song-tile-aspect:${aspectRatio};`}
-  aria-hidden="true"
->
-  <div class="song-tile-top">
-    <span class="song-tile-meta-text">TRACK</span>
-    <span class="song-tile-meta-text">{sequence}</span>
-  </div>
-  <div class="song-tile-signature">{initials}</div>
-  <div class="song-tile-bottom">
-    <span class="song-tile-meta-text">{typeName}</span>
-    <span class="song-tile-meta-text">{mediaCount} MEDIA</span>
-  </div>
+<div class="song-tile" style={`--song-tile-aspect:${aspectRatio};`} aria-hidden="true">
+  {
+    thumbnailUrl
+      ? (
+          <img
+            class="song-tile-image"
+            src={thumbnailUrl}
+            srcset={youtubeThumbnailSrcset(thumbnailUrl)}
+            sizes="(max-width: 640px) 50vw, 240px"
+            loading="lazy"
+            alt=""
+          />
+        )
+      : (
+          <>
+            <div class="song-tile-top">
+              <span class="song-tile-meta-text">{sequence}</span>
+            </div>
+            <span class="song-tile-icon">
+              <svg width="42" height="42" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M9 17.5V6.2l9-1.8v9.4a2.6 2.6 0 1 1-1.5-2.36V6.1L10.5 7.3v9.1A2.6 2.6 0 1 1 9 14.05z" />
+              </svg>
+            </span>
+            <div class="song-tile-bottom">
+              <span class="song-tile-meta-text">{mediaCount} MEDIA</span>
+            </div>
+          </>
+        )
+  }
 </div>

--- a/src/viewer/src/pages/songs/index.astro
+++ b/src/viewer/src/pages/songs/index.astro
@@ -9,9 +9,6 @@ import Layout from '../../layouts/Layout.astro';
 
 const songs = await songContentRepository.all();
 
-// 今後のローンチでジャケットアートの見せ方を定義する
-const showSongVisualLayouts = false;
-
 const formatSongCredits = (lyricists: string[], composers: string[], arrangers: string[]): string =>
   [
     lyricists.length > 0 ? `作詞 ${lyricists.join(' / ')}` : null,
@@ -25,21 +22,17 @@ const formatSongCredits = (lyricists: string[], composers: string[], arrangers: 
 <Layout pageTitle="楽曲">
   <section class="shell page-section">
     <SectionHead title="楽曲">
-      {
-        showSongVisualLayouts && (
-          <LayoutSwitcher
-            client:load
-            slot="right"
-            name="songs"
-            initialValue="grid"
-            options={[
-              { value: 'grid', label: 'GRID' },
-              { value: 'table', label: 'TABLE' },
-              { value: 'card', label: 'CARD' },
-            ]}
-          />
-        )
-      }
+      <LayoutSwitcher
+        client:load
+        slot="right"
+        name="songs"
+        initialValue="grid"
+        options={[
+          { value: 'grid', label: 'GRID' },
+          { value: 'table', label: 'TABLE' },
+          { value: 'card', label: 'CARD' },
+        ]}
+      />
     </SectionHead>
 
     <FilterBar
@@ -56,44 +49,41 @@ const formatSongCredits = (lyricists: string[], composers: string[], arrangers: 
     />
 
     <div data-layout-group="songs">
-      {
-        showSongVisualLayouts && (
-          <div data-layout-panel="grid">
-            <div class="song-grid">
-              {
-                songs.map((song, index) => {
-                  return (
-                    <a
-                      href={`/songs/${song.songId}`}
-                      class="song-grid-card"
-                      data-song-entry
-                      data-song-category={song.type.value}
-                      data-song-search={`${song.title} ${song.lyricists.join(' ')} ${song.composers.join(' ')} ${song.arrangers.join(' ')}`.toLowerCase()}
-                    >
-                      <SongTile
-                        songId={song.songId}
-                        title={song.title}
-                        typeName={song.type.name}
-                        mediaCount={song.counts.mediaCount}
-                        index={index}
-                      />
-                      <div class="song-grid-body">
-                        <div class="song-grid-meta">
-                          <span class="pill">{song.type.name}</span>
-                          <div class="song-meta-inline">
-                            <span>{song.counts.mediaCount} mv</span>
-                          </div>
-                        </div>
-                        <div class="song-grid-title">{song.title}</div>
+      <div data-layout-panel="grid">
+        <div class="song-grid">
+          {
+            songs.map((song, index) => {
+              return (
+                <a
+                  href={`/songs/${song.songId}`}
+                  class="song-grid-card"
+                  data-song-entry
+                  data-song-category={song.type.value}
+                  data-song-search={`${song.title} ${song.lyricists.join(' ')} ${song.composers.join(' ')} ${song.arrangers.join(' ')}`.toLowerCase()}
+                >
+                  <SongTile
+                    songId={song.songId}
+                    title={song.title}
+                    typeName={song.type.name}
+                    mediaCount={song.counts.mediaCount}
+                    index={index}
+                    media={song.media}
+                  />
+                  <div class="song-grid-body">
+                    <div class="song-grid-meta">
+                      <span class="pill" data-song-type={song.type.value}>{song.type.name}</span>
+                      <div class="song-meta-inline">
+                        <span>{song.counts.mediaCount} media</span>
                       </div>
-                    </a>
-                  );
-                })
-              }
-            </div>
-          </div>
-        )
-      }
+                    </div>
+                    <div class="song-grid-title">{song.title}</div>
+                  </div>
+                </a>
+              );
+            })
+          }
+        </div>
+      </div>
 
       <div data-layout-panel="table">
         <EntryStatus client:load entrySelector="[data-song-entry]" label="楽曲" emptySelector="[data-song-empty]" />
@@ -126,7 +116,7 @@ const formatSongCredits = (lyricists: string[], composers: string[], arrangers: 
                       <div class="table-title">{song.title}</div>
                       {credits && <div class="song-row-credit">{credits}</div>}
                     </div>
-                    <span class="song-row-type">{song.type.name}</span>
+                    <span class="song-row-type" data-song-type={song.type.value}>{song.type.name}</span>
                     <span class="song-row-media"><strong>{song.counts.mediaCount}</strong><span>件</span></span>
                   </a>
                 );
@@ -136,43 +126,40 @@ const formatSongCredits = (lyricists: string[], composers: string[], arrangers: 
         </div>
       </div>
 
-      {
-        showSongVisualLayouts && (
-          <div data-layout-panel="card" hidden>
-            <div class="songs-card-grid">
-              {
-                songs.map((song, index) => {
-                  return (
-                    <a
-                      href={`/songs/${song.songId}`}
-                      class="song-card"
-                      data-song-entry
-                      data-song-category={song.type.value}
-                      data-song-search={`${song.title} ${song.lyricists.join(' ')} ${song.composers.join(' ')} ${song.arrangers.join(' ')}`.toLowerCase()}
-                    >
-                      <SongTile
-                        songId={song.songId}
-                        title={song.title}
-                        typeName={song.type.name}
-                        mediaCount={song.counts.mediaCount}
-                        index={index}
-                      />
-                      <div class="song-card-body">
-                        <div class="label-mono">{song.type.name}</div>
-                        <div class="timeline-title">{song.title}</div>
-                        <p class="song-grid-description">{song.description}</p>
-                        <div class="song-card-stats">
-                          <div><span class="detail-index">{song.counts.mediaCount}</span><span class="label-mono">media</span></div>
-                        </div>
-                      </div>
-                    </a>
-                  );
-                })
-              }
-            </div>
-          </div>
-        )
-      }
+      <div data-layout-panel="card" hidden>
+        <div class="songs-card-grid">
+          {
+            songs.map((song, index) => {
+              return (
+                <a
+                  href={`/songs/${song.songId}`}
+                  class="song-card"
+                  data-song-entry
+                  data-song-category={song.type.value}
+                  data-song-search={`${song.title} ${song.lyricists.join(' ')} ${song.composers.join(' ')} ${song.arrangers.join(' ')}`.toLowerCase()}
+                >
+                  <SongTile
+                    songId={song.songId}
+                    title={song.title}
+                    typeName={song.type.name}
+                    mediaCount={song.counts.mediaCount}
+                    index={index}
+                    media={song.media}
+                  />
+                  <div class="song-card-body">
+                    <span class="pill" data-song-type={song.type.value}>{song.type.name}</span>
+                    <div class="timeline-title">{song.title}</div>
+                    <p class="song-grid-description">{song.description}</p>
+                    <div class="song-card-stats">
+                      <div><span class="detail-index">{song.counts.mediaCount}</span><span class="label-mono">media</span></div>
+                    </div>
+                  </div>
+                </a>
+              );
+            })
+          }
+        </div>
+      </div>
     </div>
   </section>
 </Layout>

--- a/src/viewer/src/styles/viewer.css
+++ b/src/viewer/src/styles/viewer.css
@@ -704,6 +704,20 @@ a {
   border-color: transparent;
 }
 
+/* 楽曲種別バッジ: オリジナルはアクセント、カバーは中間色で一目で区別する。 */
+
+.pill[data-song-type="1"] {
+  color: var(--accent-strong);
+  background: color-mix(in oklab, var(--accent) 20%, transparent);
+  border-color: transparent;
+}
+
+.pill[data-song-type="2"] {
+  color: var(--fg-muted);
+  background: color-mix(in oklab, var(--fg) 10%, transparent);
+  border-color: color-mix(in oklab, var(--fg) 24%, transparent);
+}
+
 /* セグメンテッドコントロール */
 
 .seg {
@@ -805,7 +819,7 @@ image-slot:hover {
 
 .song-card {
   display: grid;
-  grid-template-columns: 200px 1fr;
+  grid-template-columns: minmax(0, 5fr) 7fr;
   cursor: pointer;
   background: var(--bg-elev);
   border: 1px solid var(--line);
@@ -879,6 +893,12 @@ image-slot:hover {
   font-size: 13px;
   line-height: 1.5;
   color: var(--fg-muted);
+}
+
+/* テーブルでもオリジナルはアクセント色で強調して区別する。 */
+
+.song-row-type[data-song-type="1"] {
+  color: var(--accent-strong);
 }
 
 .song-row-media {
@@ -1865,6 +1885,22 @@ image-slot:hover {
   padding: 24px;
 }
 
+/* flex カラム内で種別バッジを内容幅に収め、左寄せする。 */
+
+.song-card-body .pill {
+  align-self: flex-start;
+  margin-bottom: 10px;
+}
+
+/* 説明の行数を抑えてカード高さを揃え、左サムネの縦横比を保つ。 */
+
+.song-card .song-grid-description {
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+}
+
 .song-card-stats {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
@@ -1877,6 +1913,12 @@ image-slot:hover {
 .song-card-stats div {
   display: flex;
   flex-direction: column;
+}
+
+/* stats を下端に固定して本文の縦バランスを整える。 */
+
+.song-card .song-card-stats {
+  margin-top: auto;
 }
 
 .media-featured-grid {
@@ -2308,6 +2350,9 @@ image-slot:hover {
   transform: translate(-50%, -50%);
 }
 
+/* サムネイルが無い楽曲のプレースホルダー。実写サムネと並んでも浮かないよう、
+   テーマ連動の中間色にアイコンを主役として据える。 */
+
 .song-tile {
   position: relative;
   display: flex;
@@ -2317,32 +2362,16 @@ image-slot:hover {
   aspect-ratio: var(--song-tile-aspect, 1 / 1);
   padding: 16px;
   overflow: hidden;
-  background:
-    repeating-linear-gradient(90deg, rgba(255, 255, 255, 0.05) 0 1px, transparent 1px 18px),
-    repeating-linear-gradient(0deg, rgba(0, 0, 0, 0.14) 0 1px, transparent 1px 22px),
-    linear-gradient(135deg, var(--song-tile-color-a), var(--song-tile-color-b));
-  border: 1px solid color-mix(in oklab, var(--line) 55%, transparent);
-  isolation: isolate;
+  background: var(--bg-elev-2);
+  border: 1px solid var(--line);
 }
 
-.song-tile::before {
+.song-tile-image {
   position: absolute;
-  inset: 10px;
-  z-index: -1;
-  content: "";
-  border: 1px solid rgba(255, 255, 255, 0.18);
-}
-
-.song-tile::after {
-  position: absolute;
-  right: 18px;
-  bottom: -20%;
-  z-index: -1;
-  width: 24%;
-  height: 140%;
-  content: "";
-  background: rgba(255, 255, 255, 0.1);
-  transform: rotate(18deg);
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }
 
 .song-tile-top,
@@ -2350,11 +2379,11 @@ image-slot:hover {
   display: flex;
   gap: 12px;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-end;
   font-family: "JetBrains Mono", monospace;
   font-size: 10px;
   line-height: 1.2;
-  color: rgba(255, 255, 255, 0.72);
+  color: var(--fg-faint);
 }
 
 .song-tile-meta-text {
@@ -2364,16 +2393,17 @@ image-slot:hover {
   white-space: nowrap;
 }
 
-.song-tile-signature {
+.song-tile-icon {
+  display: flex;
   align-self: center;
-  max-width: 100%;
-  font-family: "Shippori Mincho", "Noto Serif JP", serif;
-  font-size: 56px;
-  font-weight: 500;
-  line-height: 1;
-  color: rgba(255, 255, 255, 0.9);
-  text-align: center;
-  text-shadow: 0 12px 30px rgba(0, 0, 0, 0.28);
+  color: color-mix(in oklab, var(--fg) 30%, transparent);
+}
+
+/* 横並びカードでは左タイルを本文の高さいっぱいに伸ばして揃える。 */
+
+.song-card > .song-tile {
+  height: 100%;
+  aspect-ratio: auto;
 }
 
 .mv-thumb {


### PR DESCRIPTION
## 概要

- Grid/Card 表記を復活させた
- オリジナルとカバーがぱっと見でわかるように色分け