### PR TITLE
CI のパスフィルタ追加と PHPUnit のスイート分割

### DIFF
--- a/.github/workflows/admin-qa.yaml
+++ b/.github/workflows/admin-qa.yaml
@@ -4,9 +4,36 @@ on:
   schedule:
     - cron: "0 0 * * *"
   pull_request:
+    # main, stg 向け PR は release-qa 経由で必ず全実行する
+    branches-ignore:
+      - main
+      - stg
+    paths:
+      - "src/admin/**"
+      - "src/contracts/**"
+      - "src/package.json"
+      - "src/pnpm-lock.yaml"
+      - "src/pnpm-workspace.yaml"
+      - "src/biome.json"
+      - "mise.toml"
+      - "mise.ci.toml"
+      - ".github/workflows/admin-qa.yaml"
+      - ".github/actions/**"
   push:
     branches:
       - dev
+    paths:
+      - "src/admin/**"
+      - "src/contracts/**"
+      - "src/package.json"
+      - "src/pnpm-lock.yaml"
+      - "src/pnpm-workspace.yaml"
+      - "src/biome.json"
+      - "mise.toml"
+      - "mise.ci.toml"
+      - ".github/workflows/admin-qa.yaml"
+      - ".github/actions/**"
+  workflow_call:
 
 env:
   MISE_ENV: ci

--- a/.github/workflows/contracts-qa.yaml
+++ b/.github/workflows/contracts-qa.yaml
@@ -2,9 +2,32 @@ name: Contracts QA
 
 on:
   pull_request:
+    # main, stg 向け PR は release-qa 経由で必ず全実行する
+    branches-ignore:
+      - main
+      - stg
+    paths:
+      - "src/contracts/**"
+      - "src/package.json"
+      - "src/pnpm-lock.yaml"
+      - "src/pnpm-workspace.yaml"
+      - "mise.toml"
+      - "mise.ci.toml"
+      - ".github/workflows/contracts-qa.yaml"
+      - ".github/actions/**"
   push:
     branches:
       - dev
+    paths:
+      - "src/contracts/**"
+      - "src/package.json"
+      - "src/pnpm-lock.yaml"
+      - "src/pnpm-workspace.yaml"
+      - "mise.toml"
+      - "mise.ci.toml"
+      - ".github/workflows/contracts-qa.yaml"
+      - ".github/actions/**"
+  workflow_call:
 
 jobs:
   format:

--- a/.github/workflows/release-qa.yaml
+++ b/.github/workflows/release-qa.yaml
@@ -1,0 +1,33 @@
+name: Release QA
+
+# main, stg 向け PR ではパスに関係なくすべての QA を実行する
+on:
+  pull_request:
+    branches:
+      - main
+      - stg
+  push:
+    branches:
+      - main
+      - stg
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  server:
+    name: Server QA
+    uses: ./.github/workflows/server-qa.yaml
+
+  viewer:
+    name: Viewer QA
+    uses: ./.github/workflows/viewer-qa.yaml
+
+  admin:
+    name: Admin QA
+    uses: ./.github/workflows/admin-qa.yaml
+
+  contracts:
+    name: Contracts QA
+    uses: ./.github/workflows/contracts-qa.yaml

--- a/.github/workflows/server-qa.yaml
+++ b/.github/workflows/server-qa.yaml
@@ -4,12 +4,39 @@ on:
   schedule:
     - cron: "0 0 * * *"
   pull_request:
+    # main, stg 向け PR は release-qa 経由で必ず全実行する
+    branches-ignore:
+      - main
+      - stg
+    paths:
+      - "src/server/**"
+      - "src/contracts/**"
+      - "infra/**"
+      - "compose.yaml"
+      - "mise.toml"
+      - "mise.ci.toml"
+      - ".github/workflows/server-qa.yaml"
+      - ".github/actions/**"
   push:
     branches:
       - dev
+    paths:
+      - "src/server/**"
+      - "src/contracts/**"
+      - "infra/**"
+      - "compose.yaml"
+      - "mise.toml"
+      - "mise.ci.toml"
+      - ".github/workflows/server-qa.yaml"
+      - ".github/actions/**"
+  workflow_call:
 
 env:
   MISE_ENV: ci
+  SERVER_DOCKER_PATH: /tmp/cache/docker/server
+  OPENAPI_GENERATOR_CLI_DOCKER_PATH: /tmp/cache/docker/openapi-generator-cli
+  MYSQL_DOCKER_PATH: /tmp/cache/docker/mysql
+  VENDOR_PATH: ./src/server/vendor
 
 permissions:
   contents: read
@@ -19,23 +46,14 @@ jobs:
   setup:
     name: Setup server
     runs-on: ubuntu-latest
-    outputs:
-      vendor-key: ${{ steps.define-variables.outputs.VENDOR_KEY }}
-
     steps:
       - name: Checkout the code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.ref }}
