### PR TITLE
media:youtube:import で取り込むメディアをデフォルト非表示にする

### DIFF
--- a/src/server/packages/Media/Application/Cli/UseCase/ImportYouTube/ImportYouTubeUseCase.php
+++ b/src/server/packages/Media/Application/Cli/UseCase/ImportYouTube/ImportYouTubeUseCase.php
@@ -84,7 +84,7 @@ readonly class ImportYouTubeUseCase
                 $url->value,
                 new DateTimeImmutable($video->publishedAt)->setTimezone(new DateTimeZone(date_default_timezone_get())),
                 $this->resolveType($video->title, $isShort)->value,
-                true,
+                false,
             );
         }
 

--- a/src/server/tests/Feature/Console/Commands/Media/ImportYouTubeCommandTest.php
+++ b/src/server/tests/Feature/Console/Commands/Media/ImportYouTubeCommandTest.php
@@ -58,7 +58,7 @@ class ImportYouTubeCommandTest extends DatabaseTestCase
             $this->assertSame($title, $rows[$i]->title);
             $this->assertSame($type->value, (int)$rows[$i]->type);
             $this->assertSame($publishedAt, $rows[$i]->published_at);
-            $this->assertSame(1, (int)$rows[$i]->is_display);
+            $this->assertSame(0, (int)$rows[$i]->is_display);
         }
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

`media:youtube:import` で取り込んだメディアが、デフォルトで viewer に表示されないようにします。

## やったこと

- `ImportYouTubeUseCase` で保存する `is_display` を `true` から `false` に変更
- Feature テストの期待値を非表示に合わせて更新

## やってないこと

- 既存の取り込み済みデータの一括非表示化
- 管理画面からの表示切り替え UI の変更

## 関連

なし

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-67761d7d-26fd-4f82-a7d2-5b8848b34fd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-67761d7d-26fd-4f82-a7d2-5b8848b34fd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

