### PR TITLE
Track の title を上書き名に再定義して楽曲紐づきを維持した別名収録を表現

### DIFF
--- a/src/admin/src/components/release/MediaEditor.tsx
+++ b/src/admin/src/components/release/MediaEditor.tsx
@@ -10,9 +10,13 @@ export const MEDIUM_FORMAT_OPTIONS: Array<{ value: MediumFormatValue; label: str
   { value: 99, label: 'その他' },
 ];
 
-/** songId が null のトラックは管理対象外楽曲(タイトルのみトラック) */
+/**
+ * songId が null のトラックは管理対象外楽曲(タイトルのみトラック)で title が必須。
+ * songId ありのトラックは title が空なら楽曲名で表示、入力があれば上書き名になる。
+ */
 export type TrackForm = {
   songId: string | null;
+  songTitle: string | null;
   title: string;
 };
 
@@ -31,19 +35,20 @@ export const toMediumForms = (data: ReleaseGetResponse): MediumForm[] => {
     formatValue: medium.formatValue,
     tracks: medium.tracks.map(track => ({
       songId: track.songId,
-      title: track.songId !== null ? titleBySongId.get(track.songId) ?? track.songId : track.title ?? '',
+      songTitle: track.songId !== null ? titleBySongId.get(track.songId) ?? track.songId : null,
+      title: track.title ?? '',
     })),
   }));
 };
 
-/** フォーム状態を API の media リクエスト形へ変換する(position / trackNo は並び順から採番、songId / title は XOR) */
+/** フォーム状態を API の media リクエスト形へ変換する(position / trackNo は並び順から採番、空の title は null) */
 export const toMediaPayload = (media: MediumForm[]) =>
   media.map((medium, mediumIndex) => ({
     position: mediumIndex + 1,
     formatValue: medium.formatValue,
     tracks: medium.tracks.map((track, trackIndex) => ({
       songId: track.songId,
-      title: track.songId !== null ? null : track.title,
+      title: track.title.trim() === '' ? null : track.title.trim(),
       trackNo: trackIndex + 1,
     })),
   }));