-          submodules: true
 
       - name: Setup mise
         uses: ./.github/actions/setup-mise
-
-      - name: Define variables
-        id: define-variables
-        run: |
-          echo "VENDOR_KEY=${VENDOR_KEY_PREFIX}${{ hashFiles('./src/server/composer.*') }}" >> $GITHUB_OUTPUT
 
       - name: Login to GHCR
         uses: docker/login-action@06fb636fac595d6fb4b28a5dfcb21a6f5091859c # v4.5.0
@@ -49,33 +67,39 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ env.SERVER_DOCKER_PATH }}
-          key: ${{ env.SERVER_DOCKER_KEY_PREFIX }}${{ hashFiles('./infra/local/docker/php/Dockerfile') }}
+          key: docker-server-${{ hashFiles('./infra/local/docker/php/Dockerfile') }}
 
       - name: Build server image
         if: steps.cache-server-docker-image.outputs.cache-hit != 'true'
-        run: mise run build:php
+        run: |
+          mise run build:php
+          mkdir -p "${SERVER_DOCKER_PATH}"
 
       - name: Cache openapi-generator-cli docker image
         id: cache-openapi-generator-cli-docker-image
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ env.OPENAPI_GENERATOR_CLI_DOCKER_PATH }}
-          key: ${{ env.OPENAPI_GENERATOR_CLI_DOCKER_KEY_PREFIX }}${{ hashFiles('./infra/local/docker/openapi-generator/Dockerfile') }}
+          key: docker-openapi-generator-cli-${{ hashFiles('./infra/local/docker/openapi-generator/Dockerfile') }}
 
       - name: Build openapi-generator-cli image
         if: steps.cache-openapi-generator-cli-docker-image.outputs.cache-hit != 'true'
-        run: mise run build:openapi-generator
+        run: |
+          mise run build:openapi-generator
+          mkdir -p "${OPENAPI_GENERATOR_CLI_DOCKER_PATH}"
 
       - name: Cache mysql docker image
         id: cache-mysql-docker-image
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ env.MYSQL_DOCKER_PATH }}
-          key: ${{ env.MYSQL_DOCKER_KEY_PREFIX }}${{ hashFiles('./infra/local/docker/mysql/Dockerfile', './infra/local/docker/mysql/my.cnf', './infra/local/docker/mysql/init/*') }}
+          key: docker-mysql-${{ hashFiles('./infra/local/docker/mysql/Dockerfile', './infra/local/docker/mysql/my.cnf', './infra/local/docker/mysql/init/*') }}
 
       - name: Build mysql image
         if: steps.cache-mysql-docker-image.outputs.cache-hit != 'true'
-        run: mise run build:mysql
+        run: |
+          mise run build:mysql
+          mkdir -p "${MYSQL_DOCKER_PATH}"
 
       - name: Copy .env
         run: cp src/server/.env.example src/server/.env
@@ -88,7 +112,7 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ env.VENDOR_PATH }}
-          key: ${{ steps.define-variables.outputs.VENDOR_KEY }}
+          key: composer-${{ hashFiles('./src/server/composer.*') }}
 
       - name: Composer install
         run: mise run api:composer:install
@@ -134,7 +158,7 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ env.VENDOR_PATH }}
-          key: ${{ needs.setup.outputs.vendor-key }}
+          key: composer-${{ hashFiles('./src/server/composer.*') }}
 
       - name: Check Layer
         run: mise run api:arkitect
@@ -167,7 +191,7 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ env.VENDOR_PATH }}
-          key: ${{ needs.setup.outputs.vendor-key }}
+          key: composer-${{ hashFiles('./src/server/composer.*') }}
 
       - name: Run ecs
         run: mise run api:ecs
@@ -200,21 +224,30 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ env.VENDOR_PATH }}
-          key: ${{ needs.setup.outputs.vendor-key }}
+          key: composer-${{ hashFiles('./src/server/composer.*') }}
 
       - name: Run PHPStan
         run: mise run api:phpstan
 
   phpunit:
     needs: setup
-    name: PHPUnit
+    name: PHPUnit (${{ matrix.suite }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - suite: unit
+            db: false
+          - suite: integration
+            db: true
+          - suite: feature
+            db: true
     steps:
       - name: Checkout the code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.ref }}
-          submodules: true
 
       - name: Setup mise
         uses: ./.github/actions/setup-mise
@@ -227,9 +260,15 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Container
+        if: ${{ !matrix.db }}
+        run: mise run up
+
+      - name: Run Container with DB
+        if: ${{ matrix.db }}
         run: mise run up:test
 
       - name: Wait for MySQL
+        if: ${{ matrix.db }}
         run: |
           for i in $(seq 1 30); do
             if docker compose exec -T mysql mysqladmin ping -h 127.0.0.1 --silent 2>/dev/null; then
