### PR TITLE
Admin の楽曲人物選択を検索式に改善

### DIFF
--- a/src/admin/src/components/song/CreateForm.tsx
+++ b/src/admin/src/components/song/CreateForm.tsx
@@ -13,8 +13,8 @@ import { setFlash } from '../Flash';
 import { FormError } from '../FormError';
 import { SearchableSelect } from '../SearchableSelect';
 import { buildSongMediaRequest, MediaSection, type MediaEntry } from './MediaSection';
+import { toRequestSongPersons, type PersonSelections } from './person-selection';
 import { PersonSearchSection } from './PersonSearchSection';
-import { toRequestSongPersons, type SelectedPerson } from './person-selection';
 
 type SongTagEntry = {
   songTagId: string;
@@ -85,9 +85,7 @@ export const CreateForm = (props: CreateFormProps) => {
   const [availableTags] = createSignal<SongTag[]>(props.data.tags);
   const [availableMedia, setAvailableMedia] = createSignal<Media[]>(props.data.media);
 
-  const [lyricists, setLyricists] = createSignal<SelectedPerson[]>([]);
-  const [composers, setComposers] = createSignal<SelectedPerson[]>([]);
-  const [arrangers, setArrangers] = createSignal<SelectedPerson[]>([]);
+  const [personSelections, setPersonSelections] = createSignal<PersonSelections>({ 1: [], 2: [], 3: [] });
   const [tags, setTags] = createSignal<SongTagEntry[]>([]);
   const [mediaEntries, setMediaEntries] = createSignal<MediaEntry[]>([]);
   const [tagPickerValue, setTagPickerValue] = createSignal('');
@@ -115,9 +113,9 @@ export const CreateForm = (props: CreateFormProps) => {
   };
 
   const buildPersons = (): RequestSongPerson[] => [
-    ...toRequestSongPersons(lyricists(), 1),
-    ...toRequestSongPersons(composers(), 2),
-    ...toRequestSongPersons(arrangers(), 3),
+    ...toRequestSongPersons(personSelections()[1], 1),
+    ...toRequestSongPersons(personSelections()[2], 2),
+    ...toRequestSongPersons(personSelections()[3], 3),
   ];
 
   const handleSubmit = withSubmitting(async (e: Event) => {
@@ -292,9 +290,7 @@ export const CreateForm = (props: CreateFormProps) => {
         <fieldset class="fieldset bg-base-200 border-base-300 rounded-box border p-6">
           <legend class="px-2 text-sm font-semibold text-base-content/70">関係者</legend>
           <div class="space-y-4">
-            <PersonSearchSection label="作詞" selected={lyricists} setSelected={setLyricists} />
-            <PersonSearchSection label="作曲" selected={composers} setSelected={setComposers} />
-            <PersonSearchSection label="編曲" selected={arrangers} setSelected={setArrangers} />
+            <PersonSearchSection selections={personSelections} setSelections={setPersonSelections} />
           </div>
         </fieldset>
 

--- a/src/admin/src/components/song/CreateForm.tsx
+++ b/src/admin/src/components/song/CreateForm.tsx
@@ -1,9 +1,7 @@
 import { createResource, createSignal, For, Match, Show, Switch } from 'solid-js';
 import type {
   Media,
-  Person,
   RequestSongPerson,
-  SongPersonRole,
   SongTag,
   SongType,
   SongTypeValue,
@@ -15,18 +13,14 @@ import { setFlash } from '../Flash';
 import { FormError } from '../FormError';
 import { SearchableSelect } from '../SearchableSelect';
 import { buildSongMediaRequest, MediaSection, type MediaEntry } from './MediaSection';
-
-type PersonEntry = {
-  personId: string;
-  role: SongPersonRole;
-  orderNo: number;
-};
+import { PersonSearchSection } from './PersonSearchSection';
+import { toRequestSongPersons, type SelectedPerson } from './person-selection';
 
 type SongTagEntry = {
   songTagId: string;
 };
 
-type CreateFormData = { persons: Person[]; types: SongType[]; tags: SongTag[]; media: Media[] };
+type CreateFormData = { types: SongType[]; tags: SongTag[]; media: Media[] };
 
 interface CreateFormProps {
   data: CreateFormData;
@@ -86,15 +80,14 @@ export const CreateView = () => {
 };
 
 export const CreateForm = (props: CreateFormProps) => {
-  const [persons] = createSignal<Person[]>(props.data.persons);
   const [types] = createSignal<SongType[]>(props.data.types);
   const [typeValue, setTypeValue] = createSignal<SongTypeValue | ''>('');
   const [availableTags] = createSignal<SongTag[]>(props.data.tags);
   const [availableMedia, setAvailableMedia] = createSignal<Media[]>(props.data.media);
 
-  const [lyricists, setLyricists] = createSignal<PersonEntry[]>([]);
-  const [composers, setComposers] = createSignal<PersonEntry[]>([]);
-  const [arrangers, setArrangers] = createSignal<PersonEntry[]>([]);
+  const [lyricists, setLyricists] = createSignal<SelectedPerson[]>([]);
+  const [composers, setComposers] = createSignal<SelectedPerson[]>([]);
+  const [arrangers, setArrangers] = createSignal<SelectedPerson[]>([]);
   const [tags, setTags] = createSignal<SongTagEntry[]>([]);
   const [mediaEntries, setMediaEntries] = createSignal<MediaEntry[]>([]);
   const [tagPickerValue, setTagPickerValue] = createSignal('');
@@ -106,23 +99,6 @@ export const CreateForm = (props: CreateFormProps) => {
     const normalized = value?.toString().trim() ?? '';
 
     return normalized === '' ? null : normalized;
-  };
-
-  const addEntry = (setter: typeof setLyricists, role: SongPersonRole) => {
-    setter(prev => [...prev, { personId: '', role, orderNo: prev.length + 1 }]);
-  };
-
-  const removeEntry = (setter: typeof setLyricists, index: number) => {
-    setter(prev => prev.filter((_, i) => i !== index).map((entry, i) => ({ ...entry, orderNo: i + 1 })));
-  };
-
-  const updateEntry = (
-    setter: typeof setLyricists,
-    index: number,
-    field: keyof PersonEntry,
-    value: string | number,
-  ) => {
-    setter(prev => prev.map((entry, i) => (i === index ? { ...entry, [field]: value } : entry)));
   };
 
   const removeTagEntry = (index: number) => {
@@ -138,7 +114,11 @@ export const CreateForm = (props: CreateFormProps) => {
     setTagPickerValue('');
   };
 
-  const buildPersons = (): RequestSongPerson[] => [...lyricists(), ...composers(), ...arrangers()];
+  const buildPersons = (): RequestSongPerson[] => [
+    ...toRequestSongPersons(lyricists(), 1),
+    ...toRequestSongPersons(composers(), 2),
+    ...toRequestSongPersons(arrangers(), 3),
+  ];
 
   const handleSubmit = withSubmitting(async (e: Event) => {
     e.preventDefault();
@@ -167,16 +147,6 @@ export const CreateForm = (props: CreateFormProps) => {
     handleError(status, error);
   });
 
-  const personOptions = (entries: PersonEntry[], currentPersonId: string) => {
-    const selectedPersonIds = new Set(
-      entries.filter(entry => entry.personId !== '' && entry.personId !== currentPersonId).map(entry => entry.personId),
-    );
-
-    return persons()
-      .filter(person => !selectedPersonIds.has(person.personId) || person.personId === currentPersonId)
-      .map(person => ({ value: person.personId, label: person.name }));
-  };
-
   const tagOptions = () => {
     const selectedTagIds = new Set(tags().map(entry => entry.songTagId));
 
@@ -189,69 +159,6 @@ export const CreateForm = (props: CreateFormProps) => {
     tags()
       .map(entry => availableTags().find(tag => tag.songTagId === entry.songTagId))
       .filter((tag): tag is SongTag => tag !== undefined);
-
-  const PersonSection = (props: {
-    label: string;
-    entries: () => PersonEntry[];
-    setter: typeof setLyricists;
-    role: SongPersonRole;
-  }) => (
-    <div class="mt-4">
-      <div class="flex items-center gap-2">
-        <span class="label">{props.label}</span>
-        <button type="button" class="btn btn-xs btn-outline" onclick={() => addEntry(props.setter, props.role)}>
-          + 追加
-        </button>
-      </div>
-      <For each={props.entries()}>
-        {(entry, index) => (
-          <div class="mt-2 grid gap-3 md:grid-cols-[minmax(0,2fr)_96px_40px] md:items-center">
-            <SearchableSelect
-              options={personOptions(props.entries(), entry.personId)}
-              value={entry.personId}
-              onChange={value => updateEntry(props.setter, index(), 'personId', value)}
-              placeholder="人物を検索..."
-              required
-            />
-            <div class="flex items-center gap-2">
-              <label class="text-xs text-base-content/60">順</label>
-              <input
-                type="number"
-                class="input input-bordered w-16"
-                value={entry.orderNo}
-                onchange={e => updateEntry(props.setter, index(), 'orderNo', Number(e.currentTarget.value))}
-                required
-                min="1"
-              />
-            </div>
-            <button
-              type="button"
-              class="btn btn-ghost btn-xs btn-square text-error"
-              onclick={() => removeEntry(props.setter, index())}
-            >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke-width="1.5"
-                stroke="currentColor"
-                class="size-4"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0"
-                />
-              </svg>
-            </button>
-          </div>
-        )}
-      </For>
-      <Show when={props.entries().length === 0}>
-        <p class="mt-3 text-sm text-base-content/60">{props.label}はまだ追加されていません。</p>
-      </Show>
-    </div>
-  );
 
   const TagList = () => (
     <div class="mt-4">
@@ -384,9 +291,11 @@ export const CreateForm = (props: CreateFormProps) => {
 
         <fieldset class="fieldset bg-base-200 border-base-300 rounded-box border p-6">
           <legend class="px-2 text-sm font-semibold text-base-content/70">関係者</legend>
-          <PersonSection label="作詞" entries={lyricists} setter={setLyricists} role={1} />
-          <PersonSection label="作曲" entries={composers} setter={setComposers} role={2} />
-          <PersonSection label="編曲" entries={arrangers} setter={setArrangers} role={3} />
+          <div class="space-y-4">
+            <PersonSearchSection label="作詞" selected={lyricists} setSelected={setLyricists} />
+            <PersonSearchSection label="作曲" selected={composers} setSelected={setComposers} />
+            <PersonSearchSection label="編曲" selected={arrangers} setSelected={setArrangers} />
+          </div>
         </fieldset>
 
         <MediaSection

--- a/src/admin/src/components/song/EditableForm.tsx
+++ b/src/admin/src/components/song/EditableForm.tsx
@@ -1,11 +1,9 @@
 import { createResource, createSignal, For, Match, Show, Switch } from 'solid-js';
 import type {
   Media,
-  Person,
   RequestSongPerson,
   Song,
   SongPerson,
-  SongPersonRole,
   SongTag,
   SongType,
   SongTypeValue,
@@ -17,12 +15,8 @@ import { setFlash } from '../Flash';
 import { FormError } from '../FormError';
 import { SearchableSelect } from '../SearchableSelect';
 import { buildSongMediaRequest, MediaSection, toMediaEntry, type MediaEntry } from './MediaSection';
-
-type PersonEntry = {
-  personId: string;
-  role: SongPersonRole;
-  orderNo: number;
-};
+import { PersonSearchSection } from './PersonSearchSection';
+import { toRequestSongPersons, type SelectedPerson } from './person-selection';
 
 type SongTagEntry = {
   songTagId: string;
@@ -32,7 +26,7 @@ interface DetailViewProps {
   songId: string;
 }
 
-type EditableFormData = { song: Song; persons: Person[]; types: SongType[]; tags: SongTag[]; media: Media[] };
+type EditableFormData = { song: Song; types: SongType[]; tags: SongTag[]; media: Media[] };
 
 interface EditableFormProps {
   data: EditableFormData;
@@ -123,7 +117,6 @@ export const DetailView = (props: DetailViewProps) => {
 export const EditableForm = (props: EditableFormProps) => {
   const listUrl = getListUrl();
 
-  const persons = props.data.persons;
   const types = props.data.types;
   const [typeValue, setTypeValue] = createSignal<SongTypeValue | ''>(props.data.song.type.value);
   const availableTags = props.data.tags;
@@ -144,13 +137,19 @@ export const EditableForm = (props: EditableFormProps) => {
     return items;
   })();
 
-  const toEntries = (items: SongPerson[] | undefined): PersonEntry[] =>
-    (items ?? []).map(item => ({ personId: item.personId, role: item.role, orderNo: item.orderNo }));
+  const toSelectedPersons = (items: SongPerson[] | undefined): SelectedPerson[] =>
+    (items ?? []).map(item => ({ personId: item.personId, name: item.name }));
 
-  const initialEntries = toEntries(props.data.song.persons);
-  const [lyricists, setLyricists] = createSignal<PersonEntry[]>(initialEntries.filter(entry => entry.role === 1));
-  const [composers, setComposers] = createSignal<PersonEntry[]>(initialEntries.filter(entry => entry.role === 2));
-  const [arrangers, setArrangers] = createSignal<PersonEntry[]>(initialEntries.filter(entry => entry.role === 3));
+  const persons = props.data.song.persons;
+  const [lyricists, setLyricists] = createSignal<SelectedPerson[]>(
+    toSelectedPersons(persons.filter(person => person.role === 1)),
+  );
+  const [composers, setComposers] = createSignal<SelectedPerson[]>(
+    toSelectedPersons(persons.filter(person => person.role === 2)),
+  );
+  const [arrangers, setArrangers] = createSignal<SelectedPerson[]>(
+    toSelectedPersons(persons.filter(person => person.role === 3)),
+  );
   const [tags, setTags] = createSignal<SongTagEntry[]>(props.data.song.tags.map(tag => ({ songTagId: tag.songTagId })));
   const [availableMedia, setAvailableMedia] = createSignal<Media[]>(initialAvailableMedia);
   const [mediaEntries, setMediaEntries] = createSignal<MediaEntry[]>(props.data.song.media.map(toMediaEntry));
@@ -163,23 +162,6 @@ export const EditableForm = (props: EditableFormProps) => {
     const normalized = value?.toString().trim() ?? '';
 
     return normalized === '' ? null : normalized;
-  };
-
-  const addEntry = (setter: typeof setLyricists, role: SongPersonRole) => {
-    setter(prev => [...prev, { personId: '', role, orderNo: prev.length + 1 }]);
-  };
-
-  const removeEntry = (setter: typeof setLyricists, index: number) => {
-    setter(prev => prev.filter((_, i) => i !== index).map((entry, i) => ({ ...entry, orderNo: i + 1 })));
-  };
-
-  const updateEntry = (
-    setter: typeof setLyricists,
-    index: number,
-    field: keyof PersonEntry,
-    value: string | number,
-  ) => {
-    setter(prev => prev.map((entry, i) => (i === index ? { ...entry, [field]: value } : entry)));
   };
 
   const removeTagEntry = (index: number) => {
@@ -195,7 +177,11 @@ export const EditableForm = (props: EditableFormProps) => {
     setTagPickerValue('');
   };
 
-  const buildPersons = (): RequestSongPerson[] => [...lyricists(), ...composers(), ...arrangers()];
+  const buildPersons = (): RequestSongPerson[] => [
+    ...toRequestSongPersons(lyricists(), 1),
+    ...toRequestSongPersons(composers(), 2),
+    ...toRequestSongPersons(arrangers(), 3),
+  ];
 
   const handleSubmit = async (e: Event) => {
     e.preventDefault();
@@ -267,16 +253,6 @@ export const EditableForm = (props: EditableFormProps) => {
     handleError(status, error);
   });
 
-  const personOptions = (entries: PersonEntry[], currentPersonId: string) => {
-    const selectedPersonIds = new Set(
-      entries.filter(entry => entry.personId !== '' && entry.personId !== currentPersonId).map(entry => entry.personId),
-    );
-
-    return persons
-      .filter(person => !selectedPersonIds.has(person.personId) || person.personId === currentPersonId)
-      .map(person => ({ value: person.personId, label: person.name }));
-  };
-
   const tagOptions = () => {
     const selectedTagIds = new Set(tags().map(entry => entry.songTagId));
 
@@ -289,69 +265,6 @@ export const EditableForm = (props: EditableFormProps) => {
     tags()
       .map(entry => availableTags.find(tag => tag.songTagId === entry.songTagId))
       .filter((tag): tag is SongTag => tag !== undefined);
-
-  const PersonSection = (props: {
-    label: string;
-    entries: () => PersonEntry[];
-    setter: typeof setLyricists;
-    role: SongPersonRole;
-  }) => (
-    <div class="mt-4">
-      <div class="flex items-center gap-2">
-        <span class="label">{props.label}</span>
-        <button type="button" class="btn btn-xs btn-outline" onclick={() => addEntry(props.setter, props.role)}>
-          + 追加
-        </button>
-      </div>
-      <For each={props.entries()}>
-        {(entry, index) => (
-          <div class="mt-2 grid gap-3 md:grid-cols-[minmax(0,2fr)_96px_40px] md:items-center">
-            <SearchableSelect
-              options={personOptions(props.entries(), entry.personId)}
-              value={entry.personId}
-              onChange={value => updateEntry(props.setter, index(), 'personId', value)}
-              placeholder="人物を検索..."
-              required
-            />
-            <div class="flex items-center gap-2">
-              <label class="text-xs text-base-content/60">順</label>
-              <input
-                type="number"
-                class="input input-bordered w-16"
-                value={entry.orderNo}
-                onchange={e => updateEntry(props.setter, index(), 'orderNo', Number(e.currentTarget.value))}
-                required
-                min="1"
-              />
-            </div>
-            <button
-              type="button"
-              class="btn btn-ghost btn-xs btn-square text-error"
-              onclick={() => removeEntry(props.setter, index())}
-            >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke-width="1.5"
-                stroke="currentColor"
-                class="size-4"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0"
-                />
-              </svg>
-            </button>
-          </div>
-        )}
-      </For>
-      <Show when={props.entries().length === 0}>
-        <p class="mt-3 text-sm text-base-content/60">{props.label}はまだ追加されていません。</p>
-      </Show>
-    </div>
-  );
 
   const TagList = () => (
     <div class="mt-4">
@@ -500,9 +413,11 @@ export const EditableForm = (props: EditableFormProps) => {
 
           <fieldset class="fieldset bg-base-200 border-base-300 rounded-box border p-6">
             <legend class="px-2 text-sm font-semibold text-base-content/70">関係者</legend>
-            <PersonSection label="作詞" entries={lyricists} setter={setLyricists} role={1} />
-            <PersonSection label="作曲" entries={composers} setter={setComposers} role={2} />
-            <PersonSection label="編曲" entries={arrangers} setter={setArrangers} role={3} />
+            <div class="space-y-4">
+              <PersonSearchSection label="作詞" selected={lyricists} setSelected={setLyricists} />
+              <PersonSearchSection label="作曲" selected={composers} setSelected={setComposers} />
+              <PersonSearchSection label="編曲" selected={arrangers} setSelected={setArrangers} />
+            </div>
           </fieldset>
 
           <MediaSection

--- a/src/admin/src/components/song/EditableForm.tsx
+++ b/src/admin/src/components/song/EditableForm.tsx
@@ -15,8 +15,8 @@ import { setFlash } from '../Flash';
 import { FormError } from '../FormError';
 import { SearchableSelect } from '../SearchableSelect';
 import { buildSongMediaRequest, MediaSection, toMediaEntry, type MediaEntry } from './MediaSection';
+import { toRequestSongPersons, type PersonSelections, type SelectedPerson } from './person-selection';
 import { PersonSearchSection } from './PersonSearchSection';
-import { toRequestSongPersons, type SelectedPerson } from './person-selection';
 
 type SongTagEntry = {
   songTagId: string;
@@ -141,15 +141,11 @@ export const EditableForm = (props: EditableFormProps) => {
     (items ?? []).map(item => ({ personId: item.personId, name: item.name }));
 
   const persons = props.data.song.persons;
-  const [lyricists, setLyricists] = createSignal<SelectedPerson[]>(
-    toSelectedPersons(persons.filter(person => person.role === 1)),
-  );
-  const [composers, setComposers] = createSignal<SelectedPerson[]>(
-    toSelectedPersons(persons.filter(person => person.role === 2)),
-  );
-  const [arrangers, setArrangers] = createSignal<SelectedPerson[]>(
-    toSelectedPersons(persons.filter(person => person.role === 3)),
-  );
+  const [personSelections, setPersonSelections] = createSignal<PersonSelections>({
+    1: toSelectedPersons(persons.filter(person => person.role === 1)),
+    2: toSelectedPersons(persons.filter(person => person.role === 2)),
+    3: toSelectedPersons(persons.filter(person => person.role === 3)),
+  });
   const [tags, setTags] = createSignal<SongTagEntry[]>(props.data.song.tags.map(tag => ({ songTagId: tag.songTagId })));
   const [availableMedia, setAvailableMedia] = createSignal<Media[]>(initialAvailableMedia);
   const [mediaEntries, setMediaEntries] = createSignal<MediaEntry[]>(props.data.song.media.map(toMediaEntry));
@@ -178,9 +174,9 @@ export const EditableForm = (props: EditableFormProps) => {
   };
 
   const buildPersons = (): RequestSongPerson[] => [
-    ...toRequestSongPersons(lyricists(), 1),
-    ...toRequestSongPersons(composers(), 2),
-    ...toRequestSongPersons(arrangers(), 3),
+    ...toRequestSongPersons(personSelections()[1], 1),
+    ...toRequestSongPersons(personSelections()[2], 2),
+    ...toRequestSongPersons(personSelections()[3], 3),
   ];
 
   const handleSubmit = async (e: Event) => {
@@ -414,9 +410,7 @@ export const EditableForm = (props: EditableFormProps) => {
           <fieldset class="fieldset bg-base-200 border-base-300 rounded-box border p-6">
             <legend class="px-2 text-sm font-semibold text-base-content/70">関係者</legend>
             <div class="space-y-4">
-              <PersonSearchSection label="作詞" selected={lyricists} setSelected={setLyricists} />
-              <PersonSearchSection label="作曲" selected={composers} setSelected={setComposers} />
-              <PersonSearchSection label="編曲" selected={arrangers} setSelected={setArrangers} />
+              <PersonSearchSection selections={personSelections} setSelections={setPersonSelections} />
             </div>
           </fieldset>
 

--- a/src/admin/src/components/song/PersonSearchSection.tsx
+++ b/src/admin/src/components/song/PersonSearchSection.tsx
@@ -29,10 +29,9 @@ export const PersonSearchSection = (props: Props) => {
   const [searching, setSearching] = createSignal(false);
   const [hasSearched, setHasSearched] = createSignal(false);
   const [searchError, setSearchError] = createSignal<string | null>(null);
-  const [targetRole, setTargetRole] = createSignal<SongPersonRole>(1);
 
-  const selectedIds = () => new Set(props.selections()[targetRole()].map(person => person.personId));
-  const targetLabel = () => ROLE_OPTIONS.find(option => option.role === targetRole())?.label ?? '';
+  const isSelected = (role: SongPersonRole, personId: string) =>
+    props.selections()[role].some(person => person.personId === personId);
 
   const search = async (name: string, nextPage = 1) => {
     if (searching()) {
@@ -79,9 +78,14 @@ export const PersonSearchSection = (props: Props) => {
     setMaxPage(data.maxPage);
   };
 
-  const addPerson = (person: Person) => {
+  const togglePerson = (role: SongPersonRole, person: Person) => {
+    if (isSelected(role, person.personId)) {
+      removePerson(role, person.personId);
+      return;
+    }
+
     props.setSelections(current =>
-      addSelectedPersonToRole(current, targetRole(), { personId: person.personId, name: person.name }));
+      addSelectedPersonToRole(current, role, { personId: person.personId, name: person.name }));
   };
 
   const removePerson = (role: SongPersonRole, personId: string) => {
@@ -100,46 +104,33 @@ export const PersonSearchSection = (props: Props) => {
 
   return (
     <section class="space-y-4 rounded-box border border-base-300 bg-base-100 p-4">
-      <div class="grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto]">
-        <div>
-          <label class="label" for="song-person-search">人物名</label>
-          <div class="flex gap-2">
-            <input
-              id="song-person-search"
-              type="text"
-              class="input input-bordered min-w-0 flex-1"
-              value={query()}
-              placeholder="人物名で検索"
-              onInput={event => setQuery(event.currentTarget.value)}
-              onKeyDown={(event) => {
-                if (event.key === 'Enter') {
-                  event.preventDefault();
-                  void search(query().trim());
-                }
-              }}
-            />
-            <button
-              type="button"
-              class="btn btn-outline"
-              disabled={searching()}
-              onClick={() => void search(query().trim())}
-            >
-              {searching() ? '検索中...' : '検索'}
-            </button>
-          </div>
-          <Show when={searchError()}>{message => <p class="mt-2 text-sm text-error">{message()}</p>}</Show>
-        </div>
-        <div>
-          <label class="label" for="song-person-role">追加先</label>
-          <select
-            id="song-person-role"
-            class="select select-bordered w-full sm:w-32"
-            value={targetRole()}
-            onChange={event => setTargetRole(Number(event.currentTarget.value) as SongPersonRole)}
+      <div>
+        <label class="label" for="song-person-search">人物名</label>
+        <div class="flex gap-2">
+          <input
+            id="song-person-search"
+            type="text"
+            class="input input-bordered min-w-0 flex-1"
+            value={query()}
+            placeholder="人物名で検索"
+            onInput={event => setQuery(event.currentTarget.value)}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') {
+                event.preventDefault();
+                void search(query().trim());
+              }
+            }}
+          />
+          <button
+            type="button"
+            class="btn btn-outline"
+            disabled={searching()}
+            onClick={() => void search(query().trim())}
           >
-            <For each={ROLE_OPTIONS}>{option => <option value={option.role}>{option.label}</option>}</For>
-          </select>
+            {searching() ? '検索中...' : '検索'}
+          </button>
         </div>
+        <Show when={searchError()}>{message => <p class="mt-2 text-sm text-error">{message()}</p>}</Show>
       </div>
 
       <Show when={hasSearched() && !searchError()}>
@@ -151,20 +142,25 @@ export const PersonSearchSection = (props: Props) => {
             <For each={results()}>
               {person => (
                 <div class="flex items-center justify-between gap-3 rounded-box border border-base-300 p-3">
-                  <div class="flex min-w-0 items-center gap-2">
-                    <span class="truncate">{person.name}</span>
-                    <Show when={selectedIds().has(person.personId)}>
-                      <span class="badge badge-sm badge-primary badge-soft">{targetLabel()}に追加済み</span>
-                    </Show>
+                  <span class="min-w-0 truncate">{person.name}</span>
+                  <div class="join shrink-0">
+                    <For each={ROLE_OPTIONS}>
+                      {option => (
+                        <button
+                          type="button"
+                          class="btn btn-xs join-item"
+                          classList={{
+                            'btn-primary': isSelected(option.role, person.personId),
+                            'btn-outline': !isSelected(option.role, person.personId),
+                          }}
+                          aria-pressed={isSelected(option.role, person.personId)}
+                          onClick={() => togglePerson(option.role, person)}
+                        >
+                          {option.label}
+                        </button>
+                      )}
+                    </For>
                   </div>
-                  <button
-                    type="button"
-                    class="btn btn-primary btn-xs"
-                    disabled={selectedIds().has(person.personId)}
-                    onClick={() => addPerson(person)}
-                  >
-                    {targetLabel()}に追加
-                  </button>
                 </div>
               )}
             </For>

--- a/src/admin/src/components/song/PersonSearchSection.tsx
+++ b/src/admin/src/components/song/PersonSearchSection.tsx
@@ -1,0 +1,213 @@
+import { createSignal, For, Show } from 'solid-js';
+import type { Accessor, Setter } from 'solid-js';
+import type { Person } from '../../generated';
+import { client } from '../../utils/client';
+import { addSelectedPerson, moveSelectedPerson, type SelectedPerson } from './person-selection';
+
+interface Props {
+  label: string;
+  selected: Accessor<SelectedPerson[]>;
+  setSelected: Setter<SelectedPerson[]>;
+}
+
+const PER_PAGE = 25;
+
+export const PersonSearchSection = (props: Props) => {
+  const [query, setQuery] = createSignal('');
+  const [searchedName, setSearchedName] = createSignal('');
+  const [results, setResults] = createSignal<Person[]>([]);
+  const [page, setPage] = createSignal(1);
+  const [maxPage, setMaxPage] = createSignal(1);
+  const [searching, setSearching] = createSignal(false);
+  const [hasSearched, setHasSearched] = createSignal(false);
+  const [searchError, setSearchError] = createSignal<string | null>(null);
+
+  const selectedIds = () => new Set(props.selected().map(person => person.personId));
+
+  const search = async (name: string, nextPage = 1) => {
+    if (searching()) {
+      return;
+    }
+
+    if (name === '') {
+      setSearchError('人物名を入力してください');
+      setResults([]);
+      setHasSearched(false);
+      return;
+    }
+
+    setSearching(true);
+    setSearchError(null);
+    setHasSearched(true);
+    setSearchedName(name);
+
+    const { data, status } = await client.api.persons.search.get({
+      query: {
+        name,
+        sort: 'name',
+        order: 'asc',
+        page: nextPage,
+        per_page: PER_PAGE,
+      },
+    });
+
+    setSearching(false);
+
+    if (status === 401) {
+      window.location.href = '/auth/login';
+      return;
+    }
+
+    if (!data) {
+      setSearchError(`検索に失敗しました (${status})`);
+      setResults([]);
+      return;
+    }
+
+    setResults(data.persons);
+    setPage(nextPage);
+    setMaxPage(data.maxPage);
+  };
+
+  const addPerson = (person: Person) => {
+    props.setSelected(current => addSelectedPerson(current, { personId: person.personId, name: person.name }));
+  };
+
+  const removePerson = (personId: string) => {
+    props.setSelected(current => current.filter(person => person.personId !== personId));
+  };
+
+  return (
+    <section class="space-y-3 rounded-box border border-base-300 bg-base-100 p-4">
+      <h3 class="font-semibold">{props.label}</h3>
+
+      <div>
+        <label class="label" for={`${props.label}-person-search`}>人物名</label>
+        <div class="flex gap-2">
+          <input
+            id={`${props.label}-person-search`}
+            type="text"
+            class="input input-bordered min-w-0 flex-1"
+            value={query()}
+            placeholder="人物名で検索"
+            onInput={event => setQuery(event.currentTarget.value)}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') {
+                event.preventDefault();
+                void search(query().trim());
+              }
+            }}
+          />
+          <button
+            type="button"
+            class="btn btn-outline"
+            disabled={searching()}
+            onClick={() => void search(query().trim())}
+          >
+            {searching() ? '検索中...' : '検索'}
+          </button>
+        </div>
+        <Show when={searchError()}>{message => <p class="mt-2 text-sm text-error">{message()}</p>}</Show>
+      </div>
+
+      <Show when={hasSearched() && !searchError()}>
+        <div class="space-y-2">
+          <Show
+            when={results().length > 0}
+            fallback={<p class="text-sm text-base-content/60">条件に一致する人物はありません。</p>}
+          >
+            <For each={results()}>
+              {person => (
+                <div class="flex items-center justify-between gap-3 rounded-box border border-base-300 p-3">
+                  <div class="flex min-w-0 items-center gap-2">
+                    <span class="truncate">{person.name}</span>
+                    <Show when={selectedIds().has(person.personId)}>
+                      <span class="badge badge-sm badge-primary badge-soft">追加済み</span>
+                    </Show>
+                  </div>
+                  <button
+                    type="button"
+                    class="btn btn-primary btn-xs"
+                    disabled={selectedIds().has(person.personId)}
+                    onClick={() => addPerson(person)}
+                  >
+                    追加
+                  </button>
+                </div>
+              )}
+            </For>
+          </Show>
+
+          <Show when={maxPage() > 1}>
+            <div class="flex items-center justify-between text-xs text-base-content/60">
+              <span>{page()} / {maxPage()} ページ</span>
+              <div class="flex gap-2">
+                <button
+                  type="button"
+                  class="btn btn-ghost btn-xs"
+                  disabled={searching() || page() <= 1}
+                  onClick={() => void search(searchedName(), page() - 1)}
+                >
+                  前へ
+                </button>
+                <button
+                  type="button"
+                  class="btn btn-ghost btn-xs"
+                  disabled={searching() || page() >= maxPage()}
+                  onClick={() => void search(searchedName(), page() + 1)}
+                >
+                  次へ
+                </button>
+              </div>
+            </div>
+          </Show>
+        </div>
+      </Show>
+
+      <div>
+        <p class="label">選択中</p>
+        <Show
+          when={props.selected().length > 0}
+          fallback={<p class="text-sm text-base-content/60">{props.label}はまだ追加されていません。</p>}
+        >
+          <div class="space-y-2">
+            <For each={props.selected()}>
+              {(person, index) => (
+                <div class="flex items-center justify-between gap-3 rounded-box border border-base-300 p-3">
+                  <span class="min-w-0 truncate">{person.name}</span>
+                  <div class="flex shrink-0 gap-1">
+                    <button
+                      type="button"
+                      class="btn btn-ghost btn-xs"
+                      aria-label={`${person.name}を上へ移動`}
+                      disabled={index() === 0}
+                      onClick={() => props.setSelected(current => moveSelectedPerson(current, index(), -1))}
+                    >
+                      ↑
+                    </button>
+                    <button
+                      type="button"
+                      class="btn btn-ghost btn-xs"
+                      aria-label={`${person.name}を下へ移動`}
+                      disabled={index() === props.selected().length - 1}
+                      onClick={() => props.setSelected(current => moveSelectedPerson(current, index(), 1))}
+                    >
+                      ↓
+                    </button>
+                    <button
+                      type="button"
+                      class="btn btn-ghost btn-xs text-error"
+                      onClick={() => removePerson(person.personId)}
+                    >
+                      削除
+                    </button>
+                  </div>
+                </div>
+              )}
+            </For>
+          </div>
+        </Show>
+      </div>
+    </section>
+  );
+};

--- a/src/admin/src/components/song/PersonSearchSection.tsx
+++ b/src/admin/src/components/song/PersonSearchSection.tsx
@@ -1,16 +1,24 @@
 import { createSignal, For, Show } from 'solid-js';
 import type { Accessor, Setter } from 'solid-js';
-import type { Person } from '../../generated';
+import type { Person, SongPersonRole } from '../../generated';
 import { client } from '../../utils/client';
-import { addSelectedPerson, moveSelectedPerson, type SelectedPerson } from './person-selection';
+import {
+  addSelectedPersonToRole,
+  moveSelectedPerson,
+  type PersonSelections,
+} from './person-selection';
 
 interface Props {
-  label: string;
-  selected: Accessor<SelectedPerson[]>;
-  setSelected: Setter<SelectedPerson[]>;
+  selections: Accessor<PersonSelections>;
+  setSelections: Setter<PersonSelections>;
 }
 
 const PER_PAGE = 25;
+const ROLE_OPTIONS: { role: SongPersonRole; label: string }[] = [
+  { role: 1, label: '作詞' },
+  { role: 2, label: '作曲' },
+  { role: 3, label: '編曲' },
+];
 
 export const PersonSearchSection = (props: Props) => {
   const [query, setQuery] = createSignal('');
@@ -21,8 +29,10 @@ export const PersonSearchSection = (props: Props) => {
   const [searching, setSearching] = createSignal(false);
   const [hasSearched, setHasSearched] = createSignal(false);
   const [searchError, setSearchError] = createSignal<string | null>(null);
+  const [targetRole, setTargetRole] = createSignal<SongPersonRole>(1);
 
-  const selectedIds = () => new Set(props.selected().map(person => person.personId));
+  const selectedIds = () => new Set(props.selections()[targetRole()].map(person => person.personId));
+  const targetLabel = () => ROLE_OPTIONS.find(option => option.role === targetRole())?.label ?? '';
 
   const search = async (name: string, nextPage = 1) => {
     if (searching()) {
@@ -70,44 +80,66 @@ export const PersonSearchSection = (props: Props) => {
   };
 
   const addPerson = (person: Person) => {
-    props.setSelected(current => addSelectedPerson(current, { personId: person.personId, name: person.name }));
+    props.setSelections(current =>
+      addSelectedPersonToRole(current, targetRole(), { personId: person.personId, name: person.name }));
   };
 
-  const removePerson = (personId: string) => {
-    props.setSelected(current => current.filter(person => person.personId !== personId));
+  const removePerson = (role: SongPersonRole, personId: string) => {
+    props.setSelections(current => ({
+      ...current,
+      [role]: current[role].filter(person => person.personId !== personId),
+    }));
+  };
+
+  const movePerson = (role: SongPersonRole, index: number, direction: -1 | 1) => {
+    props.setSelections(current => ({
+      ...current,
+      [role]: moveSelectedPerson(current[role], index, direction),
+    }));
   };
 
   return (
-    <section class="space-y-3 rounded-box border border-base-300 bg-base-100 p-4">
-      <h3 class="font-semibold">{props.label}</h3>
-
-      <div>
-        <label class="label" for={`${props.label}-person-search`}>人物名</label>
-        <div class="flex gap-2">
-          <input
-            id={`${props.label}-person-search`}
-            type="text"
-            class="input input-bordered min-w-0 flex-1"
-            value={query()}
-            placeholder="人物名で検索"
-            onInput={event => setQuery(event.currentTarget.value)}
-            onKeyDown={(event) => {
-              if (event.key === 'Enter') {
-                event.preventDefault();
-                void search(query().trim());
-              }
-            }}
-          />
-          <button
-            type="button"
-            class="btn btn-outline"
-            disabled={searching()}
-            onClick={() => void search(query().trim())}
-          >
-            {searching() ? '検索中...' : '検索'}
-          </button>
+    <section class="space-y-4 rounded-box border border-base-300 bg-base-100 p-4">
+      <div class="grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto]">
+        <div>
+          <label class="label" for="song-person-search">人物名</label>
+          <div class="flex gap-2">
+            <input
+              id="song-person-search"
+              type="text"
+              class="input input-bordered min-w-0 flex-1"
+              value={query()}
+              placeholder="人物名で検索"
+              onInput={event => setQuery(event.currentTarget.value)}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') {
+                  event.preventDefault();
+                  void search(query().trim());
+                }
+              }}
+            />
+            <button
+              type="button"
+              class="btn btn-outline"
+              disabled={searching()}
+              onClick={() => void search(query().trim())}
+            >
+              {searching() ? '検索中...' : '検索'}
+            </button>
+          </div>
+          <Show when={searchError()}>{message => <p class="mt-2 text-sm text-error">{message()}</p>}</Show>
         </div>
-        <Show when={searchError()}>{message => <p class="mt-2 text-sm text-error">{message()}</p>}</Show>
+        <div>
+          <label class="label" for="song-person-role">追加先</label>
+          <select
+            id="song-person-role"
+            class="select select-bordered w-full sm:w-32"
+            value={targetRole()}
+            onChange={event => setTargetRole(Number(event.currentTarget.value) as SongPersonRole)}
+          >
+            <For each={ROLE_OPTIONS}>{option => <option value={option.role}>{option.label}</option>}</For>
+          </select>
+        </div>
       </div>
 
       <Show when={hasSearched() && !searchError()}>
@@ -122,7 +154,7 @@ export const PersonSearchSection = (props: Props) => {
                   <div class="flex min-w-0 items-center gap-2">
                     <span class="truncate">{person.name}</span>
                     <Show when={selectedIds().has(person.personId)}>
-                      <span class="badge badge-sm badge-primary badge-soft">追加済み</span>
+                      <span class="badge badge-sm badge-primary badge-soft">{targetLabel()}に追加済み</span>
                     </Show>
                   </div>
                   <button
@@ -131,7 +163,7 @@ export const PersonSearchSection = (props: Props) => {
                     disabled={selectedIds().has(person.personId)}
                     onClick={() => addPerson(person)}
                   >
-                    追加
+                    {targetLabel()}に追加
                   </button>
                 </div>
               )}
@@ -164,49 +196,55 @@ export const PersonSearchSection = (props: Props) => {
         </div>
       </Show>
 
-      <div>
-        <p class="label">選択中</p>
-        <Show
-          when={props.selected().length > 0}
-          fallback={<p class="text-sm text-base-content/60">{props.label}はまだ追加されていません。</p>}
-        >
-          <div class="space-y-2">
-            <For each={props.selected()}>
-              {(person, index) => (
-                <div class="flex items-center justify-between gap-3 rounded-box border border-base-300 p-3">
-                  <span class="min-w-0 truncate">{person.name}</span>
-                  <div class="flex shrink-0 gap-1">
-                    <button
-                      type="button"
-                      class="btn btn-ghost btn-xs"
-                      aria-label={`${person.name}を上へ移動`}
-                      disabled={index() === 0}
-                      onClick={() => props.setSelected(current => moveSelectedPerson(current, index(), -1))}
-                    >
-                      ↑
-                    </button>
-                    <button
-                      type="button"
-                      class="btn btn-ghost btn-xs"
-                      aria-label={`${person.name}を下へ移動`}
-                      disabled={index() === props.selected().length - 1}
-                      onClick={() => props.setSelected(current => moveSelectedPerson(current, index(), 1))}
-                    >
-                      ↓
-                    </button>
-                    <button
-                      type="button"
-                      class="btn btn-ghost btn-xs text-error"
-                      onClick={() => removePerson(person.personId)}
-                    >
-                      削除
-                    </button>
-                  </div>
+      <div class="grid gap-3 lg:grid-cols-3">
+        <For each={ROLE_OPTIONS}>
+          {option => (
+            <div class="rounded-box border border-base-300 p-3">
+              <p class="font-semibold">{option.label}</p>
+              <Show
+                when={props.selections()[option.role].length > 0}
+                fallback={<p class="mt-2 text-sm text-base-content/60">まだ追加されていません。</p>}
+              >
+                <div class="mt-2 space-y-2">
+                  <For each={props.selections()[option.role]}>
+                    {(person, index) => (
+                      <div class="flex items-center justify-between gap-3 rounded-box border border-base-300 p-3">
+                        <span class="min-w-0 truncate">{person.name}</span>
+                        <div class="flex shrink-0 gap-1">
+                          <button
+                            type="button"
+                            class="btn btn-ghost btn-xs"
+                            aria-label={`${person.name}を上へ移動`}
+                            disabled={index() === 0}
+                            onClick={() => movePerson(option.role, index(), -1)}
+                          >
+                            ↑
+                          </button>
+                          <button
+                            type="button"
+                            class="btn btn-ghost btn-xs"
+                            aria-label={`${person.name}を下へ移動`}
+                            disabled={index() === props.selections()[option.role].length - 1}
+                            onClick={() => movePerson(option.role, index(), 1)}
+                          >
+                            ↓
+                          </button>
+                          <button
+                            type="button"
+                            class="btn btn-ghost btn-xs text-error"
+                            onClick={() => removePerson(option.role, person.personId)}
+                          >
+                            削除
+                          </button>
+                        </div>
+                      </div>
+                    )}
+                  </For>
                 </div>
-              )}
-            </For>
-          </div>
-        </Show>
+              </Show>
+            </div>
+          )}
+        </For>
       </div>
     </section>
   );

--- a/src/admin/src/components/song/person-selection.test.ts
+++ b/src/admin/src/components/song/person-selection.test.ts
@@ -1,11 +1,30 @@
 import { describe, expect, it } from 'bun:test';
-import { addSelectedPerson, moveSelectedPerson, toRequestSongPersons } from './person-selection';
+import {
+  addSelectedPerson,
+  addSelectedPersonToRole,
+  moveSelectedPerson,
+  toRequestSongPersons,
+} from './person-selection';
 
 describe('楽曲の人物選択', () => {
   it('同じ役割には同一人物を重複して追加しない', () => {
     const selected = [{ personId: 'person-1', name: '人物1' }];
 
     expect(addSelectedPerson(selected, { personId: 'person-1', name: '人物1' })).toEqual(selected);
+  });
+
+  it('選択した役割だけに人物を追加する', () => {
+    const selections = {
+      1: [{ personId: 'person-1', name: '人物1' }],
+      2: [],
+      3: [],
+    };
+
+    expect(addSelectedPersonToRole(selections, 2, { personId: 'person-2', name: '人物2' })).toEqual({
+      1: [{ personId: 'person-1', name: '人物1' }],
+      2: [{ personId: 'person-2', name: '人物2' }],
+      3: [],
+    });
   });
 
   it('選択済み人物を上下に並べ替える', () => {

--- a/src/admin/src/components/song/person-selection.test.ts
+++ b/src/admin/src/components/song/person-selection.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'bun:test';
+import { addSelectedPerson, moveSelectedPerson, toRequestSongPersons } from './person-selection';
+
+describe('楽曲の人物選択', () => {
+  it('同じ役割には同一人物を重複して追加しない', () => {
+    const selected = [{ personId: 'person-1', name: '人物1' }];
+
+    expect(addSelectedPerson(selected, { personId: 'person-1', name: '人物1' })).toEqual(selected);
+  });
+
+  it('選択済み人物を上下に並べ替える', () => {
+    const selected = [
+      { personId: 'person-1', name: '人物1' },
+      { personId: 'person-2', name: '人物2' },
+      { personId: 'person-3', name: '人物3' },
+    ];
+
+    expect(moveSelectedPerson(selected, 1, -1)).toEqual([
+      { personId: 'person-2', name: '人物2' },
+      { personId: 'person-1', name: '人物1' },
+      { personId: 'person-3', name: '人物3' },
+    ]);
+  });
+
+  it('画面上の順序から送信用の表示順を生成する', () => {
+    const selected = [
+      { personId: 'person-2', name: '人物2' },
+      { personId: 'person-1', name: '人物1' },
+    ];
+
+    expect(toRequestSongPersons(selected, 2)).toEqual([
+      { personId: 'person-2', role: 2, orderNo: 1 },
+      { personId: 'person-1', role: 2, orderNo: 2 },
+    ]);
+  });
+});

--- a/src/admin/src/components/song/person-selection.ts
+++ b/src/admin/src/components/song/person-selection.ts
@@ -1,0 +1,45 @@
+import type { RequestSongPerson, SongPersonRole } from '../../generated';
+
+export type SelectedPerson = {
+  personId: string;
+  name: string;
+};
+
+export const addSelectedPerson = (selected: SelectedPerson[], person: SelectedPerson): SelectedPerson[] => {
+  if (selected.some(item => item.personId === person.personId)) {
+    return selected;
+  }
+
+  return [...selected, person];
+};
+
+export const moveSelectedPerson = (
+  selected: SelectedPerson[],
+  index: number,
+  direction: -1 | 1,
+): SelectedPerson[] => {
+  const nextIndex = index + direction;
+  if (nextIndex < 0 || nextIndex >= selected.length) {
+    return selected;
+  }
+
+  const next = [...selected];
+  const current = next[index];
+  const target = next[nextIndex];
+  if (!current || !target) {
+    return selected;
+  }
+
+  next[index] = target;
+  next[nextIndex] = current;
+  return next;
+};
+
+export const toRequestSongPersons = (
+  selected: SelectedPerson[],
+  role: SongPersonRole,
+): RequestSongPerson[] => selected.map((person, index) => ({
+  personId: person.personId,
+  role,
+  orderNo: index + 1,
+}));

--- a/src/admin/src/components/song/person-selection.ts
+++ b/src/admin/src/components/song/person-selection.ts
@@ -5,6 +5,8 @@ export type SelectedPerson = {
   name: string;
 };
 
+export type PersonSelections = Record<SongPersonRole, SelectedPerson[]>;
+
 export const addSelectedPerson = (selected: SelectedPerson[], person: SelectedPerson): SelectedPerson[] => {
   if (selected.some(item => item.personId === person.personId)) {
     return selected;
@@ -12,6 +14,15 @@ export const addSelectedPerson = (selected: SelectedPerson[], person: SelectedPe
 
   return [...selected, person];
 };
+
+export const addSelectedPersonToRole = (
+  selections: PersonSelections,
+  role: SongPersonRole,
+  person: SelectedPerson,
+): PersonSelections => ({
+  ...selections,
+  [role]: addSelectedPerson(selections[role], person),
+});
 
 export const moveSelectedPerson = (
   selected: SelectedPerson[],

--- a/src/admin/src/server/routes/songs.test.ts
+++ b/src/admin/src/server/routes/songs.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+
+const credentials: Record<string, unknown> = {};
+let listPersonsCalls = 0;
+
+mock.module('astro:env/server', () => ({
+  CACHE_TOKEN: 'cache-token',
+  CACHE_URL: 'https://cache.local',
+}));
+
+mock.module('@upstash/redis', () => {
+  class Redis {
+    async set(key: string, value: unknown): Promise<'OK'> {
+      credentials[key] = value;
+      return 'OK';
+    }
+
+    async get<T>(key: string): Promise<T | null> {
+      return (credentials[key] as T | undefined) ?? null;
+    }
+
+    async del(key: string): Promise<number> {
+      delete credentials[key];
+      return 1;
+    }
+  }
+
+  return { Redis };
+});
+
+mock.module('../client', () => ({
+  withAuthRetry: async <T>(_authSession: unknown, callback: (client: unknown) => Promise<T>): Promise<T> => {
+    return callback({ kind: 'auth-client' });
+  },
+}));
+
+const ok = (data: unknown) => ({ data, response: new Response(null, { status: 200 }) });
+
+mock.module('../../generated', () => ({
+  mediaServiceSearchMedia: async () => ok({ media: [], maxPage: 1 }),
+  personServiceListPersons: async () => {
+    listPersonsCalls += 1;
+    return ok({ persons: [{ personId: 'person-id', name: '人物', orderNo: 1 }] });
+  },
+  songServiceCreateSong: async () => ok({}),
+  songServiceDeleteSong: async () => ok({}),
+  songServiceGetSong: async () => ok({ song: { songId: 'song-id', persons: [], tags: [], media: [] } }),
+  songServiceSearchSongs: async () => ok({ songs: [], maxPage: 1 }),
+  songServiceUpdateSong: async () => ok({}),
+  songTagServiceListSongTags: async () => ok({ tags: [] }),
+  songTypeServiceListSongTypes: async () => ok({ types: [] }),
+}));
+
+const { songs } = await import('./songs');
+
+describe('song form routes', () => {
+  beforeEach(() => {
+    for (const key of Object.keys(credentials)) {
+      delete credentials[key];
+    }
+
+    listPersonsCalls = 0;
+    credentials['session:test-session'] = {
+      accessToken: 'access-token',
+      refreshTokenId: 'refresh-token-id',
+      refreshToken: 'refresh-token',
+      csrfToken: 'csrf-token',
+    };
+  });
+
+  it('作成フォーム表示時に全人物を事前取得しない', async () => {
+    const response = await songs.handle(authenticatedRequest('http://localhost/songs/create-form'));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(listPersonsCalls).toBe(0);
+    expect(body).not.toHaveProperty('persons');
+  });
+
+  it('編集フォーム表示時に全人物を事前取得しない', async () => {
+    const response = await songs.handle(authenticatedRequest('http://localhost/songs/song-id/edit-form'));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(listPersonsCalls).toBe(0);
+    expect(body).not.toHaveProperty('persons');
+  });
+});
+
+const authenticatedRequest = (url: string) => new Request(url, {
+  headers: {
+    cookie: 'session=test-session',
+    'x-csrf-token': 'csrf-token',
+  },
+});

--- a/src/admin/src/server/routes/songs.test.ts
+++ b/src/admin/src/server/routes/songs.test.ts
@@ -89,7 +89,7 @@ describe('song form routes', () => {
 
 const authenticatedRequest = (url: string) => new Request(url, {
   headers: {
-    cookie: 'session=test-session',
+    'cookie': 'session=test-session',
     'x-csrf-token': 'csrf-token',
   },
 });

--- a/src/admin/src/server/routes/songs.ts
+++ b/src/admin/src/server/routes/songs.ts
@@ -1,7 +1,6 @@
 import { Elysia, t } from 'elysia';
 import {
   mediaServiceSearchMedia,
-  personServiceListPersons,
   songServiceCreateSong,
   songServiceDeleteSong,
   songServiceGetSong,
@@ -28,15 +27,13 @@ export const songs = new Elysia({ prefix: '/songs' })
   .use(authGuard)
   .get('/create-form', async ({ authSession }) => {
     return withAuthRetry(authSession, async (client) => {
-      const [persons, types, tags, media] = await Promise.all([
-        personServiceListPersons({ client }),
+      const [types, tags, media] = await Promise.all([
         songTypeServiceListSongTypes({ client }),
         songTagServiceListSongTags({ client }),
         mediaServiceSearchMedia({ client, query: { per_page: 50 } }),
       ]);
 
       return {
-        persons: resolveApiResponse(persons).persons,
         types: resolveApiResponse(types).types,
         tags: resolveApiResponse(tags).tags,
         media: resolveApiResponse(media).media,
@@ -85,9 +82,8 @@ export const songs = new Elysia({ prefix: '/songs' })
     '/:songId/edit-form',
     async ({ params: { songId }, authSession }) => {
       return withAuthRetry(authSession, async (client) => {
-        const [song, persons, types, tags, media] = await Promise.all([
+        const [song, types, tags, media] = await Promise.all([
           songServiceGetSong({ client, path: { songId } }),
-          personServiceListPersons({ client }),
           songTypeServiceListSongTypes({ client }),
           songTagServiceListSongTags({ client }),
           mediaServiceSearchMedia({ client, query: { per_page: 50 } }),
@@ -95,7 +91,6 @@ export const songs = new Elysia({ prefix: '/songs' })
 
         return {
           ...resolveApiResponse(song),
-          persons: resolveApiResponse(persons).persons,
           types: resolveApiResponse(types).types,
           tags: resolveApiResponse(tags).tags,
           media: resolveApiResponse(media).media,


### PR DESCRIPTION
## 概要

楽曲の作成・編集時に全人物を事前取得せず、役割ごとに人物を検索して追加できるようにします
人物数が増えても候補を探しやすくし、表示順の入力ミスも防ぎます

## やったこと

- 作詞者・作曲者・編曲者ごとに人物名検索とページ送りを追加
- 検索結果からの追加、同一役割内の重複防止、複数役割への追加に対応
- 選択済み人物を上下操作で並べ替え、送信時の表示順を自動生成
- 楽曲フォーム初期表示時の全人物一覧取得を廃止
- 人物選択モデルと BFF レスポンス境界のテストを追加

## やってないこと

- 楽曲フォーム内からの人物新規作成
- API 契約と人物検索 API の変更

## 関連

- 特になし