@@ -106,7 +111,7 @@ export const MediaEditor = (props: MediaEditorProps) => {
   };
 
   const addTrack = (song: SongSummary) => {
-    appendTrack({ songId: song.songId, title: song.title });
+    appendTrack({ songId: song.songId, songTitle: song.title, title: '' });
   };
 
   const addTitleOnlyTrack = () => {
@@ -116,8 +121,17 @@ export const MediaEditor = (props: MediaEditorProps) => {
       return;
     }
 
-    appendTrack({ songId: null, title });
+    appendTrack({ songId: null, songTitle: null, title });
     setManualTitle('');
+  };
+
+  const setTrackTitle = (mediumIndex: number, trackIndex: number, title: string) => {
+    props.onChange(prev =>
+      prev.map((medium, i) =>
+        i === mediumIndex
+          ? { ...medium, tracks: medium.tracks.map((track, j) => (j === trackIndex ? { ...track, title } : track)) }
+          : medium,
+      ));
   };
 
   const removeTrack = (mediumIndex: number, trackIndex: number) => {
@@ -261,7 +275,8 @@ export const MediaEditor = (props: MediaEditorProps) => {
                         <thead>
                           <tr>
                             <th>曲順</th>
-                            <th>楽曲名</th>
+                            <th>楽曲</th>
+                            <th>トラック名</th>
                             <th class="text-right">操作</th>
                           </tr>
                         </thead>
@@ -271,10 +286,21 @@ export const MediaEditor = (props: MediaEditorProps) => {
                               <tr>
                                 <td>{trackIndex() + 1}</td>
                                 <td>
-                                  {track.title}
-                                  <Show when={track.songId === null}>
-                                    <span class="badge badge-ghost badge-sm ml-2">対象外</span>
+                                  <Show
+                                    when={track.songId !== null}
+                                    fallback={<span class="badge badge-ghost badge-sm">対象外</span>}
+                                  >
+                                    {track.songTitle}
                                   </Show>
+                                </td>
+                                <td>
+                                  <input
+                                    type="text"
+                                    class="input input-bordered input-sm w-full min-w-48"
+                                    value={track.title}
+                                    onInput={e => setTrackTitle(mediumIndex, trackIndex(), e.currentTarget.value)}
+                                    placeholder={track.songId !== null ? track.songTitle ?? '' : 'トラック名を入力'}
+                                  />
                                 </td>
                                 <td>
                                   <div class="flex justify-end gap-2">
@@ -316,6 +342,9 @@ export const MediaEditor = (props: MediaEditorProps) => {
                         </tbody>
                       </table>
                     </div>
+                    <p class="mt-2 text-xs text-base-content/60">
+                      トラック名が空の場合は楽曲名で表示されます（管理対象外楽曲では必須です）。
+                    </p>
                   </Show>
                 </div>
               </div>

--- a/src/admin/src/generated/types.gen.ts
+++ b/src/admin/src/generated/types.gen.ts
@@ -409,7 +409,7 @@ export type ReleaseJacketArtUploadResponse = {
 };
 
 /**
- * リリース収録曲の表示用情報。タイトルのみトラックは songId: null で載る
+ * リリース収録曲の read model。参照トラックの title は楽曲の正式名(上書き名は反映しない)、タイトルのみトラックは songId: null でトラックタイトルが載る
  */
 export type ReleaseReferencedSong = {
     mediumPosition: OrderNo;
@@ -619,7 +619,7 @@ export type SongUpdateResponse = {
 export type SortOrder = 'asc' | 'desc';
 
 /**
- * 収録曲。songId / title はどちらか一方のみを指定する(XOR。検証はサーバー側の責務)。songId ありは Song 集約を参照する参照トラック、title ありは表示専用のタイトルのみトラック
+ * 収録曲。songId / title の少なくとも一方を指定する(検証はサーバー側の責務)。songId ありは Song 集約を参照する参照トラックで、title を併記すると表示名を上書きする。songId なしは表示専用のタイトルのみトラック
  */
 export type Track = {
     songId: Uuid | null;
@@ -824,7 +824,7 @@ export type SongTypeName = string;
 export type Title = string;
 
 /**
- * 管理対象外楽曲のトラックタイトル
+ * トラックの表示名。参照トラックでは楽曲名の上書き、タイトルのみトラックでは必須のタイトル
  */
 export type TrackTitle = string;
 

--- a/src/contracts/generated/oas/IsekaiObservatory.Admin.v1.yaml
+++ b/src/contracts/generated/oas/IsekaiObservatory.Admin.v1.yaml
@@ -2844,7 +2844,7 @@ components:
             - type: 'null'
         title:
           $ref: '#/components/schemas/title'
-      description: 'リリース収録曲の表示用情報。タイトルのみトラックは songId: null で載る'
+      description: 'リリース収録曲の read model。参照トラックの title は楽曲の正式名(上書き名は反映しない)、タイトルのみトラックは songId: null でトラックタイトルが載る'
     ReleaseUpdateRequest:
       type: object
       required:
@@ -3359,7 +3359,7 @@ components:
             - type: 'null'
         trackNo:
           $ref: '#/components/schemas/orderNo'
-      description: 収録曲。songId / title はどちらか一方のみを指定する(XOR。検証はサーバー側の責務)。songId ありは Song 集約を参照する参照トラック、title ありは表示専用のタイトルのみトラック
+      description: 収録曲。songId / title の少なくとも一方を指定する(検証はサーバー側の責務)。songId ありは Song 集約を参照する参照トラックで、title を併記すると表示名を上書きする。songId なしは表示専用のタイトルのみトラック
     ValidationError:
       type: object
       required:
@@ -3533,7 +3533,7 @@ components:
     trackTitle:
       type: string
       minLength: 1
-      description: 管理対象外楽曲のトラックタイトル
+      description: トラックの表示名。参照トラックでは楽曲名の上書き、タイトルのみトラックでは必須のタイトル
     uuid:
       type: string
       format: uuid

--- a/src/contracts/generated/oas/IsekaiObservatory.Viewer.v1.yaml
+++ b/src/contracts/generated/oas/IsekaiObservatory.Viewer.v1.yaml
@@ -416,7 +416,7 @@ components:
           type: string
         isDisplay:
           type: boolean
-      description: '収録曲。タイトルのみトラックは songId: null / isDisplay: false で返る。リンク可否は songId != null && isDisplay で判定する'
+      description: '収録曲。title は上書き名があればそれ、なければ楽曲名。タイトルのみトラックは songId: null / isDisplay: false で返る。リンク可否は songId != null && isDisplay で判定する'
     SiteStatsResponse:
       type: object
       required:

--- a/src/contracts/src/admin/releases/domain.tsp
+++ b/src/contracts/src/admin/releases/domain.tsp
@@ -28,7 +28,7 @@ scalar releasedOn extends string;
 @doc("ジャケットアートURL")
 scalar jacketArtUrl extends string;
 
-@doc("管理対象外楽曲のトラックタイトル")
+@doc("トラックの表示名。参照トラックでは楽曲名の上書き、タイトルのみトラックでは必須のタイトル")
 @minLength(1)
 scalar trackTitle extends string;
 
@@ -81,7 +81,7 @@ model ReleaseGroupReferencedRelease {
   formatValues: MediumFormatValue[];
 }
 
-@doc("収録曲。songId / title はどちらか一方のみを指定する(XOR。検証はサーバー側の責務)。songId ありは Song 集約を参照する参照トラック、title ありは表示専用のタイトルのみトラック")
+@doc("収録曲。songId / title の少なくとも一方を指定する(検証はサーバー側の責務)。songId ありは Song 集約を参照する参照トラックで、title を併記すると表示名を上書きする。songId なしは表示専用のタイトルのみトラック")
 model Track {
   songId: uuid | null;
   title: trackTitle | null;
@@ -108,7 +108,7 @@ model Release {
   media: Medium[];
 }
 
-@doc("リリース収録曲の表示用情報。タイトルのみトラックは songId: null で載る")
+@doc("リリース収録曲の read model。参照トラックの title は楽曲の正式名(上書き名は反映しない)、タイトルのみトラックは songId: null でトラックタイトルが載る")
 model ReleaseReferencedSong {
   mediumPosition: orderNo;
   trackNo: orderNo;

--- a/src/contracts/src/viewer/releases/domain.tsp
+++ b/src/contracts/src/viewer/releases/domain.tsp
@@ -54,7 +54,7 @@ model MediumFormat {
   value: MediumFormatValue;
 }
 
-@doc("収録曲。タイトルのみトラックは songId: null / isDisplay: false で返る。リンク可否は songId != null && isDisplay で判定する")
+@doc("収録曲。title は上書き名があればそれ、なければ楽曲名。タイトルのみトラックは songId: null / isDisplay: false で返る。リンク可否は songId != null && isDisplay で判定する")
 model ReleaseTrackItem {
   trackNo: orderNo;
   songId: uuid | null;

--- a/src/server/Generated/Admin/lib/Model/ReleaseReferencedSong.php
+++ b/src/server/Generated/Admin/lib/Model/ReleaseReferencedSong.php
@@ -35,7 +35,7 @@ use \OpenAPI\Admin\Client\ObjectSerializer;
  * ReleaseReferencedSong Class Doc Comment
  *
  * @category Class
- * @description リリース収録曲の表示用情報。タイトルのみトラックは songId: null で載る
+ * @description リリース収録曲の read model。参照トラックの title は楽曲の正式名(上書き名は反映しない)、タイトルのみトラックは songId: null でトラックタイトルが載る
  * @package  OpenAPI\Admin\Client
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech

--- a/src/server/Generated/Admin/lib/Model/Track.php
+++ b/src/server/Generated/Admin/lib/Model/Track.php
@@ -35,7 +35,7 @@ use \OpenAPI\Admin\Client\ObjectSerializer;
  * Track Class Doc Comment
  *
  * @category Class
- * @description 収録曲。songId / title はどちらか一方のみを指定する(XOR。検証はサーバー側の責務)。songId ありは Song 集約を参照する参照トラック、title ありは表示専用のタイトルのみトラック
+ * @description 収録曲。songId / title の少なくとも一方を指定する(検証はサーバー側の責務)。songId ありは Song 集約を参照する参照トラックで、title を併記すると表示名を上書きする。songId なしは表示専用のタイトルのみトラック
  * @package  OpenAPI\Admin\Client
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
@@ -368,7 +368,7 @@ class Track implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Sets title
      *
-     * @param string $title 管理対象外楽曲のトラックタイトル
+     * @param string $title トラックの表示名。参照トラックでは楽曲名の上書き、タイトルのみトラックでは必須のタイトル
      *
      * @return self
      */

--- a/src/server/Generated/Viewer/lib/Model/ReleaseTrackItem.php
+++ b/src/server/Generated/Viewer/lib/Model/ReleaseTrackItem.php
@@ -35,7 +35,7 @@ use \OpenAPI\Viewer\Client\ObjectSerializer;
  * ReleaseTrackItem Class Doc Comment
  *
  * @category Class
- * @description 収録曲。タイトルのみトラックは songId: null / isDisplay: false で返る。リンク可否は songId !&#x3D; null &amp;&amp; isDisplay で判定する
+ * @description 収録曲。title は上書き名があればそれ、なければ楽曲名。タイトルのみトラックは songId: null / isDisplay: false で返る。リンク可否は songId !&#x3D; null &amp;&amp; isDisplay で判定する
  * @package  OpenAPI\Viewer\Client
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech

--- a/src/server/database/atlas/schemas/release-tracks.my.hcl
+++ b/src/server/database/atlas/schemas/release-tracks.my.hcl
@@ -27,15 +27,15 @@ table "release_tracks" {
   column "title" {
     null    = true
     type    = varchar(255)
-    comment = "管理対象外楽曲のタイトル"
+    comment = "トラック表示名(参照トラックでは楽曲名の上書き)"
   }
 
   primary_key {
     columns = [column.release_id, column.position, column.track_no]
   }
 
-  check "release_tracks_song_id_title_xor" {
-    expr = "(`song_id` IS NULL) != (`title` IS NULL)"
+  check "release_tracks_song_id_title_at_least_one" {
+    expr = "(`song_id` IS NOT NULL) OR (`title` IS NOT NULL)"
   }
 
   index "fk_release_tracks_song_id" {

--- a/src/server/packages/Release/Application/Admin/Query/ReleaseReferencedSong.php
+++ b/src/server/packages/Release/Application/Admin/Query/ReleaseReferencedSong.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Release\Application\Admin\Query;
 
+/**
+ * リリース収録曲の read model。参照トラックの title は楽曲の正式名 (上書き名は反映しない)。
+ */
 readonly class ReleaseReferencedSong
 {
     public function __construct(

--- a/src/server/packages/Release/Domain/Models/Track.php
+++ b/src/server/packages/Release/Domain/Models/Track.php
@@ -12,9 +12,9 @@ use Support\Domain\Error\EntityRuleViolationError;
 use Support\Domain\ValueObjects\OrderNo;
 
 /**
- * 収録曲。次の 2 形態のどちらか一方のみを取る（XOR）。
+ * 収録曲。songId と title の少なくとも一方を持つ。
  *
- * - 参照トラック: songId あり / title なし（Song 集約を参照する）
+ * - 参照トラック: songId あり（Song 集約を参照する）。title があれば表示名を上書きする
  * - タイトルのみトラック: songId なし / title あり（管理対象外楽曲。表示専用）
  */
 readonly class Track
@@ -31,8 +31,8 @@ readonly class Track
      */
     public static function create(?SongId $songId, ?TrackTitle $title, OrderNo $trackNo): Result
     {
-        if (is_null($songId) === is_null($title)) {
-            return new Err(new EntityRuleViolationError('media', '収録曲には楽曲かタイトルのどちらか一方のみを指定してください。'));
+        if (is_null($songId) && is_null($title)) {
+            return new Err(new EntityRuleViolationError('media', '収録曲には楽曲かタイトルの少なくとも一方を指定してください。'));
         }
 
         return new Ok(new self($songId, $title, $trackNo));

--- a/src/server/packages/Release/Domain/Models/TrackTitle.php
+++ b/src/server/packages/Release/Domain/Models/TrackTitle.php
@@ -8,7 +8,8 @@ use Override;
 use Support\Domain\ValueObjects\String\TextValueObject;
 
 /**
- * 管理対象外楽曲のトラックタイトル。Song 集約の title とは別物として Release 側に置く。
+ * トラックの表示名。参照トラックでは楽曲名の上書き、管理対象外楽曲ではそのタイトル。
+ * Song 集約の title とは別物として Release 側に置く。
  */
 readonly class TrackTitle extends TextValueObject
 {

--- a/src/server/packages/Release/Infrastructures/Admin/ReleaseDetailQueryService.php
+++ b/src/server/packages/Release/Infrastructures/Admin/ReleaseDetailQueryService.php
@@ -31,6 +31,7 @@ readonly class ReleaseDetailQueryService implements ReleaseDetailQueryServiceInt
                     'release_tracks.track_no',
                     'release_tracks.song_id',
                 ])
+                // 参照トラックは楽曲の正式名を返す (上書き名は Release 集約の tracks 側で扱う)。
                 ->select(new Sql('COALESCE(songs.title, release_tracks.title)'), 'title')
                 ->from('release_tracks')
                 ->outerJoin('songs', 'release_tracks.song_id = songs.song_id')

--- a/src/server/packages/Release/Infrastructures/Viewer/ReleaseGroupQueryService.php
+++ b/src/server/packages/Release/Infrastructures/Viewer/ReleaseGroupQueryService.php
@@ -169,7 +169,8 @@ readonly class ReleaseGroupQueryService implements ReleaseGroupQueryServiceInter
                     'release_tracks.song_id',
                     'songs.is_display',
                 ])
-                ->select(new Sql('COALESCE(songs.title, release_tracks.title)'), 'title')
+                // 上書き名 (release_tracks.title) を優先し、なければ楽曲名で表示する。
+                ->select(new Sql('COALESCE(release_tracks.title, songs.title)'), 'title')
                 ->from('release_tracks')
                 ->outerJoin('songs', 'songs.song_id = release_tracks.song_id')
                 ->where('release_tracks.release_id', 'IN', $binReleaseIds)

--- a/src/server/tests/Feature/Api/Admin/V1/Release/CreateReleaseTest.php
+++ b/src/server/tests/Feature/Api/Admin/V1/Release/CreateReleaseTest.php
@@ -190,7 +190,7 @@ class CreateReleaseTest extends DatabaseTestCase
     }
 
     #[Test]
-    public function createFailsWhenTrackHasBothSongIdAndTitle(): void
+    public function canCreateWithOverriddenTrackTitle(): void
     {
         $songId = $this->generateUuid();
         $releaseGroupId = $this->generateUuid();
@@ -198,6 +198,53 @@ class CreateReleaseTest extends DatabaseTestCase
         $this->storeSongs(
             $this->createSong($songId, 'テスト楽曲1', '説明', SongType::Original, true, 1),
         );
+        $this->storeReleaseGroups(
+            $this->createReleaseGroup($releaseGroupId, '観測された春', ReleaseGroupType::Album, true),
+        );
+
+        // 楽曲への紐づきを維持したまま、トラックとしての表示名だけを上書きするケース。
+        $this->withAuth()
+            ->postJson(route(ReleaseRouteMap::Create), [
+                'releaseGroupId' => $releaseGroupId,
+                'name' => '初回限定盤',
+                'releasedOn' => '2026-05-09',
+                'description' => '',
+                'jacketArtUrl' => null,
+                'isDisplay' => true,
+                'orderNo' => 10,
+                'media' => [
+                    [
+                        'position' => 1,
+                        'formatValue' => MediumFormat::Cd->value,
+                        'tracks' => [
+                            ['songId' => $songId, 'title' => 'テスト楽曲1 -instrumental-', 'trackNo' => 1],
+                        ],
+                    ],
+                ],
+            ])->assertStatus(200)
+            ->assertJson(
+                static fn (AssertableJson $json) => $json
+                    ->has(
+                        'release',
+                        static fn (AssertableJson $json) => $json
+                            ->where('media.0.tracks.0.songId', $songId)
+                            ->where('media.0.tracks.0.title', 'テスト楽曲1 -instrumental-')
+                            ->where('media.0.tracks.0.trackNo', 1)
+                            ->etc(),
+                    ),
+            );
+
+        $this->assertDatabaseHas('release_tracks', [
+            'track_no' => 1,
+            'title' => 'テスト楽曲1 -instrumental-',
+        ]);
+    }
+
+    #[Test]
+    public function createFailsWhenTrackHasNeitherSongIdNorTitle(): void
+    {
+        $releaseGroupId = $this->generateUuid();
+
         $this->storeReleaseGroups(
             $this->createReleaseGroup($releaseGroupId, '観測された春', ReleaseGroupType::Album, true),
         );
@@ -216,7 +263,7 @@ class CreateReleaseTest extends DatabaseTestCase
                         'position' => 1,
                         'formatValue' => MediumFormat::Cd->value,
                         'tracks' => [
-                            ['songId' => $songId, 'title' => '管理対象外の楽曲', 'trackNo' => 1],
+                            ['songId' => null, 'title' => null, 'trackNo' => 1],
                         ],
                     ],
                 ],
@@ -228,7 +275,7 @@ class CreateReleaseTest extends DatabaseTestCase
                         1,
                         static fn (AssertableJson $json) => $json
                             ->where('field', 'media')
-                            ->where('message', '収録曲には楽曲かタイトルのどちらか一方のみを指定してください。'),
+                            ->where('message', '収録曲には楽曲かタイトルの少なくとも一方を指定してください。'),
                     ),
             );
     }

--- a/src/server/tests/Feature/Api/Admin/V1/Release/GetReleaseTest.php
+++ b/src/server/tests/Feature/Api/Admin/V1/Release/GetReleaseTest.php
@@ -48,6 +48,7 @@ class GetReleaseTest extends DatabaseTestCase
                         'tracks' => [
                             ['songId' => $songId, 'title' => null, 'trackNo' => 1],
                             ['songId' => null, 'title' => '管理対象外の楽曲', 'trackNo' => 2],
+                            ['songId' => $songId, 'title' => 'テスト楽曲1 -instrumental-', 'trackNo' => 3],
                         ],
                     ],
                 ],
@@ -82,6 +83,12 @@ class GetReleaseTest extends DatabaseTestCase
                                     'title' => '管理対象外の楽曲',
                                     'trackNo' => 2,
                                 ],
+                                // 上書き名を持つ参照トラックは title に上書き名の生値が載る。
+                                [
+                                    'songId' => $songId,
+                                    'title' => 'テスト楽曲1 -instrumental-',
+                                    'trackNo' => 3,
+                                ],
                             ],
                         ],
                     ],
@@ -99,6 +106,13 @@ class GetReleaseTest extends DatabaseTestCase
                         'trackNo' => 2,
                         'songId' => null,
                         'title' => '管理対象外の楽曲',
+                    ],
+                    // 上書き名を持つ参照トラックでも read model は楽曲の正式名を返す。
+                    [
+                        'mediumPosition' => 1,
+                        'trackNo' => 3,
+                        'songId' => $songId,
+                        'title' => 'テスト楽曲1',
                     ],
                 ],
             ]);

