### PR TITLE
同一楽曲の複数収録を許可してアンコール等を表現可能にする

### DIFF
--- a/src/admin/src/components/release/MediaEditor.tsx
+++ b/src/admin/src/components/release/MediaEditor.tsx
@@ -1,4 +1,4 @@
-import { For, Index, Show, createMemo, createSignal } from 'solid-js';
+import { For, Index, Show, createSignal } from 'solid-js';
 import type { MediumFormatValue, ReleaseGetResponse, SongSummary } from '../../generated';
 import { client } from '../../utils/client';
 
@@ -63,14 +63,6 @@ export const MediaEditor = (props: MediaEditorProps) => {
   const [hasSearched, setHasSearched] = createSignal(false);
   const [targetMediumIndex, setTargetMediumIndex] = createSignal(0);
 
-  // 楽曲は媒体をまたいでもリリース全体で 1 回まで（タイトルのみトラックには課さない）。
-  const selectedSongIds = createMemo(
-    () =>
-      new Set(
-        props.media.flatMap(medium => medium.tracks.flatMap(track => (track.songId !== null ? [track.songId] : []))),
-      ),
-  );
-
   const addMedium = () => {
     props.onChange(prev => [...prev, { formatValue: 1, tracks: [] }]);
   };
@@ -114,10 +106,6 @@ export const MediaEditor = (props: MediaEditorProps) => {
   };
 
   const addTrack = (song: SongSummary) => {
-    if (selectedSongIds().has(song.songId)) {
-      return;
-    }
-
     appendTrack({ songId: song.songId, title: song.title });
   };
 
@@ -415,10 +403,9 @@ export const MediaEditor = (props: MediaEditorProps) => {
                               <button
                                 type="button"
                                 class="btn btn-primary btn-xs"
-                                disabled={selectedSongIds().has(song.songId)}
                                 onClick={() => addTrack(song)}
                               >
-                                {selectedSongIds().has(song.songId) ? '追加済み' : '追加'}
+                                追加
                               </button>
                             </td>
                           </tr>

--- a/src/server/database/atlas/schemas/release-tracks.my.hcl
+++ b/src/server/database/atlas/schemas/release-tracks.my.hcl
@@ -42,11 +42,6 @@ table "release_tracks" {
     columns = [column.song_id]
   }
 
-  index "release_tracks_release_id_song_id_unique" {
-    unique  = true
-    columns = [column.release_id, column.song_id]
-  }
-
   foreign_key "fk_release_tracks_release_medium" {
     columns     = [column.release_id, column.position]
     ref_columns = [table.release_media.column.release_id, table.release_media.column.position]

--- a/src/server/packages/Release/Domain/Models/Media.php
+++ b/src/server/packages/Release/Domain/Models/Media.php
@@ -25,7 +25,6 @@ readonly class Media extends ImmutableCollection
     {
         $media = [];
         $seenPositions = [];
-        $seenSongIds = [];
 
         foreach ($items as $item) {
             $positionResult = OrderNo::create($item['position']);
@@ -56,21 +55,6 @@ readonly class Media extends ImmutableCollection
                 return new Err(new DomainValidationError([
                     'media' => ['同じ媒体順を複数指定することはできません。'],
                 ]));
-            }
-
-            // 楽曲の重複は媒体をまたいでリリース全体で禁止する（タイトルのみトラックは対象外）。
-            foreach ($medium->tracks as $track) {
-                if (is_null($track->songId)) {
-                    continue;
-                }
-
-                if (isset($seenSongIds[$track->songId->value])) {
-                    return new Err(new DomainValidationError([
-                        'media' => ['同じ楽曲を複数指定することはできません。'],
-                    ]));
-                }
-
-                $seenSongIds[$track->songId->value] = true;
             }
 
             $seenPositions[$medium->position->value] = true;

--- a/src/server/tests/Feature/Api/Admin/V1/Release/CreateReleaseTest.php
+++ b/src/server/tests/Feature/Api/Admin/V1/Release/CreateReleaseTest.php
@@ -140,6 +140,56 @@ class CreateReleaseTest extends DatabaseTestCase
     }
 
     #[Test]
+    public function canCreateWithSameSongInSameMedium(): void
+    {
+        $songId = $this->generateUuid();
+        $releaseGroupId = $this->generateUuid();
+
+        $this->storeSongs(
+            $this->createSong($songId, 'テスト楽曲1', '説明', SongType::Original, true, 1),
+        );
+        $this->storeReleaseGroups(
+            $this->createReleaseGroup($releaseGroupId, '観測された春', ReleaseGroupType::Album, true),
+        );
+
+        // ライブ盤のアンコールなど、同じ楽曲が同一媒体に複数回収録されるケース。
+        $this->withAuth()
+            ->postJson(route(ReleaseRouteMap::Create), [
+                'releaseGroupId' => $releaseGroupId,
+                'name' => 'ライブ盤',
+                'releasedOn' => '2026-05-09',
+                'description' => '',
+                'jacketArtUrl' => null,
+                'isDisplay' => true,
+                'orderNo' => 10,
+                'media' => [
+                    [
+                        'position' => 1,
+                        'formatValue' => MediumFormat::Cd->value,
+                        'tracks' => [
+                            ['songId' => $songId, 'title' => null, 'trackNo' => 1],
+                            ['songId' => $songId, 'title' => null, 'trackNo' => 2],
+                        ],
+                    ],
+                ],
+            ])->assertStatus(200)
+            ->assertJson(
+                static fn (AssertableJson $json) => $json
+                    ->has(
+                        'release',
+                        static fn (AssertableJson $json) => $json
+                            ->where('media.0.tracks.0.songId', $songId)
+                            ->where('media.0.tracks.0.trackNo', 1)
+                            ->where('media.0.tracks.1.songId', $songId)
+                            ->where('media.0.tracks.1.trackNo', 2)
+                            ->etc(),
+                    ),
+            );
+
+        $this->assertDatabaseCount('release_tracks', 2);
+    }
+
+    #[Test]
     public function createFailsWhenTrackHasBothSongIdAndTitle(): void
     {
         $songId = $this->generateUuid();

--- a/src/server/tests/Feature/Api/Admin/V1/Release/UpdateReleaseTest.php
+++ b/src/server/tests/Feature/Api/Admin/V1/Release/UpdateReleaseTest.php
@@ -236,11 +236,13 @@ class UpdateReleaseTest extends DatabaseTestCase
     }
 
     #[Test]
-    public function updateFailsWhenSameSongAppearsAcrossMedia(): void
+    public function canUpdateWithSameSongAcrossMedia(): void
     {
         $songId = $this->generateUuid();
         $releaseGroupId = $this->generateUuid();
         $releaseId = $this->generateUuid();
+
+        $converter = $this->app->make(UuidConverterInterface::class);
 
         $this->storeSongs($this->createSong($songId, 'テスト楽曲1', '説明', SongType::Original, true, 10));
         $this->storeReleaseGroups(
@@ -270,16 +272,26 @@ class UpdateReleaseTest extends DatabaseTestCase
                         'tracks' => [['songId' => $songId, 'title' => null, 'trackNo' => 1]],
                     ],
                 ],
-            ])->assertStatus(422)
+            ])->assertStatus(200)
             ->assertJson(
                 static fn (AssertableJson $json) => $json
                     ->has(
-                        'errors',
-                        1,
+                        'release',
                         static fn (AssertableJson $json) => $json
-                            ->where('field', 'media')
-                            ->where('message', '同じ楽曲を複数指定することはできません。'),
+                            ->where('media.0.tracks.0.songId', $songId)
+                            ->where('media.1.tracks.0.songId', $songId)
+                            ->etc(),
                     ),
             );