@@ -247,13 +286,14 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ env.VENDOR_PATH }}
-          key: ${{ needs.setup.outputs.vendor-key }}
+          key: composer-${{ hashFiles('./src/server/composer.*') }}
 
       - name: Setup env
         run: mise run setup:env
 
       - name: Run migration
+        if: ${{ matrix.db }}
         run: mise run migrate:local --auto-approve
 
       - name: Run PHPUnit
-        run: mise run api:test:all
+        run: mise run api:test:${{ matrix.suite }}

--- a/.github/workflows/viewer-qa.yaml
+++ b/.github/workflows/viewer-qa.yaml
@@ -4,9 +4,36 @@ on:
   schedule:
     - cron: "0 0 * * *"
   pull_request:
+    # main, stg 向け PR は release-qa 経由で必ず全実行する
+    branches-ignore:
+      - main
+      - stg
+    paths:
+      - "src/viewer/**"
+      - "src/contracts/**"
+      - "src/package.json"
+      - "src/pnpm-lock.yaml"
+      - "src/pnpm-workspace.yaml"
+      - "src/biome.json"
+      - "mise.toml"
+      - "mise.ci.toml"
+      - ".github/workflows/viewer-qa.yaml"
+      - ".github/actions/**"
   push:
     branches:
       - dev
+    paths:
+      - "src/viewer/**"
+      - "src/contracts/**"
+      - "src/package.json"
+      - "src/pnpm-lock.yaml"
+      - "src/pnpm-workspace.yaml"
+      - "src/biome.json"
+      - "mise.toml"
+      - "mise.ci.toml"
+      - ".github/workflows/viewer-qa.yaml"
+      - ".github/actions/**"
+  workflow_call:
 
 env:
   MISE_ENV: ci

--- a/mise.ci.toml
+++ b/mise.ci.toml
@@ -2,14 +2,6 @@
 SERVER_IMAGE = "ghcr.io/sayuprc/isekai-observatory-api:{{vars.server_tag}}"
 OPENAPI_IMAGE = "ghcr.io/sayuprc/openapi-generator:{{vars.openapi_tag}}"
 MYSQL_IMAGE = "ghcr.io/sayuprc/isekai-observatory-mysql:{{vars.mysql_tag}}"
-SERVER_DOCKER_PATH = "/tmp/cache/docker/server"
-SERVER_DOCKER_KEY_PREFIX = "docker-server-"
-VENDOR_PATH = "./src/server/vendor"
-VENDOR_KEY_PREFIX = "composer-"
-OPENAPI_GENERATOR_CLI_DOCKER_PATH = "/tmp/cache/docker/openapi-generator-cli"
-OPENAPI_GENERATOR_CLI_DOCKER_KEY_PREFIX = "docker-openapi-generator-cli-"
-MYSQL_DOCKER_PATH = "/tmp/cache/docker/mysql"
-MYSQL_DOCKER_KEY_PREFIX = "docker-mysql-"
 
 [tasks."build:php"]
 description = "CI 向けに PHP イメージをビルドして GHCR にプッシュする"
@@ -22,7 +14,6 @@ docker build -t $SERVER_IMAGE ./infra/local/docker/php \
   --build-arg USERNAME=$(id -u -n) \
   --build-arg GROUPNAME=$(id -g -n)
 docker push $SERVER_IMAGE
-mkdir -p $SERVER_DOCKER_PATH
 '''
 
 [tasks."build:openapi-generator"]
@@ -35,7 +26,6 @@ docker build -t $OPENAPI_IMAGE ./infra/local/docker/openapi-generator \
   --build-arg USERNAME=$(id -u -n) \
   --build-arg GROUPNAME=$(id -g -n)
 docker push $OPENAPI_IMAGE
-mkdir -p $OPENAPI_GENERATOR_CLI_DOCKER_PATH
 '''
 
 [tasks."build:mysql"]
@@ -44,7 +34,6 @@ run = '''
 docker build -t $MYSQL_IMAGE ./infra/local/docker/mysql \
   --build-arg TAG={{vars.mysql_tag}}
 docker push $MYSQL_IMAGE
-mkdir -p $MYSQL_DOCKER_PATH
 '''
 
 [tasks.up]


### PR DESCRIPTION
## 概要

- 各 QA workflow の pull_request と dev への push に paths フィルタを追加し、変更に関係する CI のみ実行する
- main, stg 向け PR は release-qa 経由で常にすべての QA を実行する
- mise.ci.toml のうちテンプレート変数を使わない env を server-qa.yaml へ移動し、キャッシュキーは直書きに変更
- PHPUnit を Unit/Integration/Feature の 3 ジョブに分割し、Unit は MySQL なしで実行する
- 存在しない submodule の checkout 指定を削除