--- a/src/server/tests/Feature/Api/Admin/V1/Release/UpdateReleaseTest.php
+++ b/src/server/tests/Feature/Api/Admin/V1/Release/UpdateReleaseTest.php
@@ -181,6 +181,72 @@ class UpdateReleaseTest extends DatabaseTestCase
     }
 
     #[Test]
+    public function canUpdateWithOverriddenTrackTitle(): void
+    {
+        $songId = $this->generateUuid();
+        $releaseGroupId = $this->generateUuid();
+        $releaseId = $this->generateUuid();
+
+        $this->storeSongs(
+            $this->createSong($songId, 'テスト楽曲1', '説明', SongType::Original, true, 10),
+        );
+        $this->storeReleaseGroups(
+            $this->createReleaseGroup($releaseGroupId, '観測された春', ReleaseGroupType::Album, true),
+        );
+        $this->storeReleases(
+            $this->createRelease(
+                $releaseId,
+                $releaseGroupId,
+                '旧版名',
+                true,
+                media: [
+                    [
+                        'position' => 1,
+                        'format' => MediumFormat::Digital->value,
+                        'tracks' => [['songId' => $songId, 'title' => null, 'trackNo' => 1]],
+                    ],
+                ],
+            ),
+        );
+
+        // 既存の参照トラックに表示名の上書きを設定するケース。
+        $this->withAuth()
+            ->putJson(route(ReleaseRouteMap::Update, $releaseId), [
+                'name' => '新版名',
+                'releasedOn' => '2026-05-09',
+                'description' => '説明',
+                'jacketArtUrl' => null,
+                'isDisplay' => true,
+                'orderNo' => 1,
+                'media' => [
+                    [
+                        'position' => 1,
+                        'formatValue' => MediumFormat::Cd->value,
+                        'tracks' => [
+                            ['songId' => $songId, 'title' => 'テスト楽曲1 -instrumental-', 'trackNo' => 1],
+                        ],
+                    ],
+                ],
+            ])->assertStatus(200)
+            ->assertJson(
+                static fn (AssertableJson $json) => $json
+                    ->has(
+                        'release',
+                        static fn (AssertableJson $json) => $json
+                            ->where('media.0.tracks.0.songId', $songId)
+                            ->where('media.0.tracks.0.title', 'テスト楽曲1 -instrumental-')
+                            ->where('media.0.tracks.0.trackNo', 1)
+                            ->etc(),
+                    ),
+            );
+
+        $this->assertDatabaseHas('release_tracks', [
+            'track_no' => 1,
+            'title' => 'テスト楽曲1 -instrumental-',
+        ]);
+    }
+
+    #[Test]
     public function notFound(): void
     {
         $this->withAuth()

--- a/src/server/tests/Feature/Api/Viewer/V1/Release/ListReleaseGroupTest.php
+++ b/src/server/tests/Feature/Api/Viewer/V1/Release/ListReleaseGroupTest.php
@@ -57,6 +57,7 @@ class ListReleaseGroupTest extends DatabaseTestCase
                             ['songId' => $visibleSongId, 'title' => null, 'trackNo' => 1],
                             ['songId' => $hiddenSongId, 'title' => null, 'trackNo' => 2],
                             ['songId' => null, 'title' => '管理対象外の楽曲', 'trackNo' => 3],
+                            ['songId' => $visibleSongId, 'title' => '公開楽曲 -acoustic-', 'trackNo' => 4],
                         ],
                     ],
                 ],