+
+        $tracks = DB::table('release_tracks')
+            ->where('release_id', $converter->toBin($releaseId))
+            ->orderBy('position')
+            ->get()
+            ->all();
+
+        $this->assertCount(2, $tracks);
+        $this->assertSame($songId, $this->toUuid($tracks[0]->song_id));
+        $this->assertSame($songId, $this->toUuid($tracks[1]->song_id));
     }
 }

--- a/src/server/tests/Feature/Api/Viewer/V1/Release/ListReleaseGroupTest.php
+++ b/src/server/tests/Feature/Api/Viewer/V1/Release/ListReleaseGroupTest.php
@@ -182,6 +182,49 @@ class ListReleaseGroupTest extends DatabaseTestCase
     }
 
     #[Test]
+    public function showsSameSongAsMultipleTracks(): void
+    {
+        $songId = $this->generateUuid();
+        $releaseGroupId = $this->generateUuid();
+        $releaseId = $this->generateUuid();
+
+        $this->storeSongs(
+            $this->createSong($songId, '公開楽曲', '説明', SongType::Original, true, 10),
+        );
+        $this->storeReleaseGroups(
+            $this->createReleaseGroup($releaseGroupId, 'ライブ盤グループ', ReleaseGroupType::Album, true),
+        );
+        $this->storeReleases(
+            $this->createRelease(
+                $releaseId,
+                $releaseGroupId,
+                'ライブ盤',
+                true,
+                new ImmutableDate('2026-05-01'),
+                media: [
+                    // アンコールなど、同じ楽曲が同一媒体に複数回収録されるケース。
+                    [
+                        'position' => 1,
+                        'format' => MediumFormat::Cd->value,
+                        'tracks' => [
+                            ['songId' => $songId, 'title' => null, 'trackNo' => 1],
+                            ['songId' => $songId, 'title' => null, 'trackNo' => 2],
+                        ],
+                    ],
+                ],
+            ),
+        );
+
+        $this->get(route(ViewerReleaseGroupRouteMap::List))
+            ->assertStatus(200)
+            ->assertJsonCount(2, 'releaseGroups.0.releases.0.media.0.tracks')
+            ->assertJsonPath('releaseGroups.0.releases.0.media.0.tracks.0.songId', $songId)
+            ->assertJsonPath('releaseGroups.0.releases.0.media.0.tracks.0.trackNo', 1)
+            ->assertJsonPath('releaseGroups.0.releases.0.media.0.tracks.1.songId', $songId)
+            ->assertJsonPath('releaseGroups.0.releases.0.media.0.tracks.1.trackNo', 2);
+    }
+
+    #[Test]
     public function paginatesWithCursor(): void
     {
         $releaseGroupId1 = $this->generateUuid();


### PR DESCRIPTION
## 概要

ライブ盤のアンコールなど、同じ楽曲が 1 つのリリースに複数回収録されるケースを表現できるようにする
「楽曲はリリース全体で 1 回まで」の制約を DB・ドメイン・admin UI の 3 箇所から取り除き、同一楽曲の複数収録を単純に許可する (MusicBrainz のライブ盤と同じ表現、API 契約の変更なし)

## やったこと

- DB: `release_tracks` の unique index `release_tracks_release_id_song_id_unique` を削除 (FK 用 index と PK は維持)
- ドメイン: `Media::fromArray` の `$seenSongIds` による重複チェックを削除 (媒体順・曲順の重複禁止は維持)
- admin: `MediaEditor.tsx` の `selectedSongIds` memo と `addTrack` の追加ガードを削除し、検索結果の追加ボタンを常に「追加」表示に変更
- テスト
  - `UpdateReleaseTest`: 媒体をまたぐ重複がエラーになるテストを「200 で通り release_tracks に 2 行入る」テストに書き換え
  - `CreateReleaseTest`: 同一媒体内の重複 (アンコール相当) が作成できるケースを追加
  - `ListReleaseGroupTest` (viewer): 同一楽曲が 2 トラックとして返るケースを追加

## やってないこと

- アンコール用の専用フラグや "(Encore)" 等の注釈表記の導入 (トラック表記を変えたくなった場合は表示タイトル上書きを将来の拡張として別途検討)
- viewer の変更 (トラック配列を順に描画するだけのため変更不要なことを確認済み)
- 楽曲詳細のリリースグループ表示の変更 (`SongQueryService` で重複排除済みのため変更不要なことを確認済み)

## 関連

- #858 (title-only トラック対応、本 PR はその index ベース化された UI を前提とする)
