### PR TITLE
エラーハンドリング系 exec-plan 2 件を完了へ移動

### DIFF
--- a/docs/exec-plans/completed/20260731-error-handling-result-to-exceptions.md
+++ b/docs/exec-plans/completed/20260731-error-handling-result-to-exceptions.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-in-progress
+completed
 
 ## Background
 
@@ -81,6 +81,8 @@ Result を server 全層から撤去し例外ベースへ移行する。
 
 ## Validation
 
+- Stage 2 本体は PR #910、レビュー指摘対応は PR #912 でマージ済み。検証集約 (Field/Fields) は
+  その後 ADR-0014 (PR #913) で契約境界への集約に置き換えられた
 - `mise run api:ecs` / `api:phpstan` (level 10) / `api:arkitect` / `api:test` (603 tests, skip 3 は既存) すべて green
 - `src/server` から `ResultType\` への参照 0 件、composer から `sayuprc/result-type` 除去済み
 - Stage 1: `contract:format:check` / `contract:test` / `contract:compile:*`、admin lint/style/format/build、viewer format/lint/build すべて green (PR #909 でマージ済み)

--- a/docs/exec-plans/completed/20260801-input-validation-to-contract-boundary.md
+++ b/docs/exec-plans/completed/20260801-input-validation-to-contract-boundary.md
@@ -6,7 +6,7 @@ ADR-0014: 入力形式検証の契約境界への集約 (エラーハンドリ�
 
 ## Status
 
-in-progress
+completed
 
 ## Background
 
@@ -111,6 +111,7 @@ VO 固有の形式ルールは実質 TrackTitle / MediumName の非空 (API 経�
 
 ## Validation
 
+- PR #913 をレビュー・マージ済み (2026-08-01、refactor/api-handling へ)
 - CLI (2026-08-01): media:youtube-channel:remove に不正 ID を渡し、
   「YouTube チャンネルIDの形式が不正です」表示 + exit 1 を確認
 - server (2026-08-01): api:ecs / api:phpstan / api:arkitect / api:test (603 件) 全通過


### PR DESCRIPTION
## 概要

マージ済みの実装に対応する exec-plan の完了処理
Status を completed に更新し docs/exec-plans/completed/ へ移動する

## やったこと

- 20260801-input-validation-to-contract-boundary (ADR-0014): PR #913 のマージを Validation に記録して完了へ
- 20260731-error-handling-result-to-exceptions (ADR-0013 Stage 2): PR #910 / #912 でマージ済みの閉じ忘れ。検証集約がその後 ADR-0014 で置き換えられた旨を脚注して完了へ

## やってないこと

- 特になし (docs のみ、コード変更なし)

## 関連

- #910 #912 #913

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AoXngg7TdfSCp3vZNZ7E9n