@@ -170,6 +171,13 @@ class ListReleaseGroupTest extends DatabaseTestCase
                                                 'songId' => null,
                                                 'title' => '管理対象外の楽曲',
                                                 'isDisplay' => false,
+                                            ],
+                                            // 上書き名を持つ参照トラックは楽曲名ではなく上書き名で返る。
+                                            [
+                                                'trackNo' => 4,
+                                                'songId' => $visibleSongId,
+                                                'title' => '公開楽曲 -acoustic-',
+                                                'isDisplay' => true,
                                             ],
                                         ],
                                     ],

--- a/src/server/tests/Integration/Release/Application/Admin/UseCase/Create/CreateUseCaseTest.php
+++ b/src/server/tests/Integration/Release/Application/Admin/UseCase/Create/CreateUseCaseTest.php
@@ -117,7 +117,7 @@ class CreateUseCaseTest extends DatabaseTestCase
     }
 
     #[Test]
-    public function createFailsWhenTrackHasBothSongIdAndTitle(): void
+    public function canCreateWithOverriddenTrackTitle(): void
     {
         $songId = $this->generateUuid();
         $releaseGroupId = $this->generateUuid();
@@ -125,6 +125,41 @@ class CreateUseCaseTest extends DatabaseTestCase
         $this->storeSongs(
             $this->createSong($songId, 'テスト楽曲1', '説明', SongType::Original, true, 1),
         );
+        $this->storeReleaseGroups(
+            $this->createReleaseGroup($releaseGroupId, '観測された春', ReleaseGroupType::Album, true),
+        );
+
+        // 楽曲への紐づきを維持したまま表示名だけを上書きするケース。
+        $result = $this->getInstance()->handle(new CreateInputData(
+            releaseGroupId: $releaseGroupId,
+            name: '初回限定盤',
+            releasedOn: '2026-05-09',
+            description: '',
+            jacketArtUrl: null,
+            isDisplay: true,
+            orderNo: 10,
+            media: [
+                [
+                    'position' => 1,
+                    'formatValue' => MediumFormat::Cd->value,
+                    'tracks' => [['songId' => $songId, 'title' => 'テスト楽曲1 -instrumental-', 'trackNo' => 1]],
+                ],
+            ],
+        ));
+
+        $this->assertTrue($result->isOk());
+
+        $this->assertDatabaseHas('release_tracks', [
+            'track_no' => 1,
+            'title' => 'テスト楽曲1 -instrumental-',
+        ]);
+    }
+
+    #[Test]
+    public function createFailsWhenTrackHasNeitherSongIdNorTitle(): void
+    {
+        $releaseGroupId = $this->generateUuid();
+
         $this->storeReleaseGroups(
             $this->createReleaseGroup($releaseGroupId, '観測された春', ReleaseGroupType::Album, true),
         );
@@ -141,7 +176,7 @@ class CreateUseCaseTest extends DatabaseTestCase
                 [
                     'position' => 1,
                     'formatValue' => MediumFormat::Cd->value,
-                    'tracks' => [['songId' => $songId, 'title' => '管理対象外の楽曲', 'trackNo' => 1]],
+                    'tracks' => [['songId' => null, 'title' => null, 'trackNo' => 1]],
                 ],
             ],
         ));
