### PR TITLE
migration がずっと差分出てくるのを修正

### DIFF
--- a/src/server/database/atlas/schemas/release-tracks.my.hcl
+++ b/src/server/database/atlas/schemas/release-tracks.my.hcl
@@ -35,7 +35,7 @@ table "release_tracks" {
   }
 
   check "release_tracks_song_id_title_at_least_one" {
-    expr = "(`song_id` IS NOT NULL) OR (`title` IS NOT NULL)"
+    expr = "((`song_id` is not null) or (`title` is not null))"
   }
 
   index "fk_release_tracks_song_id" {


### PR DESCRIPTION
## 概要

atlas のマイグレーションがずっと差分出てしまう現象を解消