### PR TITLE
YouTube ショート判定を追加

### DIFF
--- a/src/server/app/Providers/Domain/MediaServiceProvider.php
+++ b/src/server/app/Providers/Domain/MediaServiceProvider.php
@@ -6,13 +6,17 @@ namespace App\Providers\Domain;
 
 use Google\Client;
 use Google\Service\YouTube;
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\ClientInterface as GuzzleClientInterface;
 use Illuminate\Support\ServiceProvider;
 use Media\Application\Admin\Query\MediaDetailQueryServiceInterface;
+use Media\Application\Cli\Query\YouTubeShortVideoQueryServiceInterface;
 use Media\Application\Cli\Query\YouTubeVideoQueryServiceInterface;
 use Media\Application\Viewer\Query\MediaQueryServiceInterface as ViewerMediaQueryServiceInterface;
 use Media\Domain\Models\MediaRepositoryInterface;
 use Media\Domain\Models\YouTubeChannel\YouTubeChannelRepositoryInterface;
 use Media\Infrastructures\Admin\MediaDetailQueryService;
+use Media\Infrastructures\Cli\YouTubeShortVideoQueryService;
 use Media\Infrastructures\Cli\YouTubeVideoQueryService;
 use Media\Infrastructures\MediaRepository;
 use Media\Infrastructures\Viewer\MediaQueryService as ViewerMediaQueryService;
@@ -29,6 +33,8 @@ class MediaServiceProvider extends ServiceProvider
         $this->app->bind(ViewerMediaQueryServiceInterface::class, ViewerMediaQueryService::class);
         $this->app->bind(YouTubeChannelRepositoryInterface::class, YouTubeChannelRepository::class);
         $this->app->bind(YouTubeVideoQueryServiceInterface::class, YouTubeVideoQueryService::class);
