### PR TITLE
Release 編集画面に所属リリースグループのタイトルを表示する

### DIFF
--- a/src/admin/src/components/release/DetailView.tsx
+++ b/src/admin/src/components/release/DetailView.tsx
@@ -205,6 +205,12 @@ const ReleaseForm = (props: ReleaseFormProps) => {
       <a href={groupUrl} class="btn btn-ghost btn-sm mb-4">
         ← グループ詳細に戻る
       </a>
+      <p class="mb-4 text-sm text-base-content/70">
+        リリースグループ:&nbsp;
+        <a href={groupUrl} class="link link-hover font-medium text-base-content">
+          {props.data.releaseGroupTitle}
+        </a>
+      </p>
       <FormError message={formError()} onClose={clearErrors} />
       <div class="max-w-5xl space-y-6">
         <form onSubmit={handleSubmit}>

--- a/src/admin/src/generated/types.gen.ts
+++ b/src/admin/src/generated/types.gen.ts
@@ -330,6 +330,10 @@ export type ReleaseFormatValue = 1 | 2 | 3 | 4 | 99;
 
 export type ReleaseGetResponse = {
     release: Release;
+    /**
+     * 所属リリースグループのタイトル。編集対象の文脈表示用
+     */
+    releaseGroupTitle: ReleaseGroupTitle;
     songs: Array<ReleaseReferencedSong>;
 };
 

--- a/src/contracts/generated/oas/IsekaiObservatory.Admin.v1.yaml
+++ b/src/contracts/generated/oas/IsekaiObservatory.Admin.v1.yaml
@@ -2670,10 +2670,15 @@ components:
       type: object
       required:
         - release
+        - releaseGroupTitle
         - songs
       properties:
         release:
           $ref: '#/components/schemas/Release'
+        releaseGroupTitle:
+          allOf:
+            - $ref: '#/components/schemas/releaseGroupTitle'
+          description: 所属リリースグループのタイトル。編集対象の文脈表示用
         songs:
           type: array
           items:

--- a/src/contracts/src/admin/releases/transport.tsp
+++ b/src/contracts/src/admin/releases/transport.tsp
@@ -79,5 +79,9 @@ model ReleaseUpdateResponse {
 
 model ReleaseGetResponse {
   release: Release;
+
+  @doc("所属リリースグループのタイトル。編集対象の文脈表示用")
+  releaseGroupTitle: releaseGroupTitle;
+
   songs: ReleaseReferencedSong[];
 }

--- a/src/server/Generated/Admin/lib/Model/ReleaseGetResponse.php
+++ b/src/server/Generated/Admin/lib/Model/ReleaseGetResponse.php
@@ -58,6 +58,7 @@ class ReleaseGetResponse implements ModelInterface, ArrayAccess, \JsonSerializab
       */
     protected static $openAPITypes = [
         'release' => '\OpenAPI\Admin\Client\Model\Release',
+        'release_group_title' => 'string',
         'songs' => '\OpenAPI\Admin\Client\Model\ReleaseReferencedSong[]'
     ];
 
@@ -70,6 +71,7 @@ class ReleaseGetResponse implements ModelInterface, ArrayAccess, \JsonSerializab
       */
     protected static $openAPIFormats = [
         'release' => null,
+        'release_group_title' => null,
         'songs' => null
     ];
 
@@ -80,6 +82,7 @@ class ReleaseGetResponse implements ModelInterface, ArrayAccess, \JsonSerializab
       */
     protected static array $openAPINullables = [
         'release' => false,
+        'release_group_title' => false,
         'songs' => false
     ];
 
@@ -170,6 +173,7 @@ class ReleaseGetResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      */
     protected static $attributeMap = [
         'release' => 'release',
+        'release_group_title' => 'releaseGroupTitle',
         'songs' => 'songs'
     ];
 
@@ -180,6 +184,7 @@ class ReleaseGetResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      */
     protected static $setters = [
         'release' => 'setRelease',
+        'release_group_title' => 'setReleaseGroupTitle',
         'songs' => 'setSongs'
     ];
 
@@ -190,6 +195,7 @@ class ReleaseGetResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      */
     protected static $getters = [
         'release' => 'getRelease',
+        'release_group_title' => 'getReleaseGroupTitle',
         'songs' => 'getSongs'
     ];
 
@@ -251,6 +257,7 @@ class ReleaseGetResponse implements ModelInterface, ArrayAccess, \JsonSerializab
     public function __construct(?array $data = null)
     {
         $this->setIfExists('release', $data ?? [], null);
+        $this->setIfExists('release_group_title', $data ?? [], null);
         $this->setIfExists('songs', $data ?? [], null);
     }
 
@@ -284,6 +291,13 @@ class ReleaseGetResponse implements ModelInterface, ArrayAccess, \JsonSerializab
         if ($this->container['release'] === null) {
             $invalidProperties[] = "'release' can't be null";
         }
+        if ($this->container['release_group_title'] === null) {
+            $invalidProperties[] = "'release_group_title' can't be null";
+        }
+        if ((mb_strlen($this->container['release_group_title']) < 1)) {
+            $invalidProperties[] = "invalid value for 'release_group_title', the character length must be bigger than or equal to 1.";
+        }
+
         if ($this->container['songs'] === null) {
             $invalidProperties[] = "'songs' can't be null";
         }
@@ -325,6 +339,38 @@ class ReleaseGetResponse implements ModelInterface, ArrayAccess, \JsonSerializab
             throw new \InvalidArgumentException('non-nullable release cannot be null');
         }
         $this->container['release'] = $release;
+
+        return $this;
+    }
+
+    /**
+     * Gets release_group_title
+     *
+     * @return string
+     */
+    public function getReleaseGroupTitle()
+    {
+        return $this->container['release_group_title'];
+    }
+
+    /**
+     * Sets release_group_title
+     *
+     * @param string $release_group_title 所属リリースグループのタイトル。編集対象の文脈表示用
+     *
+     * @return self
+     */
+    public function setReleaseGroupTitle($release_group_title)
+    {
+        if (is_null($release_group_title)) {
+            throw new \InvalidArgumentException('non-nullable release_group_title cannot be null');
+        }
+
+        if ((mb_strlen($release_group_title) < 1)) {
+            throw new \InvalidArgumentException('invalid length for $release_group_title when calling ReleaseGetResponse., must be bigger than or equal to 1.');
+        }
+
+        $this->container['release_group_title'] = $release_group_title;
 
         return $this;
     }

