### PR TITLE
ReleaseGroup のリリース日ベースの並びを調整

### DIFF
--- a/src/admin/src/components/release-group/CreateForm.tsx
+++ b/src/admin/src/components/release-group/CreateForm.tsx
@@ -16,6 +16,7 @@ const RELEASE_GROUP_TYPE_OPTIONS: Array<{ value: ReleaseGroupTypeValue; label: s
 export const CreateForm = () => {
   const [typeValue, setTypeValue] = createSignal<ReleaseGroupTypeValue>(1);
   const [isDisplay, setIsDisplay] = createSignal(true);
+  const [orderNo, setOrderNo] = createSignal(1);
 
   const { formError, getFieldError, clearErrors, handleError } = createFormErrors();
   const { isSubmitting, withSubmitting } = createSubmitting();
@@ -32,6 +33,7 @@ export const CreateForm = () => {
       typeValue: typeValue(),
       description: formData.get('description')?.toString() ?? '',
       isDisplay: isDisplay(),
+      orderNo: orderNo(),
     });
 
     if (data) {
@@ -106,6 +108,22 @@ export const CreateForm = () => {
                 <option value="false">表示しない</option>
               </select>
               <Show when={getFieldError('isDisplay')}>
+                {message => <p class="mt-1 text-xs text-error">{message()}</p>}
+              </Show>
+            </div>
+
+            <div>
+              <label class="label">表示補助番号</label>
+              <input
+                type="number"
+                class="input w-full"
+                name="orderNo"
+                min="1"
+                value={orderNo()}
+                onChange={e => setOrderNo(Number(e.currentTarget.value))}
+                classList={{ 'input-error': !!getFieldError('orderNo') }}
+              />
+              <Show when={getFieldError('orderNo')}>
                 {message => <p class="mt-1 text-xs text-error">{message()}</p>}
               </Show>
             </div>

--- a/src/admin/src/components/release-group/SearchList.tsx
+++ b/src/admin/src/components/release-group/SearchList.tsx
@@ -266,7 +266,6 @@ export const SearchList = () => {
               <th>タイトル</th>
               <th>種別</th>
               <th>初リリース日</th>
-              <th>表示順</th>
               <th>表示設定</th>
               <th>操作</th>
             </tr>
@@ -274,13 +273,13 @@ export const SearchList = () => {
           <tbody>
             <Switch>
               <Match when={data.loading}>
-                <ListState state="loading" colSpan={6} />
+                <ListState state="loading" colSpan={5} />
               </Match>
               <Match when={fetchError()}>
-                {message => <ListState state="error" colSpan={6} message={message()} onRetry={() => refetch()} />}
+                {message => <ListState state="error" colSpan={5} message={message()} onRetry={() => refetch()} />}
               </Match>
               <Match when={data() && data()!.releaseGroups.length === 0}>
-                <ListState state="empty" colSpan={6} message="条件に一致するリリースグループはありません。" />
+                <ListState state="empty" colSpan={5} message="条件に一致するリリースグループはありません。" />
               </Match>
               <Match when={data()}>
                 {result => (
@@ -298,7 +297,6 @@ export const SearchList = () => {
                             ? normalizeDateDisplayValue(releaseGroup.firstReleasedOn)
                             : '—'}
                         </td>
-                        <td class="text-sm">{releaseGroup.orderNo}</td>
                         <td>
                           <span
                             class={`badge badge-sm ${

--- a/src/admin/src/generated/types.gen.ts
+++ b/src/admin/src/generated/types.gen.ts
@@ -354,6 +354,7 @@ export type ReleaseGroupCreateRequest = {
     typeValue: ReleaseGroupTypeValue;
     description: string;
     isDisplay: boolean;
+    orderNo: OrderNo;
 };
 
 export type ReleaseGroupCreateResponse = {

--- a/src/admin/src/server/routes/release-groups.ts
+++ b/src/admin/src/server/routes/release-groups.ts
@@ -17,7 +17,15 @@ export const releaseGroups = new Elysia({ prefix: '/release-groups' })
     '/',
     async ({ body, authSession }) => {
       return withAuthRetry(authSession, async (client) => {
-        return resolveApiResponse(await releaseGroupServiceCreateReleaseGroup({ client, body }));
+        return resolveApiResponse(
+          await releaseGroupServiceCreateReleaseGroup({
+            client,
+            body: {
+              ...body,
+              typeValue: body.typeValue as ReleaseGroupTypeValue,
+            },
+          }),
+        );
       });
     },
     {
@@ -26,6 +34,7 @@ export const releaseGroups = new Elysia({ prefix: '/release-groups' })
         typeValue: t.Numeric(),
         description: t.String(),
         isDisplay: t.Boolean(),
+        orderNo: t.Number(),
       }),
     },
   )

--- a/src/contracts/generated/oas/IsekaiObservatory.Admin.v1.yaml
+++ b/src/contracts/generated/oas/IsekaiObservatory.Admin.v1.yaml
@@ -2713,6 +2713,7 @@ components:
         - typeValue
         - description
         - isDisplay
+        - orderNo
       properties:
         title:
           $ref: '#/components/schemas/releaseGroupTitle'
@@ -2722,6 +2723,8 @@ components:
           type: string
         isDisplay:
           type: boolean
+        orderNo:
+          $ref: '#/components/schemas/orderNo'
     ReleaseGroupCreateResponse:
       type: object
       required:

--- a/src/contracts/src/admin/releases/transport.tsp
+++ b/src/contracts/src/admin/releases/transport.tsp
@@ -9,6 +9,7 @@ model ReleaseGroupCreateRequest {
   typeValue: ReleaseGroupTypeValue;
   description: string;
   isDisplay: boolean;
+  orderNo: orderNo;
 }
 
 model ReleaseGroupCreateResponse {

--- a/src/server/Generated/Admin/lib/Model/ReleaseGroupCreateRequest.php
+++ b/src/server/Generated/Admin/lib/Model/ReleaseGroupCreateRequest.php
@@ -60,7 +60,8 @@ class ReleaseGroupCreateRequest implements ModelInterface, ArrayAccess, \JsonSer
         'title' => 'string',
         'type_value' => '\OpenAPI\Admin\Client\Model\ReleaseGroupTypeValue',
         'description' => 'string',
-        'is_display' => 'bool'
+        'is_display' => 'bool',
+        'order_no' => 'int'
     ];
 
     /**
@@ -74,7 +75,8 @@ class ReleaseGroupCreateRequest implements ModelInterface, ArrayAccess, \JsonSer
         'title' => null,
         'type_value' => null,
         'description' => null,
-        'is_display' => null
+        'is_display' => null,
+        'order_no' => 'int32'
     ];
 
     /**
@@ -86,7 +88,8 @@ class ReleaseGroupCreateRequest implements ModelInterface, ArrayAccess, \JsonSer
         'title' => false,
         'type_value' => false,
         'description' => false,
-        'is_display' => false
+        'is_display' => false,
+        'order_no' => false
     ];
 
     /**
@@ -178,7 +181,8 @@ class ReleaseGroupCreateRequest implements ModelInterface, ArrayAccess, \JsonSer
         'title' => 'title',
         'type_value' => 'typeValue',
         'description' => 'description',
-        'is_display' => 'isDisplay'
+        'is_display' => 'isDisplay',
+        'order_no' => 'orderNo'
     ];
 
     /**
@@ -190,7 +194,8 @@ class ReleaseGroupCreateRequest implements ModelInterface, ArrayAccess, \JsonSer
         'title' => 'setTitle',
         'type_value' => 'setTypeValue',
         'description' => 'setDescription',
-        'is_display' => 'setIsDisplay'
+        'is_display' => 'setIsDisplay',
+        'order_no' => 'setOrderNo'
     ];
 
     /**
@@ -202,7 +207,8 @@ class ReleaseGroupCreateRequest implements ModelInterface, ArrayAccess, \JsonSer
         'title' => 'getTitle',
         'type_value' => 'getTypeValue',
         'description' => 'getDescription',
-        'is_display' => 'getIsDisplay'
+        'is_display' => 'getIsDisplay',
+        'order_no' => 'getOrderNo'
     ];
 
     /**
@@ -266,6 +272,7 @@ class ReleaseGroupCreateRequest implements ModelInterface, ArrayAccess, \JsonSer
         $this->setIfExists('type_value', $data ?? [], null);
         $this->setIfExists('description', $data ?? [], null);
         $this->setIfExists('is_display', $data ?? [], null);
+        $this->setIfExists('order_no', $data ?? [], null);
     }
 
     /**
@@ -311,6 +318,13 @@ class ReleaseGroupCreateRequest implements ModelInterface, ArrayAccess, \JsonSer
         if ($this->container['is_display'] === null) {
             $invalidProperties[] = "'is_display' can't be null";
         }
+        if ($this->container['order_no'] === null) {
+            $invalidProperties[] = "'order_no' can't be null";
+        }
+        if (($this->container['order_no'] < 1)) {
+            $invalidProperties[] = "invalid value for 'order_no', must be bigger than or equal to 1.";
+        }
+
         return $invalidProperties;
     }
 
@@ -435,6 +449,38 @@ class ReleaseGroupCreateRequest implements ModelInterface, ArrayAccess, \JsonSer
             throw new \InvalidArgumentException('non-nullable is_display cannot be null');
         }
         $this->container['is_display'] = $is_display;
+
+        return $this;
+    }
+
+    /**
+     * Gets order_no
+     *
+     * @return int
+     */
+    public function getOrderNo()
+    {
+        return $this->container['order_no'];
+    }
+
+    /**
+     * Sets order_no
+     *
+     * @param int $order_no 表示順
+     *
+     * @return self
+     */
+    public function setOrderNo($order_no)
+    {
+        if (is_null($order_no)) {
+            throw new \InvalidArgumentException('non-nullable order_no cannot be null');
+        }
+
+        if (($order_no < 1)) {
+            throw new \InvalidArgumentException('invalid value for $order_no when calling ReleaseGroupCreateRequest., must be bigger than or equal to 1.');
+        }
+
+        $this->container['order_no'] = $order_no;
 
         return $this;
     }

--- a/src/server/packages/Release/Application/Admin/UseCase/Group/Create/CreateInputData.php
+++ b/src/server/packages/Release/Application/Admin/UseCase/Group/Create/CreateInputData.php
@@ -11,6 +11,7 @@ readonly class CreateInputData
         public int $typeValue,
         public string $description,
         public bool $isDisplay,
+        public int $orderNo,
     ) {
     }
 }

--- a/src/server/packages/Release/Application/Admin/UseCase/Group/Create/CreateUseCase.php
+++ b/src/server/packages/Release/Application/Admin/UseCase/Group/Create/CreateUseCase.php
@@ -53,6 +53,7 @@ readonly class CreateUseCase
                 $inputData->typeValue,
                 $inputData->description,
                 $inputData->isDisplay,
+                $inputData->orderNo,
             );
 
             if ($result->isErr()) {

--- a/src/server/packages/Release/Domain/Models/ReleaseGroupRepositoryInterface.php
+++ b/src/server/packages/Release/Domain/Models/ReleaseGroupRepositoryInterface.php
@@ -8,11 +8,6 @@ interface ReleaseGroupRepositoryInterface
 {
     public function find(ReleaseGroupId $releaseGroupId): ?ReleaseGroup;
 
-    /**
-     * 登録済みの最大 order_no を返す (未登録なら 0)
-     */
-    public function maxOrderNo(): int;
-
     public function save(ReleaseGroup $releaseGroup): ReleaseGroup;
 
     public function delete(ReleaseGroupId $releaseGroupId): void;

--- a/src/server/packages/Release/Domain/Services/ReleaseGroupIntegrityService.php
+++ b/src/server/packages/Release/Domain/Services/ReleaseGroupIntegrityService.php
@@ -7,7 +7,6 @@ namespace Release\Domain\Services;
 use Release\Domain\Models\Description;
 use Release\Domain\Models\ReleaseGroup;
 use Release\Domain\Models\ReleaseGroupId;
-use Release\Domain\Models\ReleaseGroupRepositoryInterface;
 use Release\Domain\Models\ReleaseGroupTitle;
 use Release\Domain\Models\ReleaseGroupType;
 use ResultType\Err;
@@ -21,20 +20,11 @@ use Support\Domain\ValueObjects\OrderNo;
 
 class ReleaseGroupIntegrityService
 {
-    /**
-     * 新規作成時の表示順の刻み幅。間への挿入余地を残すため隙間を空けて採番する
-     */
-    private const int ORDER_NO_STEP = 10;
-
-    public function __construct(
-        private readonly UuidGeneratorInterface $generator,
-        private readonly ReleaseGroupRepositoryInterface $repository,
-    ) {
+    public function __construct(private readonly UuidGeneratorInterface $generator)
+    {
     }
 
     /**
-     * 表示順は入力させず、既存の最大 order_no + 刻み幅で自動採番する
-     *
      * @return Result<ReleaseGroup, DomainError>
      */
     public function prepareForCreate(
@@ -42,9 +32,8 @@ class ReleaseGroupIntegrityService
         int $typeValue,
         string $description,
         bool $isDisplay,
+        int $orderNo,
     ): Result {
-        $orderNo = $this->repository->maxOrderNo() + self::ORDER_NO_STEP;
-
         return $this->build($this->generator->generate(), $title, $typeValue, $description, $isDisplay, $orderNo);
     }
 

--- a/src/server/packages/Release/Infrastructures/Admin/ReleaseGroupDetailQueryService.php
+++ b/src/server/packages/Release/Infrastructures/Admin/ReleaseGroupDetailQueryService.php
@@ -28,8 +28,8 @@ readonly class ReleaseGroupDetailQueryService implements ReleaseGroupDetailQuery
                 ->withSelect(['release_id', 'name', 'released_on', 'jacket_art_url', 'is_display', 'order_no'])
                 ->from('releases')
                 ->where('release_group_id', '=', $this->converter->toBin($releaseGroupId->value))
-                ->orderBy('order_no')
                 ->orderBy('released_on')
+                ->orderBy('order_no')
                 ->orderBy('name'),
         );
 

--- a/src/server/packages/Release/Infrastructures/Admin/ReleaseGroupSearchQueryService.php
+++ b/src/server/packages/Release/Infrastructures/Admin/ReleaseGroupSearchQueryService.php
@@ -46,9 +46,9 @@ readonly class ReleaseGroupSearchQueryService implements ReleaseGroupSearchQuery
                 ->groupBy('release_groups.description')
                 ->groupBy('release_groups.is_display')
                 ->groupBy('release_groups.order_no')
-                // 表示順の昇順、同順は最古発売日の降順（リリース未登録のグループは末尾）、同日はタイトル昇順。
-                ->orderBy('release_groups.order_no')
+                // 最古発売日の降順、同日は order_no の降順、リリース未登録のグループは末尾にする
                 ->orderBy('first_released_on', 'desc')
+                ->orderBy('release_groups.order_no', 'desc')
                 ->orderBy('release_groups.title')
                 ->limit($criteria->perPage->value)
                 ->offset($offset),

--- a/src/server/packages/Release/Infrastructures/ReleaseGroupRepository.php
+++ b/src/server/packages/Release/Infrastructures/ReleaseGroupRepository.php
@@ -46,16 +46,6 @@ readonly class ReleaseGroupRepository implements ReleaseGroupRepositoryInterface
     }
 
     #[Override]
-    public function maxOrderNo(): int
-    {
-        return Row::intValue(
-            $this->queryFactory->select()
-                ->from(self::TABLE)
-                ->aggregate($this->queryFactory->pdo(), 'COALESCE(MAX(`order_no`), 0)'),
-        );
-    }
-
-    #[Override]
     public function save(ReleaseGroup $releaseGroup): ReleaseGroup
     {
         $data = $releaseGroup->toArray();

--- a/src/server/packages/Release/Infrastructures/Viewer/ReleaseGroupQueryService.php
+++ b/src/server/packages/Release/Infrastructures/Viewer/ReleaseGroupQueryService.php
@@ -30,7 +30,7 @@ readonly class ReleaseGroupQueryService implements ReleaseGroupQueryServiceInter
     #[Override]
     public function list(?string $cursor, int $limit): ReleaseGroupListPage
     {
-        // 公開リリースを 1 件以上持つ公開グループのみを対象にする。
+        // 公開リリースを 1 件以上持つ公開グループのみを対象にする
         $query = $this->queryFactory->select()
             ->withSelect([
                 'release_groups.release_group_id',
@@ -53,21 +53,21 @@ readonly class ReleaseGroupQueryService implements ReleaseGroupQueryServiceInter
         if (is_string($cursor)) {
             $decoded = ReleaseGroupListCursor::decode($cursor);
 
-            // キーセットページング: (order_no ASC, first_released_on DESC, release_group_id ASC) で cursor より後ろを取る
+            // キーセットページング: (first_released_on DESC, order_no DESC, release_group_id ASC) で cursor より後ろを取る
             $query = $query->having(Sql::format(
-                '(release_groups.order_no > %s OR (release_groups.order_no = %s AND (MIN(releases.released_on) < %s OR (MIN(releases.released_on) = %s AND release_groups.release_group_id > %s))))',
-                Sql::value($decoded->orderNo),
-                Sql::value($decoded->orderNo),
+                '(MIN(releases.released_on) < %s OR (MIN(releases.released_on) = %s AND (release_groups.order_no < %s OR (release_groups.order_no = %s AND release_groups.release_group_id > %s))))',
                 Sql::value($decoded->firstReleasedOn),
                 Sql::value($decoded->firstReleasedOn),
+                Sql::value($decoded->orderNo),
+                Sql::value($decoded->orderNo),
                 Sql::value($this->converter->toBin($decoded->releaseGroupId)),
             ));
         }
 
         $groupRows = $this->queryFactory->fetchAll(
             $query
-                ->orderBy('release_groups.order_no')
                 ->orderBy('first_released_on', 'desc')
+                ->orderBy('release_groups.order_no', 'desc')
                 ->orderBy('release_groups.release_group_id')
                 ->limit($limit + 1),
         );
@@ -120,8 +120,8 @@ readonly class ReleaseGroupQueryService implements ReleaseGroupQueryServiceInter
                 ->from('releases')
                 ->where('release_group_id', 'IN', $binGroupIds)
                 ->where('is_display', '=', true)
-                ->orderBy('order_no')
                 ->orderBy('released_on')
+                ->orderBy('order_no')
                 ->orderBy('name'),
         );
 

--- a/src/server/tests/Feature/Api/Admin/V1/ReleaseGroup/CreateReleaseGroupTest.php
+++ b/src/server/tests/Feature/Api/Admin/V1/ReleaseGroup/CreateReleaseGroupTest.php
@@ -28,6 +28,7 @@ class CreateReleaseGroupTest extends DatabaseTestCase
                 'typeValue' => ReleaseGroupType::Album->value,
                 'description' => '1st アルバム',
                 'isDisplay' => true,
+                'orderNo' => 1,
             ])->assertStatus(200)
             ->assertJson(
                 static fn (AssertableJson $json) => $json
@@ -39,8 +40,7 @@ class CreateReleaseGroupTest extends DatabaseTestCase
                             ->where('typeValue', ReleaseGroupType::Album->value)
                             ->where('description', '1st アルバム')
                             ->where('isDisplay', true)
-                            // 表示順は自動採番 (既存なしなので 0 + 10)。
-                            ->where('orderNo', 10),
+                            ->where('orderNo', 1),
                     ),
             );
 
@@ -49,12 +49,12 @@ class CreateReleaseGroupTest extends DatabaseTestCase
             'type' => ReleaseGroupType::Album->value,
             'description' => '1st アルバム',
             'is_display' => true,
-            'order_no' => 10,
+            'order_no' => 1,
         ]);
     }
 
     #[Test]
-    public function assignsNextOrderNoOnCreate(): void
+    public function usesSubmittedOrderNoOnCreate(): void
     {
         $this->storeReleaseGroups(
             $this->createReleaseGroup($this->generateUuid(), '既存の作品', ReleaseGroupType::Single, true, orderNo: 15),
@@ -66,8 +66,9 @@ class CreateReleaseGroupTest extends DatabaseTestCase
                 'typeValue' => ReleaseGroupType::Album->value,
                 'description' => '',
                 'isDisplay' => true,
+                'orderNo' => 7,
             ])->assertStatus(200)
-            ->assertJsonPath('releaseGroup.orderNo', 25);
+            ->assertJsonPath('releaseGroup.orderNo', 7);
     }
 
     #[Test]
@@ -79,6 +80,7 @@ class CreateReleaseGroupTest extends DatabaseTestCase
                 'typeValue' => ReleaseGroupType::Album->value,
                 'description' => '',
                 'isDisplay' => true,
+                'orderNo' => 1,
             ])->assertStatus(403);
     }
 }

--- a/src/server/tests/Feature/Api/Admin/V1/ReleaseGroup/GetReleaseGroupTest.php
+++ b/src/server/tests/Feature/Api/Admin/V1/ReleaseGroup/GetReleaseGroupTest.php
@@ -90,15 +90,6 @@ class GetReleaseGroupTest extends DatabaseTestCase
                 ],
                 'releases' => [
                     [
-                        'releaseId' => $releaseId2,
-                        'name' => '初回限定盤',
-                        'releasedOn' => '2026-06-01',
-                        'jacketArtUrl' => 'https://example.com/limited.png',
-                        'isDisplay' => true,
-                        'orderNo' => 10,
-                        'formatValues' => [ReleaseFormat::Cd->value, ReleaseFormat::Dvd->value],
-                    ],
-                    [
                         'releaseId' => $releaseId1,
                         'name' => '配信',
                         'releasedOn' => '2026-05-01',
@@ -106,6 +97,15 @@ class GetReleaseGroupTest extends DatabaseTestCase
                         'isDisplay' => true,
                         'orderNo' => 20,
                         'formatValues' => [ReleaseFormat::Digital->value],
+                    ],
+                    [
+                        'releaseId' => $releaseId2,
+                        'name' => '初回限定盤',
+                        'releasedOn' => '2026-06-01',
+                        'jacketArtUrl' => 'https://example.com/limited.png',
+                        'isDisplay' => true,
+                        'orderNo' => 10,
+                        'formatValues' => [ReleaseFormat::Cd->value, ReleaseFormat::Dvd->value],
                     ],
                 ],
             ]);

--- a/src/server/tests/Feature/Api/Admin/V1/ReleaseGroup/SearchReleaseGroupTest.php
+++ b/src/server/tests/Feature/Api/Admin/V1/ReleaseGroup/SearchReleaseGroupTest.php
@@ -82,7 +82,7 @@ class SearchReleaseGroupTest extends DatabaseTestCase
     }
 
     #[Test]
-    public function sortsByOrderNoBeforeFirstReleasedOn(): void
+    public function sortsByFirstReleasedOnBeforeOrderNo(): void
     {
         $releaseGroupId1 = $this->generateUuid();
         $releaseGroupId2 = $this->generateUuid();
@@ -103,8 +103,34 @@ class SearchReleaseGroupTest extends DatabaseTestCase
         $this->withAuth()
             ->getJson(route(ReleaseGroupRouteMap::Search))
             ->assertStatus(200)
-            ->assertJsonPath('releaseGroups.0.releaseGroupId', $releaseGroupId1)
-            ->assertJsonPath('releaseGroups.1.releaseGroupId', $releaseGroupId2);
+            ->assertJsonPath('releaseGroups.0.releaseGroupId', $releaseGroupId2)
+            ->assertJsonPath('releaseGroups.1.releaseGroupId', $releaseGroupId1);
+    }
+
+    #[Test]
+    public function sortsByOrderNoDescendingWhenFirstReleasedOnIsSame(): void
+    {
+        $releaseGroupId1 = $this->generateUuid();
+        $releaseGroupId2 = $this->generateUuid();
+
+        $this->storeReleaseGroups(
+            $this->createReleaseGroup($releaseGroupId1, '同日で order_no が小さい作品', ReleaseGroupType::Single, true, orderNo: 1),
+            $this->createReleaseGroup($releaseGroupId2, '同日で order_no が大きい作品', ReleaseGroupType::Album, true, orderNo: 2),
+        );
+        $this->storeReleases(
+            $this->createRelease($this->generateUuid(), $releaseGroupId1, '配信', true, new ImmutableDate('2026-01-01'), media: [
+                ['position' => 1, 'name' => null, 'tracks' => []],
+            ]),
+            $this->createRelease($this->generateUuid(), $releaseGroupId2, '配信', true, new ImmutableDate('2026-01-01'), media: [
+                ['position' => 1, 'name' => null, 'tracks' => []],
+            ]),
+        );
+
+        $this->withAuth()
+            ->getJson(route(ReleaseGroupRouteMap::Search))
+            ->assertStatus(200)
+            ->assertJsonPath('releaseGroups.0.releaseGroupId', $releaseGroupId2)
+            ->assertJsonPath('releaseGroups.1.releaseGroupId', $releaseGroupId1);
     }
 
     #[Test]

--- a/src/server/tests/Feature/Api/Viewer/V1/Release/ListReleaseGroupTest.php
+++ b/src/server/tests/Feature/Api/Viewer/V1/Release/ListReleaseGroupTest.php
@@ -108,43 +108,6 @@ class ListReleaseGroupTest extends DatabaseTestCase
                         'firstReleasedOn' => '2026-05-01',
                         'releases' => [
                             [
-                                'releaseId' => $releaseId2,
-                                'name' => '初回限定盤',
-                                'releasedOn' => '2026-06-01',
-                                'description' => 'CD+DVD',
-                                'jacketArtUrl' => 'https://example.com/limited.png',
-                                'orderNo' => 10,
-                                'formats' => [
-                                    [
-                                        'name' => 'CD',
-                                        'value' => 2,
-                                    ],
-                                    [
-                                        'name' => 'DVD',
-                                        'value' => 3,
-                                    ],
-                                ],
-                                'media' => [
-                                    [
-                                        'position' => 1,
-                                        'name' => 'CD',
-                                        'tracks' => [
-                                            [
-                                                'trackNo' => 1,
-                                                'songId' => $visibleSongId,
-                                                'title' => '公開楽曲',
-                                                'isDisplay' => true,
-                                            ],
-                                        ],
-                                    ],
-                                    [
-                                        'position' => 2,
-                                        'name' => 'DVD',
-                                        'tracks' => [],
-                                    ],
-                                ],
-                            ],
-                            [
                                 'releaseId' => $releaseId1,
                                 'name' => '配信',
                                 'releasedOn' => '2026-05-01',
@@ -189,6 +152,43 @@ class ListReleaseGroupTest extends DatabaseTestCase
                                                 'isDisplay' => true,
                                             ],
                                         ],
+                                    ],
+                                ],
+                            ],
+                            [
+                                'releaseId' => $releaseId2,
+                                'name' => '初回限定盤',
+                                'releasedOn' => '2026-06-01',
+                                'description' => 'CD+DVD',
+                                'jacketArtUrl' => 'https://example.com/limited.png',
+                                'orderNo' => 10,
+                                'formats' => [
+                                    [
+                                        'name' => 'CD',
+                                        'value' => 2,
+                                    ],
+                                    [
+                                        'name' => 'DVD',
+                                        'value' => 3,
+                                    ],
+                                ],
+                                'media' => [
+                                    [
+                                        'position' => 1,
+                                        'name' => 'CD',
+                                        'tracks' => [
+                                            [
+                                                'trackNo' => 1,
+                                                'songId' => $visibleSongId,
+                                                'title' => '公開楽曲',
+                                                'isDisplay' => true,
+                                            ],
+                                        ],
+                                    ],
+                                    [
+                                        'position' => 2,
+                                        'name' => 'DVD',
+                                        'tracks' => [],
                                     ],
                                 ],
                             ],
@@ -242,6 +242,27 @@ class ListReleaseGroupTest extends DatabaseTestCase
     }
 
     #[Test]
+    public function sortsReleasesByOrderNoWhenReleasedOnIsSame(): void
+    {
+        $releaseGroupId = $this->generateUuid();
+        $releaseId1 = $this->generateUuid();
+        $releaseId2 = $this->generateUuid();
+
+        $this->storeReleaseGroups(
+            $this->createReleaseGroup($releaseGroupId, '同日リリースの作品', ReleaseGroupType::Album, true),
+        );
+        $this->storeReleases(
+            $this->createRelease($releaseId2, $releaseGroupId, '同日で order_no が大きい版', true, new ImmutableDate('2026-01-01'), orderNo: 2),
+            $this->createRelease($releaseId1, $releaseGroupId, '同日で order_no が小さい版', true, new ImmutableDate('2026-01-01'), orderNo: 1),
+        );
+
+        $this->get(route(ViewerReleaseGroupRouteMap::List))
+            ->assertStatus(200)
+            ->assertJsonPath('releaseGroups.0.releases.0.releaseId', $releaseId1)
+            ->assertJsonPath('releaseGroups.0.releases.1.releaseId', $releaseId2);
+    }
+
+    #[Test]
     public function paginatesWithCursor(): void
     {
         $releaseGroupId1 = $this->generateUuid();
@@ -256,7 +277,7 @@ class ListReleaseGroupTest extends DatabaseTestCase
             $this->createRelease($this->generateUuid(), $releaseGroupId2, '配信', true, new ImmutableDate('2026-02-01')),
         );
 
-        // 最古発売日の降順なので新しい作品が先。
+        // 最古発売日の降順なので新しい作品が先
         $response = $this->get(route(ViewerReleaseGroupRouteMap::List, ['limit' => 1]))
             ->assertStatus(200)
             ->assertJsonCount(1, 'releaseGroups')
@@ -273,25 +294,25 @@ class ListReleaseGroupTest extends DatabaseTestCase
     }
 
     #[Test]
-    public function sortsByOrderNoBeforeFirstReleasedOnAndPaginates(): void
+    public function sortsByOrderNoDescendingWhenFirstReleasedOnIsSameAndPaginates(): void
     {
         $releaseGroupId1 = $this->generateUuid();
         $releaseGroupId2 = $this->generateUuid();
 
         $this->storeReleaseGroups(
-            $this->createReleaseGroup($releaseGroupId1, '古いが先頭の作品', ReleaseGroupType::Single, true, orderNo: 1),
-            $this->createReleaseGroup($releaseGroupId2, '新しいが後続の作品', ReleaseGroupType::Album, true, orderNo: 2),
+            $this->createReleaseGroup($releaseGroupId1, '同日で order_no が小さい作品', ReleaseGroupType::Single, true, orderNo: 1),
+            $this->createReleaseGroup($releaseGroupId2, '同日で order_no が大きい作品', ReleaseGroupType::Album, true, orderNo: 2),
         );
         $this->storeReleases(
             $this->createRelease($this->generateUuid(), $releaseGroupId1, '配信', true, new ImmutableDate('2026-01-01')),
-            $this->createRelease($this->generateUuid(), $releaseGroupId2, '配信', true, new ImmutableDate('2026-02-01')),
+            $this->createRelease($this->generateUuid(), $releaseGroupId2, '配信', true, new ImmutableDate('2026-01-01')),
         );
 
-        // 発売日より order_no が優先されるため、古い作品でも order_no: 1 が先頭になる。
+        // 同じ発売日なら order_no の降順で制御する
         $response = $this->get(route(ViewerReleaseGroupRouteMap::List, ['limit' => 1]))
             ->assertStatus(200)
             ->assertJsonCount(1, 'releaseGroups')
-            ->assertJsonPath('releaseGroups.0.releaseGroupId', $releaseGroupId1);
+            ->assertJsonPath('releaseGroups.0.releaseGroupId', $releaseGroupId2);
 
         $cursor = $response->json('nextCursor');
         $this->assertIsString($cursor);
@@ -299,7 +320,7 @@ class ListReleaseGroupTest extends DatabaseTestCase
         $this->get(route(ViewerReleaseGroupRouteMap::List, ['limit' => 1, 'cursor' => $cursor]))
             ->assertStatus(200)
             ->assertJsonCount(1, 'releaseGroups')
-            ->assertJsonPath('releaseGroups.0.releaseGroupId', $releaseGroupId2)
+            ->assertJsonPath('releaseGroups.0.releaseGroupId', $releaseGroupId1)
             ->assertJsonMissingPath('nextCursor');
     }
 }

--- a/src/server/tests/Integration/Release/Application/Admin/UseCase/Group/Create/CreateUseCaseTest.php
+++ b/src/server/tests/Integration/Release/Application/Admin/UseCase/Group/Create/CreateUseCaseTest.php
@@ -26,6 +26,7 @@ class CreateUseCaseTest extends DatabaseTestCase
             typeValue: ReleaseGroupType::Album->value,
             description: '1st アルバム',
             isDisplay: true,
+            orderNo: 1,
         ));
 
         $this->assertTrue($result->isOk());
@@ -36,13 +37,12 @@ class CreateUseCaseTest extends DatabaseTestCase
             'type' => ReleaseGroupType::Album->value,
             'description' => '1st アルバム',
             'is_display' => true,
-            // 表示順は自動採番 (既存なしなので 0 + 10)。
-            'order_no' => 10,
+            'order_no' => 1,
         ]);
     }
 
     #[Test]
-    public function assignsNextOrderNoFromExistingMax(): void
+    public function usesSubmittedOrderNo(): void
     {
         $this->storeReleaseGroups(
             $this->createReleaseGroup($this->generateUuid(), '既存の作品', ReleaseGroupType::Single, true, orderNo: 15),
@@ -53,10 +53,11 @@ class CreateUseCaseTest extends DatabaseTestCase
             typeValue: ReleaseGroupType::Album->value,
             description: '',
             isDisplay: true,
+            orderNo: 7,
         ));
 
         $this->assertTrue($result->isOk());
-        $this->assertSame(25, $result->unwrap()->releaseGroup->orderNo->value);
+        $this->assertSame(7, $result->unwrap()->releaseGroup->orderNo->value);
     }
 
     #[Test]
@@ -67,6 +68,7 @@ class CreateUseCaseTest extends DatabaseTestCase
             typeValue: 0,
             description: '',
             isDisplay: true,
+            orderNo: 1,
         ));
 
         $this->assertTrue($result->isErr());

--- a/src/server/tests/Integration/Release/Application/Admin/UseCase/Group/Get/GetUseCaseTest.php
+++ b/src/server/tests/Integration/Release/Application/Admin/UseCase/Group/Get/GetUseCaseTest.php
@@ -46,15 +46,37 @@ class GetUseCaseTest extends DatabaseTestCase
         $this->assertTrue($result->isOk());
         $this->assertSame($releaseGroupId, $result->unwrap()->releaseGroup->releaseGroupId->value);
 
-        // 傘下リリースは表示順、formatValues は提供形態の値順。
+        // 傘下リリースは発売日順、formatValues は提供形態の値順
         $releases = $result->unwrap()->releases;
         $this->assertCount(2, $releases);
-        $this->assertSame($releaseId2, $releases[0]->releaseId);
-        $this->assertSame(10, $releases[0]->orderNo);
-        $this->assertSame([ReleaseFormat::Cd->value, ReleaseFormat::Dvd->value], $releases[0]->formatValues);
-        $this->assertSame($releaseId1, $releases[1]->releaseId);
-        $this->assertSame(20, $releases[1]->orderNo);
-        $this->assertSame([ReleaseFormat::Digital->value], $releases[1]->formatValues);
+        $this->assertSame($releaseId1, $releases[0]->releaseId);
+        $this->assertSame(20, $releases[0]->orderNo);
+        $this->assertSame([ReleaseFormat::Digital->value], $releases[0]->formatValues);
+        $this->assertSame($releaseId2, $releases[1]->releaseId);
+        $this->assertSame(10, $releases[1]->orderNo);
+        $this->assertSame([ReleaseFormat::Cd->value, ReleaseFormat::Dvd->value], $releases[1]->formatValues);
+    }
+
+    #[Test]
+    public function sortsReleasesByOrderNoWhenReleasedOnIsSame(): void
+    {
+        $releaseGroupId = $this->generateUuid();
+        $releaseId1 = $this->generateUuid();
+        $releaseId2 = $this->generateUuid();
+
+        $this->storeReleaseGroups(
+            $this->createReleaseGroup($releaseGroupId, '同日リリースの作品', ReleaseGroupType::Album, true),
+        );
+        $this->storeReleases(
+            $this->createRelease($releaseId2, $releaseGroupId, '同日で order_no が大きい版', true, new ImmutableDate('2026-01-01'), orderNo: 2),
+            $this->createRelease($releaseId1, $releaseGroupId, '同日で order_no が小さい版', true, new ImmutableDate('2026-01-01'), orderNo: 1),
+        );
+
+        $result = $this->getInstance()->handle(new GetInputData($releaseGroupId));
+
+        $this->assertTrue($result->isOk());
+        $this->assertSame($releaseId1, $result->unwrap()->releases[0]->releaseId);
+        $this->assertSame($releaseId2, $result->unwrap()->releases[1]->releaseId);
     }
 
     #[Test]

--- a/src/server/tests/Integration/Release/Application/Admin/UseCase/Group/Search/SearchUseCaseTest.php
+++ b/src/server/tests/Integration/Release/Application/Admin/UseCase/Group/Search/SearchUseCaseTest.php
@@ -82,6 +82,32 @@ class SearchUseCaseTest extends DatabaseTestCase
     }
 
     #[Test]
+    public function sortsByOrderNoDescendingWhenFirstReleasedOnIsSame(): void
+    {
+        $releaseGroupId1 = $this->generateUuid();
+        $releaseGroupId2 = $this->generateUuid();
+
+        $this->storeReleaseGroups(
+            $this->createReleaseGroup($releaseGroupId1, '同日で order_no が小さい作品', ReleaseGroupType::Single, true, orderNo: 1),
+            $this->createReleaseGroup($releaseGroupId2, '同日で order_no が大きい作品', ReleaseGroupType::Album, true, orderNo: 2),
+        );
+        $this->storeReleases(
+            $this->createRelease($this->generateUuid(), $releaseGroupId1, '配信', true, new ImmutableDate('2026-01-01'), media: [
+                ['position' => 1, 'name' => null, 'tracks' => []],
+            ]),
+            $this->createRelease($this->generateUuid(), $releaseGroupId2, '配信', true, new ImmutableDate('2026-01-01'), media: [
+                ['position' => 1, 'name' => null, 'tracks' => []],
+            ]),
+        );
+
+        $result = $this->getInstance()->handle(new SearchInputData());
+
+        $this->assertTrue($result->isOk());
+        $this->assertSame($releaseGroupId2, $result->unwrap()->releaseGroups[0]->releaseGroupId);
+        $this->assertSame($releaseGroupId1, $result->unwrap()->releaseGroups[1]->releaseGroupId);
+    }
+
+    #[Test]
     public function paginates(): void
     {
         foreach (range(1, 30) as $i) {


### PR DESCRIPTION
## 概要

ReleaseGroup の表示順をリリース日ベースに調整し、同一リリース日の制御に order_no を使えるようにします。
あわせて ReleaseGroup 作成時の order_no 自動採番を廃止し、管理画面から入力できるようにします。

## やったこと

- viewer/admin の ReleaseGroup 一覧を `first_released_on DESC > order_no DESC` で返すように変更
- ReleaseGroup 作成リクエストに `orderNo` を追加し、自動採番を廃止
- 管理画面の ReleaseGroup 作成フォームに表示補助番号の初期値 1 を追加
- 管理画面の ReleaseGroup 一覧から表示順列を削除
- ReleaseGroup 配下の Release 並びを `released_on ASC > order_no ASC` に調整
- 契約と generated code を更新
- 関連 Feature / Integration テストを更新

## やってないこと

- 既存データの order_no 移行
- ReleaseGroup 詳細編集画面の orderNo 入力削除

## 関連

- 特になし