### PR TITLE
viewer の空状態表示を改善

### DIFF
--- a/src/viewer/src/components/viewer/EntryStatus.tsx
+++ b/src/viewer/src/components/viewer/EntryStatus.tsx
@@ -21,9 +21,11 @@ export default function EntryStatus(props: Props) {
 
     if (!props.emptySelector) return;
 
-    const emptyElement = document.querySelector(props.emptySelector);
-    if (emptyElement instanceof HTMLElement) {
-      emptyElement.hidden = nextCount !== 0;
+    const emptyElements = document.querySelectorAll(props.emptySelector);
+    for (const emptyElement of emptyElements) {
+      if (emptyElement instanceof HTMLElement) {
+        emptyElement.hidden = nextCount !== 0;
+      }
     }
   };
 

--- a/src/viewer/src/pages/songs/index.astro
+++ b/src/viewer/src/pages/songs/index.astro
@@ -51,6 +51,10 @@ const formatSongCredits = (lyricists: string[], composers: string[], arrangers: 
     <div data-layout-group="songs">
       <div data-layout-panel="grid">
         <div class="song-grid">
+          <div class="entry-empty entry-empty-panel" data-song-empty hidden>
+            <div class="entry-empty-title">該当する楽曲がありません</div>
+            <div class="entry-empty-description">検索語句や種別フィルタを変えて確認してください。</div>
+          </div>
           {
             songs.map((song, index) => {
               return (
@@ -127,6 +131,10 @@ const formatSongCredits = (lyricists: string[], composers: string[], arrangers: 
 
       <div data-layout-panel="card" hidden>
         <div class="songs-card-grid">
+          <div class="entry-empty entry-empty-panel" data-song-empty hidden>
+            <div class="entry-empty-title">該当する楽曲がありません</div>
+            <div class="entry-empty-description">検索語句や種別フィルタを変えて確認してください。</div>
+          </div>
           {
             songs.map((song, index) => {
               return (

--- a/src/viewer/src/styles/viewer.css
+++ b/src/viewer/src/styles/viewer.css
@@ -1972,6 +1972,13 @@ image-slot:hover {
   border-bottom: 1px solid var(--line);
 }
 
+.entry-empty-panel {
+  grid-column: 1 / -1;
+  justify-content: center;
+  min-height: 180px;
+  border: 1px solid var(--line);
+}
+
 .entry-empty[hidden] {
   display: none;
 }


### PR DESCRIPTION
## 概要

楽曲一覧でフィルタ結果が 0 件になったとき、table 表示だけでなく grid / card 表示でも空状態メッセージを表示するようにします。

## やったこと

- grid / card レイアウトに空状態メッセージを追加
- 複数の空状態要素をまとめて show/hide できるよう EntryStatus を更新
- grid / card 内で空状態が全幅表示されるスタイルを追加

## やってないこと

- 楽曲一覧以外のページの空状態表示変更
- 既存のフィルタ条件や検索ロジックの変更

## 関連

- 特になし