### PR TITLE
トラック名入力の IME 中断を修正

### DIFF
--- a/src/admin/src/components/release/MediaEditor.tsx
+++ b/src/admin/src/components/release/MediaEditor.tsx
@@ -271,25 +271,26 @@ export const MediaEditor = (props: MediaEditorProps) => {
                           </tr>
                         </thead>
                         <tbody>
-                          <For each={medium().tracks}>
+                          {/* For はオブジェクト同一性でキーするため、入力のたびに行が再生成されて IME が中断される。Index で DOM を保つ */}
+                          <Index each={medium().tracks}>
                             {(track, trackIndex) => (
                               <tr>
-                                <td>{trackIndex() + 1}</td>
+                                <td>{trackIndex + 1}</td>
                                 <td>
                                   <Show
-                                    when={track.songId !== null}
+                                    when={track().songId !== null}
                                     fallback={<span class="badge badge-ghost badge-sm">対象外</span>}
                                   >
-                                    {track.songTitle}
+                                    {track().songTitle}
                                   </Show>
                                 </td>
                                 <td>
                                   <input
                                     type="text"
                                     class="input input-bordered input-sm w-full min-w-48"
-                                    value={track.title}
-                                    onInput={e => setTrackTitle(mediumIndex, trackIndex(), e.currentTarget.value)}
-                                    placeholder={track.songId !== null ? track.songTitle ?? '' : 'トラック名を入力'}
+                                    value={track().title}
+                                    onInput={e => setTrackTitle(mediumIndex, trackIndex, e.currentTarget.value)}
+                                    placeholder={track().songId !== null ? track().songTitle ?? '' : 'トラック名を入力'}
                                   />
                                 </td>
                                 <td>
@@ -297,20 +298,20 @@ export const MediaEditor = (props: MediaEditorProps) => {
                                     <button
                                       type="button"
                                       class="btn btn-ghost btn-xs"
-                                      disabled={trackIndex() === 0}
-                                      onClick={() => moveTrack(mediumIndex, trackIndex(), -1)}
+                                      disabled={trackIndex === 0}
+                                      onClick={() => moveTrack(mediumIndex, trackIndex, -1)}
                                     >
                                       ↑
                                     </button>
                                     <button
                                       type="button"
                                       class="btn btn-ghost btn-xs"
-                                      disabled={trackIndex() === medium().tracks.length - 1}
-                                      onClick={() => moveTrack(mediumIndex, trackIndex(), 1)}
+                                      disabled={trackIndex === medium().tracks.length - 1}
+                                      onClick={() => moveTrack(mediumIndex, trackIndex, 1)}
                                     >
                                       ↓
                                     </button>
-                                    <Show when={track.songId}>
+                                    <Show when={track().songId}>
                                       {songId => (
                                         <a href={`/songs/${songId()}`} class="btn btn-ghost btn-xs">
                                           楽曲を見る
@@ -320,7 +321,7 @@ export const MediaEditor = (props: MediaEditorProps) => {
                                     <button
                                       type="button"
                                       class="btn btn-outline btn-error btn-xs"
-                                      onClick={() => removeTrack(mediumIndex, trackIndex())}
+                                      onClick={() => removeTrack(mediumIndex, trackIndex)}
                                     >
                                       削除
                                     </button>
@@ -328,7 +329,7 @@ export const MediaEditor = (props: MediaEditorProps) => {
                                 </td>
                               </tr>
                             )}
-                          </For>
+                          </Index>
                         </tbody>
                       </table>
                     </div>


### PR DESCRIPTION
## 概要

admin の MediaEditor でトラック名に日本語を入力すると、1 文字ごとに変換が中断されて入力できない問題を修正する
英数字でもキー入力のたびにフォーカスが失われていた

## やったこと

- トラック行の描画を `<For>` から `<Index>` に変更
  - `setTrackTitle` は入力のたびに新しいトラックオブジェクトを作るため、オブジェクト同一性でキーする `<For>` では `<tr>` ごと DOM が破棄・再生成され、input のフォーカス喪失と IME 変換セッションの強制キャンセルが起きていた
  - インデックスでキーする `<Index>` なら DOM を保ったまま値だけ更新されるため、フォーカスと変換が維持される
- 併せて `track` を accessor 参照 (`track()`) に、`trackIndex` を数値参照に変更（`Index` のシグネチャに合わせた機械的な追随）

## やってないこと

- 特になし（媒体の表示ラベル入力は元から `<Index>` 配下のため影響なし）

## 関連

- #858 で入ったトラック名入力欄の既存バグ（#862 のレビュー時に発見）