@@ -149,7 +184,7 @@ class CreateUseCaseTest extends DatabaseTestCase
         $this->assertTrue($result->isErr());
         $error = $result->unwrapErr();
         $this->assertInstanceOf(InvalidInputError::class, $error);
-        $this->assertSame(['media' => ['収録曲には楽曲かタイトルのどちらか一方のみを指定してください。']], $error->errors);
+        $this->assertSame(['media' => ['収録曲には楽曲かタイトルの少なくとも一方を指定してください。']], $error->errors);
     }
 
     #[Test]

--- a/src/server/tests/Unit/Release/Domain/Models/TrackTest.php
+++ b/src/server/tests/Unit/Release/Domain/Models/TrackTest.php
@@ -53,16 +53,21 @@ class TrackTest extends TestCase
     }
 
     #[Test]
-    public function cannotCreateWithBothSongIdAndTitle(): void
+    public function canCreateReferenceTrackWithOverriddenTitle(): void
     {
         $result = Track::create(
             SongId::reconstruct(self::SONG_ID),
-            TrackTitle::reconstruct('管理対象外の楽曲'),
+            TrackTitle::reconstruct('楽曲A -instrumental-'),
             OrderNo::reconstruct(1),
         );
 
-        $this->assertTrue($result->isErr());
-        $this->assertInstanceOf(EntityRuleViolationError::class, $result->unwrapErr());
+        $this->assertTrue($result->isOk());
+
+        $track = $result->unwrap();
+
+        $this->assertSame(self::SONG_ID, $track->songId?->value);
+        $this->assertSame('楽曲A -instrumental-', $track->title?->value);
+        $this->assertSame(['song_id' => self::SONG_ID, 'title' => '楽曲A -instrumental-', 'track_no' => 1], $track->toArray());
     }
 
     #[Test]
