### PR TITLE
ローカル環境で大きめの画像を上げられるように設定を変更

### DIFF
--- a/infra/local/docker/nginx/site.conf
+++ b/infra/local/docker/nginx/site.conf
@@ -5,6 +5,8 @@ server {
 
     server_name local.admin.isekaijoucho.fan;
 
+    client_max_body_size 20M;
+
     location / {
         proxy_http_version 1.1;
         proxy_pass http://host.docker.internal:4321;
@@ -23,6 +25,8 @@ server {
     ssl_certificate_key /etc/nginx/certs/server.key;
 
     server_name local.api.isekaijoucho.fan;
+
+    client_max_body_size 20M;
 
     location / {
         proxy_pass http://php:80;


### PR DESCRIPTION
## 概要

Nginx の設定により本番で利用しようとしていたジャケットアート画像をアップロードできなかったので設定を修正した