+        $this->app->bind(YouTubeShortVideoQueryServiceInterface::class, YouTubeShortVideoQueryService::class);
+        $this->app->bind(GuzzleClientInterface::class, GuzzleClient::class);
 
         $this->app->bind(YouTube::class, static function (): YouTube {
             $client = new Client();

--- a/src/server/composer.json
+++ b/src/server/composer.json
@@ -13,6 +13,7 @@
     "emonkak/orm": "^5.0",
     "firebase/php-jwt": "^7.0",
     "google/apiclient": "^2.19",
+    "guzzlehttp/guzzle": "^7.13",
     "laravel/framework": "^12.0",
     "laravel/sanctum": "^4.0",
     "laravel/tinker": "^2.10",

--- a/src/server/composer.lock
+++ b/src/server/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c83a86470ab5de524748b4e776ea7f5b",
+    "content-hash": "3bd66b2c6a52bb466b3b4139888f0953",
     "packages": [
         {
             "name": "aws/aws-crt-php",

--- a/src/server/packages/Media/Application/Cli/Query/YouTubeShortVideoQueryServiceInterface.php
+++ b/src/server/packages/Media/Application/Cli/Query/YouTubeShortVideoQueryServiceInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Media\Application\Cli\Query;
+
+interface YouTubeShortVideoQueryServiceInterface
+{
+    /**
+     * @param list<YouTubeUploadedVideo> $videos
+     *
+     * @return array<string, bool> videoId ごとの short 判定
+     */
+    public function detectShorts(array $videos): array;
+}

--- a/src/server/packages/Media/Application/Cli/Query/YouTubeUploadedVideo.php
+++ b/src/server/packages/Media/Application/Cli/Query/YouTubeUploadedVideo.php
@@ -6,10 +6,13 @@ namespace Media\Application\Cli\Query;
 
 readonly class YouTubeUploadedVideo
 {
+    public string $url;
+
     public function __construct(
         public string $videoId,
         public string $title,
         public string $publishedAt,
     ) {
+        $this->url = sprintf('https://www.youtube.com/watch?v=%s', rawurlencode($videoId));
     }
 }

--- a/src/server/packages/Media/Application/Cli/UseCase/ImportYouTube/ImportYouTubeUseCase.php
+++ b/src/server/packages/Media/Application/Cli/UseCase/ImportYouTube/ImportYouTubeUseCase.php
@@ -6,6 +6,8 @@ namespace Media\Application\Cli\UseCase\ImportYouTube;
 
 use DateTimeImmutable;
 use DateTimeZone;
+use Media\Application\Cli\Query\YouTubeShortVideoQueryServiceInterface;
+use Media\Application\Cli\Query\YouTubeUploadedVideo;
 use Media\Application\Cli\Query\YouTubeVideoQueryServiceInterface;
 use Media\Domain\Models\Media;
 use Media\Domain\Models\MediaRepositoryInterface;
@@ -26,6 +28,7 @@ readonly class ImportYouTubeUseCase
         private UuidGeneratorInterface $generator,
         private YouTubeChannelRepositoryInterface $channelRepository,
         private YouTubeVideoQueryServiceInterface $videoQueryService,
+        private YouTubeShortVideoQueryServiceInterface $shortVideoQueryService,
         private MediaRepositoryInterface $mediaRepository,
     ) {
     }
@@ -52,22 +55,35 @@ readonly class ImportYouTubeUseCase
             return ChannelImportResult::channelNotFound($channel);
         }
 
-        $mediaList = [];
+        $videosToImport = [];
 
         foreach ($videos as $video) {
-            $url = MediaUrl::reconstruct('https://www.youtube.com/watch?v=' . $video->videoId);
+            $url = MediaUrl::reconstruct($video->url);
 
             // 動画は新しい順に取得されるため、保存済みの動画に到達した時点で以降は取り込み済みとみなす
             if (! is_null($this->mediaRepository->findByUrl($url))) {
                 break;
             }
 
+            $videosToImport[] = $video;
+        }
+
+        $shortsByVideoId = $this->shortVideoQueryService->detectShorts(
+            array_values(array_filter($videosToImport, fn (YouTubeUploadedVideo $video): bool => ! $this->isKnownShort($video))),
+        );
+
+        $mediaList = [];
+
+        foreach ($videosToImport as $video) {
+            $url = MediaUrl::reconstruct($video->url);
+            $isShort = $this->isKnownShort($video) || ($shortsByVideoId[$video->videoId] ?? false);
+
             $mediaList[] = Media::reconstruct(
                 $this->generator->generate(),
                 $video->title,
                 $url->value,
                 new DateTimeImmutable($video->publishedAt)->setTimezone(new DateTimeZone(date_default_timezone_get())),
-                $this->resolveType($video->title)->value,
+                $this->resolveType($video->title, $isShort)->value,
                 true,
             );
         }
@@ -81,13 +97,18 @@ readonly class ImportYouTubeUseCase
         return ChannelImportResult::imported($channel, count($mediaList));
     }
 
-    private function resolveType(string $title): MediaType
+    private function resolveType(string $title, bool $isShort): MediaType
     {
         return match (true) {
-            str_contains($title, '#shorts') => MediaType::Short,
+            $isShort => MediaType::Short,
             str_contains($title, '【Official Music Video】') => MediaType::Mv,
             str_contains($title, '【歌ってみた】') => MediaType::AudioVideo,
             default => MediaType::Other,
         };
+    }
+
+    private function isKnownShort(YouTubeUploadedVideo $video): bool
+    {
+        return str_contains(mb_strtolower($video->title), '#short');
     }
 }