@@ -91,6 +96,16 @@ class TrackTest extends TestCase
 
         $this->assertNull($track->songId);
         $this->assertSame('管理対象外の楽曲', $track->title?->value);
+        $this->assertSame(1, $track->trackNo->value);
+    }
+
+    #[Test]
+    public function canReconstructReferenceTrackWithOverriddenTitle(): void
+    {
+        $track = Track::reconstruct(self::SONG_ID, '楽曲A -instrumental-', 1);
+
+        $this->assertSame(self::SONG_ID, $track->songId?->value);
+        $this->assertSame('楽曲A -instrumental-', $track->title?->value);
         $this->assertSame(1, $track->trackNo->value);
     }
 }

--- a/src/server/tests/Unit/Release/Domain/Models/TracksTest.php
+++ b/src/server/tests/Unit/Release/Domain/Models/TracksTest.php
@@ -18,24 +18,15 @@ class TracksTest extends TestCase
         $result = Tracks::fromArray([
             ['songId' => self::SONG_ID, 'title' => null, 'trackNo' => 1],
             ['songId' => null, 'title' => '管理対象外の楽曲', 'trackNo' => 2],
+            ['songId' => self::SONG_ID, 'title' => '楽曲A -instrumental-', 'trackNo' => 3],
         ]);
 
         $this->assertTrue($result->isOk());
         $this->assertSame([
             ['song_id' => self::SONG_ID, 'title' => null, 'track_no' => 1],
             ['song_id' => null, 'title' => '管理対象外の楽曲', 'track_no' => 2],
+            ['song_id' => self::SONG_ID, 'title' => '楽曲A -instrumental-', 'track_no' => 3],
         ], $result->unwrap()->toArray());
