### PR TITLE
リリース詳細のトップに表示していたジャケットアートを削除

### DIFF
--- a/src/viewer/src/components/viewer/details/ReleaseDetailContent.astro
+++ b/src/viewer/src/components/viewer/details/ReleaseDetailContent.astro
@@ -1,7 +1,5 @@
 ---
 import type { ReleaseGroup } from '../../../features/releases/types';
-import { representativeJacketArtUrl } from '../../../features/releases/types';
-import JacketArt from '../JacketArt.astro';
 import ReleaseVersionBody from './ReleaseVersionBody.astro';
 
 interface Props {
@@ -9,13 +7,11 @@ interface Props {
 }
 
 const { releaseGroup } = Astro.props;
-const jacketArtUrl = representativeJacketArtUrl(releaseGroup);
 const isSingleReleaseGroup = releaseGroup.releases.length === 1;
 ---
 
 <div class="detail-page-content release-detail-content">
-  <JacketArt imageUrl={jacketArtUrl} label={releaseGroup.title} />
-  <div class="label-mono" style="margin-top: 28px;">{releaseGroup.firstReleasedOn} · {releaseGroup.type.name}</div>
+  <div class="label-mono">{releaseGroup.firstReleasedOn} · {releaseGroup.type.name}</div>
   <h1 class="detail-title">{releaseGroup.title}</h1>
   {releaseGroup.description && <p class="detail-description" style="margin-top: 16px;">{releaseGroup.description}</p>}
 

--- a/src/viewer/src/components/viewer/details/ReleaseVersionBody.astro
+++ b/src/viewer/src/components/viewer/details/ReleaseVersionBody.astro
@@ -14,7 +14,7 @@ const { release, releaseGroupTitle } = Astro.props;
   {
     release.jacketArtUrl && (
       <div class="release-version-art">
-        <JacketArt imageUrl={release.jacketArtUrl} label={`${releaseGroupTitle} ${release.name}`} />
+        <JacketArt imageUrl={release.jacketArtUrl} label={`${releaseGroupTitle} ${release.name}`} aspectRatio="auto" />
       </div>
     )
   }

--- a/src/viewer/src/styles/viewer.css
+++ b/src/viewer/src/styles/viewer.css
@@ -2506,7 +2506,6 @@ image-slot:hover {
   gap: 24px;
 }
 
-.detail-panel .release-detail-content .jacket-art,
 .detail-panel .media-detail-content .mv-thumb {
   max-width: 280px;
 }


### PR DESCRIPTION
## 概要

リリース詳細トップのジャケットアート表示が余計だったので削除した
また、詳細画面でのジャケットアートの比率を変更