--- a/src/server/packages/Media/Infrastructures/Cli/YouTubeShortVideoQueryService.php
+++ b/src/server/packages/Media/Infrastructures/Cli/YouTubeShortVideoQueryService.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Media\Infrastructures\Cli;
+
+use Generator;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Pool;
+use Media\Application\Cli\Query\YouTubeShortVideoQueryServiceInterface;
+use Media\Application\Cli\Query\YouTubeUploadedVideo;
+use Override;
+use Psr\Http\Message\ResponseInterface;
+use Throwable;
+
+readonly class YouTubeShortVideoQueryService implements YouTubeShortVideoQueryServiceInterface
+{
+    private const int CONCURRENCY = 8;
+
+    public function __construct(private ClientInterface $httpClient)
+    {
+    }
+
+    #[Override]
+    public function detectShorts(array $videos): array
+    {
+        $results = [];
+
+        $pool = new Pool($this->httpClient, $this->requests($videos), [
+            'concurrency' => self::CONCURRENCY,
+            'fulfilled' => static function (ResponseInterface $response, string $videoId) use (&$results): void {
+                $statusCode = $response->getStatusCode();
+                $results[$videoId] = $statusCode >= 200 && $statusCode < 300;
+            },
+            'rejected' => static function (Throwable $reason, string $videoId) use (&$results): void {
+                $results[$videoId] = false;
+            },
+        ]);
+
+        $pool->promise()->wait();
+
+        return $results;
+    }
+
+    /**
+     * @param list<YouTubeUploadedVideo> $videos
+     *
+     * @return Generator<string, callable(): mixed>
+     */
+    private function requests(array $videos): Generator
+    {
+        foreach ($videos as $video) {
+            yield $video->videoId => fn () => $this->httpClient->requestAsync(
+                'GET',
+                sprintf('https://www.youtube.com/shorts/%s', rawurlencode($video->videoId)),
+                [
+                    'allow_redirects' => false,
+                    'connect_timeout' => 2,
+                    'http_errors' => false,
+                    'timeout' => 5,
+                ],
+            );
+        }
+    }
+}

--- a/src/server/tests/Feature/Console/Commands/Media/ImportYouTubeCommandTest.php
+++ b/src/server/tests/Feature/Console/Commands/Media/ImportYouTubeCommandTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Feature\Console\Commands\Media;
 
 use Illuminate\Support\Facades\DB;
+use Media\Application\Cli\Query\YouTubeShortVideoQueryServiceInterface;
 use Media\Application\Cli\Query\YouTubeUploadedVideo;
 use Media\Application\Cli\Query\YouTubeVideoQueryServiceInterface;
 use Media\Domain\Models\MediaType;
@@ -31,21 +32,23 @@ class ImportYouTubeCommandTest extends DatabaseTestCase
             self::CHANNEL_ID => [
                 new YouTubeUploadedVideo('video-mv', '【Official Music Video】テスト曲', '2024-06-04T10:00:00Z'),
                 new YouTubeUploadedVideo('video-short', 'テスト曲 #shorts', '2024-06-03T10:00:00Z'),
+                new YouTubeUploadedVideo('video-short-no-tag', '縦型動画', '2024-06-03T09:00:00Z'),
                 new YouTubeUploadedVideo('video-cover', '【歌ってみた】テストカバー', '2024-06-02T10:00:00Z'),
                 new YouTubeUploadedVideo('video-other', '雑談配信アーカイブ', '2024-06-01T10:00:00Z'),
             ],
-        ]);
+        ], ['video-short-no-tag']);
 
         $this->artisan('media:youtube:import')
-            ->expectsOutput('テストチャンネル: 4 件取り込みました')
+            ->expectsOutput('テストチャンネル: 5 件取り込みました')
             ->assertSuccessful();
 
         $rows = DB::table('media')->orderByDesc('published_at')->get()->all();
-        $this->assertCount(4, $rows);
+        $this->assertCount(5, $rows);
 
         $expected = [
             ['https://www.youtube.com/watch?v=video-mv', '【Official Music Video】テスト曲', MediaType::Mv, '2024-06-04 19:00:00'],
             ['https://www.youtube.com/watch?v=video-short', 'テスト曲 #shorts', MediaType::Short, '2024-06-03 19:00:00'],
+            ['https://www.youtube.com/watch?v=video-short-no-tag', '縦型動画', MediaType::Short, '2024-06-03 18:00:00'],
             ['https://www.youtube.com/watch?v=video-cover', '【歌ってみた】テストカバー', MediaType::AudioVideo, '2024-06-02 19:00:00'],
             ['https://www.youtube.com/watch?v=video-other', '雑談配信アーカイブ', MediaType::Other, '2024-06-01 19:00:00'],
         ];