-    }
-
-    #[Test]
-    public function cannotCreateWithBothSongIdAndTitle(): void
-    {
-        $result = Tracks::fromArray([
-            ['songId' => self::SONG_ID, 'title' => '管理対象外の楽曲', 'trackNo' => 1],
-        ]);
-
-        $this->assertTrue($result->isErr());
-        $this->assertArrayHasKey('media', $result->unwrapErr()->errors);
     }
 
     #[Test]

--- a/src/viewer/src/generated/types.gen.ts
+++ b/src/viewer/src/generated/types.gen.ts
@@ -113,7 +113,7 @@ export type ReleaseMediumItem = {
 };
 
 /**
- * 収録曲。タイトルのみトラックは songId: null / isDisplay: false で返る。リンク可否は songId != null && isDisplay で判定する
+ * 収録曲。title は上書き名があればそれ、なければ楽曲名。タイトルのみトラックは songId: null / isDisplay: false で返る。リンク可否は songId != null && isDisplay で判定する
  */
 export type ReleaseTrackItem = {
     trackNo: OrderNo;


### PR DESCRIPTION
## 概要

リリース収録曲において「楽曲としては A だが、トラックとしては A' という名前で収録される」ケースを表現できるようにします
楽曲への紐づき (songId) を維持したまま、トラックの表示名だけを上書きできます

## やったこと

- `Track` の songId / title の XOR ルールを「少なくとも一方が必須」に緩和し、title を「トラック表示名 (参照トラックでは楽曲名の上書き)」に再定義
- DB の CHECK 制約を `release_tracks_song_id_title_at_least_one` に置換
- viewer の収録曲タイトル解決を `COALESCE(release_tracks.title, songs.title)` に反転して上書き名優先で表示 (楽曲詳細へのリンクは従来どおり)
- admin の収録曲 read model (`ReleaseReferencedSong`) は楽曲の正式名を返す現状を維持し、編集フォームの楽曲名供給源として明確化
- admin の MediaEditor に「トラック名」入力欄を常設 (空 = 楽曲名で表示、placeholder に楽曲名、trim して空なら null 送信)
  - 副次的に、これまでできなかった追加後のトラック名編集も可能になった
- TypeSpec の doc 更新と OAS / 生成コードの再生成 (API の shape 変更なし)
- Unit / Integration / Feature テストを新ルールに合わせて更新し、上書きトラックのケースを追加

## やってないこと

- 上書き名と楽曲名の一致検出や null への正規化 (意図的に入力されたまま保存する)
- 楽曲ページ側での上書き名の露出 (リリースグループ名の表示のみで従来どおり影響なし)

## 関連

- #858