--- a/src/server/app/Http/Presenters/Api/Admin/V1/Release/GetPresenter.php
+++ b/src/server/app/Http/Presenters/Api/Admin/V1/Release/GetPresenter.php
@@ -28,6 +28,7 @@ class GetPresenter
             fn (GetOutputData $outputData) => [
                 new ReleaseGetResponse()
                     ->setRelease($this->converter->toOpenApiRelease($outputData->release))
+                    ->setReleaseGroupTitle($outputData->releaseGroup->title->value)
                     ->setSongs(array_map($this->converter->toOpenApiReferencedSong(...), $outputData->songs)),
                 200,
             ],

--- a/src/server/packages/Release/Application/Admin/UseCase/Get/GetOutputData.php
+++ b/src/server/packages/Release/Application/Admin/UseCase/Get/GetOutputData.php
@@ -6,6 +6,7 @@ namespace Release\Application\Admin\UseCase\Get;
 
 use Release\Application\Admin\Query\ReleaseReferencedSong;
 use Release\Domain\Models\Release;
+use Release\Domain\Models\ReleaseGroup;
 
 readonly class GetOutputData
 {
@@ -14,6 +15,7 @@ readonly class GetOutputData
      */
     public function __construct(
         public Release $release,
+        public ReleaseGroup $releaseGroup,
         public array $songs,
     ) {
     }

--- a/src/server/packages/Release/Application/Admin/UseCase/Get/GetUseCase.php
+++ b/src/server/packages/Release/Application/Admin/UseCase/Get/GetUseCase.php
@@ -6,6 +6,7 @@ namespace Release\Application\Admin\UseCase\Get;
 
 use AdminUser\Domain\Models\Permission;
 use Release\Application\Admin\Query\ReleaseDetailQueryServiceInterface;
+use Release\Domain\Models\ReleaseGroupRepositoryInterface;
 use Release\Domain\Models\ReleaseId;
 use Release\Domain\Models\ReleaseRepositoryInterface;
 use ResultType\Err;
@@ -22,6 +23,7 @@ readonly class GetUseCase
     public function __construct(
         private UseCaseAuthorizer $authorizer,
         private ReleaseRepositoryInterface $repository,
+        private ReleaseGroupRepositoryInterface $groupRepository,
         private ReleaseDetailQueryServiceInterface $query,
     ) {
     }
@@ -47,8 +49,13 @@ readonly class GetUseCase
                     return new Err(new NotFoundError('Release', $releaseId->value));
                 }
 
+                if (is_null($group = $this->groupRepository->find($found->releaseGroupId))) {
+                    return new Err(new NotFoundError('ReleaseGroup', $found->releaseGroupId->value));
+                }
+
                 return new Ok(new GetOutputData(
                     $found,
+                    $group,
                     $this->query->findReferencedSongs($releaseId),
                 ));
             });

--- a/src/server/tests/Feature/Api/Admin/V1/Release/GetReleaseTest.php
+++ b/src/server/tests/Feature/Api/Admin/V1/Release/GetReleaseTest.php
@@ -96,6 +96,7 @@ class GetReleaseTest extends DatabaseTestCase
                         ],
                     ],
                 ],
+                'releaseGroupTitle' => '観測された春',
                 'songs' => [
                     [
                         'mediumPosition' => 1,

--- a/src/server/tests/Integration/Release/Application/Admin/UseCase/Get/GetUseCaseTest.php
+++ b/src/server/tests/Integration/Release/Application/Admin/UseCase/Get/GetUseCaseTest.php
@@ -62,6 +62,7 @@ class GetUseCaseTest extends DatabaseTestCase
 
         $this->assertTrue($result->isOk());
         $this->assertSame($releaseId, $result->unwrap()->release->releaseId->value);
+        $this->assertSame('観測された春', $result->unwrap()->releaseGroup->title->value);
         $this->assertCount(2, $result->unwrap()->release->media->toGeneric());
 
         // 収録曲は媒体順 → 曲順で並ぶ。


### PR DESCRIPTION
## 概要

Release 編集画面にはリリース自身の情報しか表示されておらず、どのリリースグループの版を編集しているのか分からなくなるため、所属グループのタイトルを表示する

## やったこと

- `ReleaseGetResponse` に `releaseGroupTitle` を追加し、OAS とクライアントを再生成
- Release の Get UseCase で `ReleaseGroupRepository` から所属グループを取得して出力に追加 (グループが引けない場合は NotFound)
- Release 編集画面の「← グループ詳細に戻る」の下に「リリースグループ: <タイトル>」をグループ詳細へのリンク付きで表示
- Feature / Integration テストに releaseGroupTitle の検証を追加

## やってないこと

- リリース作成画面 (CreateForm) への同様の表示。releaseGroupId プリフィル経由の遷移が前提のため今回は対象外
- パンくずリスト等のナビゲーション全体の見直し

## 関連

- 特になし