@@ -119,7 +122,7 @@ class ImportYouTubeCommandTest extends DatabaseTestCase
     /**
      * @param array<string, list<YouTubeUploadedVideo>> $videosByChannelId
      */
-    private function fakeVideoQueryService(array $videosByChannelId): void
+    private function fakeVideoQueryService(array $videosByChannelId, array $shortVideoIds = []): void
     {
         $this->app->instance(
             YouTubeVideoQueryServiceInterface::class,
@@ -135,6 +138,35 @@ class ImportYouTubeCommandTest extends DatabaseTestCase
                 public function fetchUploadedVideos(YouTubeChannelId $channelId): ?iterable
                 {
                     return $this->videosByChannelId[$channelId->value] ?? null;
+                }
+            },
+        );
+        $this->app->instance(
+            YouTubeShortVideoQueryServiceInterface::class,
+            new readonly class ($shortVideoIds) implements YouTubeShortVideoQueryServiceInterface {
+                /**
+                 * @param list<string> $shortVideoIds
+                 */
+                public function __construct(private array $shortVideoIds)
+                {
+                }
+
+                /**
+                 * @param list<YouTubeUploadedVideo> $videos
+                 *
+                 * @return array<string, bool>
+                 */
+                #[Override]
+                public function detectShorts(array $videos): array
+                {
+                    $shortVideoIds = array_flip($this->shortVideoIds);
+                    $results = [];
+
+                    foreach ($videos as $video) {
+                        $results[$video->videoId] = isset($shortVideoIds[$video->videoId]);
+                    }
+
+                    return $results;
                 }
             },
         );

--- a/src/server/tests/Unit/Media/Infrastructures/Cli/YouTubeShortVideoQueryServiceTest.php
+++ b/src/server/tests/Unit/Media/Infrastructures/Cli/YouTubeShortVideoQueryServiceTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Media\Infrastructures\Cli;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use Media\Application\Cli\Query\YouTubeUploadedVideo;
+use Media\Infrastructures\Cli\YouTubeShortVideoQueryService;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class YouTubeShortVideoQueryServiceTest extends TestCase
+{
+    #[Test]
+    public function detectsShortsByRedirectStatus(): void
+    {
+        $service = new YouTubeShortVideoQueryService(new Client([
+            'handler' => HandlerStack::create(new MockHandler([
+                new Response(200),
+                new Response(302),
+            ])),
+        ]));
+
+        $results = $service->detectShorts([
+            new YouTubeUploadedVideo('short-video', 'ショート動画', '2024-06-03T10:00:00Z'),
+            new YouTubeUploadedVideo('normal-video', '通常動画', '2024-06-02T10:00:00Z'),
+        ]);
+
+        $this->assertSame([
+            'short-video' => true,
+            'normal-video' => false,
+        ], $results);
+    }
+}


### PR DESCRIPTION
## 概要

YouTube 動画取り込み時に、タイトルの `#short` だけでは判定できないショート動画を `/shorts/{videoId}` のリダイレクト有無で判定できるようにします。

## やったこと

- `YouTubeUploadedVideo` に URL を持たせ、取り込み側で URL を組み立てないようにした
- Guzzle を明示依存に追加し、`/shorts/{videoId}` のリダイレクト有無で short 判定するクエリサービスを追加した
- 保存対象の新規動画だけを short 判定し、既知の `#short` 動画は HTTP 判定を省略するようにした
- short 判定の HTTP リクエストを Guzzle Pool で並列化した
- コンソール取り込みテストと short 判定サービスの単体テストを追加した

## やってないこと

- 既存メディアの type 再判定・再取り込みはしていない

## 関連

- 特になし
