### PR TITLE
モバイルナビをハンバーガーからボトムナビに置き換える

### DIFF
--- a/src/viewer/src/components/common/BottomNav.astro
+++ b/src/viewer/src/components/common/BottomNav.astro
@@ -1,0 +1,33 @@
+---
+import { navLinks } from '../../shared/nav';
+import { isActivePath } from '../../shared/routing';
+
+interface Props {
+  currentPath: string;
+}
+
+const { currentPath } = Astro.props;
+
+// navLinks の href に対応するアイコン。未提供リンクの分も先に定義しておく
+const iconPaths: Record<string, string[]> = {
+  '/songs': ['M9 18V5l12-2v13', 'M6 21a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z', 'M18 19a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z'],
+  '/releases': ['M12 21a9 9 0 1 0 0-18 9 9 0 0 0 0 18Z', 'M12 14.5a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5Z'],
+  '/media': ['M3 7a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z', 'M10 9.5l5 2.5-5 2.5z'],
+  '/profile': ['M12 12a4 4 0 1 0 0-8 4 4 0 0 0 0 8Z', 'M4 21c0-4 3.5-6.5 8-6.5s8 2.5 8 6.5'],
+};
+---
+
+<nav class="bottom-nav" aria-label="モバイルナビゲーション">
+  {
+    navLinks.map(link => (
+      <a href={link.href} class={isActivePath(currentPath, link.href) ? 'active' : undefined}>
+        <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          {(iconPaths[link.href] ?? []).map(d => (
+            <path d={d} />
+          ))}
+        </svg>
+        {link.label}
+      </a>
+    ))
+  }
+</nav>

--- a/src/viewer/src/components/common/BottomNav.astro
+++ b/src/viewer/src/components/common/BottomNav.astro
@@ -8,12 +8,10 @@ interface Props {
 
 const { currentPath } = Astro.props;
 
-// navLinks の href に対応するアイコン。未提供リンクの分も先に定義しておく
+// navLinks の href に対応するアイコン
 const iconPaths: Record<string, string[]> = {
   '/songs': ['M9 18V5l12-2v13', 'M6 21a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z', 'M18 19a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z'],
   '/releases': ['M12 21a9 9 0 1 0 0-18 9 9 0 0 0 0 18Z', 'M12 14.5a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5Z'],
-  '/media': ['M3 7a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z', 'M10 9.5l5 2.5-5 2.5z'],
-  '/profile': ['M12 12a4 4 0 1 0 0-8 4 4 0 0 0 0 8Z', 'M4 21c0-4 3.5-6.5 8-6.5s8 2.5 8 6.5'],
 };
 ---
 

--- a/src/viewer/src/components/common/Header.astro
+++ b/src/viewer/src/components/common/Header.astro
@@ -24,12 +24,7 @@ const { currentPath } = Astro.props;
       </div>
     </a>
     <EnvironmentBadge />
-    <button class="nav-toggle" type="button" aria-expanded="false" aria-label="メニューを開く" data-nav-trigger>
-      <span></span>
-      <span></span>
-      <span></span>
-    </button>
-    <div class="nav-links" data-nav-links>
+    <div class="nav-links">
       {
         navLinks.map(link => (
           <a href={link.href} class={isActivePath(currentPath, link.href) ? 'active' : undefined}>

--- a/src/viewer/src/layouts/Layout.astro
+++ b/src/viewer/src/layouts/Layout.astro
@@ -1,4 +1,5 @@
 ---
+import BottomNav from '../components/common/BottomNav.astro';
 import Footer from '../components/common/Footer.astro';
 import Header from '../components/common/Header.astro';
 import { DetailDrawer } from '../components/viewer/DetailDrawer';
@@ -58,6 +59,7 @@ const noindex = import.meta.env.SITE_NOINDEX === 'true';
       <slot />
     </main>
     <Footer />
+    <BottomNav currentPath={Astro.url.pathname} />
     <DetailDrawer client:load />
     <script is:inline>
       (() => {
@@ -122,50 +124,10 @@ const noindex = import.meta.env.SITE_NOINDEX === 'true';
           picker.dataset.themeReady = 'true';
         };
 
-        const initMobileNav = () => {
-          const trigger = document.querySelector('[data-nav-trigger]');
-          const links = document.querySelector('[data-nav-links]');
-          if (!(trigger instanceof HTMLButtonElement) || !(links instanceof HTMLElement) || trigger.dataset.navReady === 'true') {
-            return;
-          }
-
-          const close = () => {
-            trigger.setAttribute('aria-expanded', 'false');
-            document.documentElement.removeAttribute('data-nav-open');
-          };
-
-          trigger.addEventListener('click', () => {
-            const open = trigger.getAttribute('aria-expanded') === 'true';
-            if (open) {
-              close();
-            } else {
-              trigger.setAttribute('aria-expanded', 'true');
-              document.documentElement.setAttribute('data-nav-open', 'true');
-            }
-          });
-
-          links.addEventListener('click', (event) => {
-            const target = event.target;
-            if (target instanceof Element && target.closest('a[href]')) {
-              close();
-            }
-          });
-
-          window.addEventListener('resize', () => {
-            if (window.innerWidth > 720) close();
-          });
-
-          trigger.dataset.navReady = 'true';
-        };
-
         if (document.readyState === 'loading') {
-          document.addEventListener('DOMContentLoaded', () => {
-            initThemeControls();
-            initMobileNav();
-          }, { once: true });
+          document.addEventListener('DOMContentLoaded', initThemeControls, { once: true });
         } else {
           initThemeControls();
-          initMobileNav();
         }
       })();
     </script>

--- a/src/viewer/src/pages/index.astro
+++ b/src/viewer/src/pages/index.astro
@@ -47,16 +47,16 @@ const observationYears = (() => {
           <span class="hero-ledger-leader"></span>
           <span class="hero-ledger-value">2019.12.09 <small>— {observationYears}TH YEAR</small></span>
         </div>
-        <div class="hero-ledger-row">
+        <a class="hero-ledger-row hero-ledger-link" href="/songs">
           <span class="hero-ledger-label">Songs</span>
           <span class="hero-ledger-leader"></span>
           <span class="hero-ledger-value">{siteStats.songCount}</span>
-        </div>
-        <div class="hero-ledger-row">
+        </a>
+        <a class="hero-ledger-row hero-ledger-link" href="/releases">
           <span class="hero-ledger-label">Releases</span>
           <span class="hero-ledger-leader"></span>
           <span class="hero-ledger-value">{siteStats.releaseCount}</span>
-        </div>
+        </a>
       </div>
     </div>
   </section>

--- a/src/viewer/src/shared/nav.ts
+++ b/src/viewer/src/shared/nav.ts
@@ -1,5 +1,5 @@
+// Home はブランドロゴから遷移できるためナビには含めない
 export const navLinks = [
-  { href: '/', label: 'Home', jp: '玄関' },
   { href: '/songs', label: 'Songs', jp: '楽曲' },
   { href: '/releases', label: 'Releases', jp: 'リリース' },
   // { href: '/media', label: 'Media', jp: 'メディア' },

--- a/src/viewer/src/styles/viewer.css
+++ b/src/viewer/src/styles/viewer.css
@@ -374,6 +374,45 @@ a {
   color: var(--accent-strong) !important;
 }
 
+/* モバイル用のボトムナビ。720px 以下でのみ表示する */
+
+.bottom-nav {
+  position: fixed;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 60;
+  display: none;
+  background: color-mix(in oklab, var(--bg) 92%, transparent);
+  border-top: 1px solid var(--line);
+  backdrop-filter: blur(20px) saturate(140%);
+}
+
+.bottom-nav svg {
+  color: var(--bottom-nav-icon, var(--fg-muted));
+  transition: color 0.2s ease;
+}
+
+.bottom-nav a {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 4px;
+  align-items: center;
+  padding: 10px 0 calc(12px + env(safe-area-inset-bottom));
+  font-family: "Noto Serif JP", serif;
+  font-size: 10px;
+  color: var(--fg-muted);
+  letter-spacing: 0.08em;
+  transition: color 0.2s ease;
+}
+
+.bottom-nav a.active {
+  --bottom-nav-icon: var(--accent);
+
+  color: var(--fg);
+}
+
 .nav-links {
   display: flex;
   gap: 4px;
@@ -414,30 +453,6 @@ a {
   display: flex;
   gap: 8px;
   align-items: center;
-}
-
-.nav-toggle {
-  display: none;
-  flex-direction: column;
-  gap: 4px;
-  align-items: center;
-  justify-content: center;
-  width: 40px;
-  height: 40px;
-  padding: 0;
-  color: var(--fg);
-  background: transparent;
-  border: 1px solid var(--line);
-  border-radius: 50%;
-}
-
-.nav-toggle span {
-  width: 16px;
-  height: 1px;
-  background: currentcolor;
-  transition:
-    transform 0.2s ease,
-    opacity 0.2s ease;
 }
 
 .icon-btn {
@@ -1500,6 +1515,31 @@ image-slot:hover {
   font-size: 10px;
   color: var(--fg-faint);
   letter-spacing: 0.12em;
+}
+
+.hero-ledger-link {
+  text-decoration: none;
+}
+
+/* タップ可能であることをホバー無しでも示すため矢印を常時表示する */
+
+.hero-ledger-link .hero-ledger-value::after {
+  display: inline-block;
+  margin-left: 10px;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 12px;
+  color: var(--fg-muted);
+  content: "→";
+  transition: color 0.2s ease, transform 0.2s ease;
+}
+
+.hero-ledger-link:hover .hero-ledger-label {
+  color: var(--accent-2);
+}
+
+.hero-ledger-link:hover .hero-ledger-value::after {
+  color: var(--accent-2);
+  transform: translateX(3px);
 }
 
 .hero-symbol {
@@ -2704,50 +2744,24 @@ image-slot:hover {
 }
 
 @media (width <= 720px) {
-
-  .nav-inner {
-    display: grid;
-    grid-template-columns: 1fr auto auto;
-    gap: 12px;
-    align-items: center;
-  }
-
-  .nav-toggle {
-    display: inline-flex;
-  }
+  /* リンクはボトムナビへ移動するためヘッダーからは消す */
 
   .nav-links {
     display: none;
-    flex-direction: column;
-    grid-column: 1 / -1;
-    gap: 0;
-    padding-top: 8px;
-    margin-left: 0;
-    border-top: 1px solid var(--line);
   }
 
-  .nav-links a {
-    padding: 12px 0;
+  .nav-utils {
+    margin-left: auto;
   }
 
-  .nav-links a.active::after {
-    display: none;
-  }
-
-  html[data-nav-open="true"] .nav-links {
+  .bottom-nav {
     display: flex;
   }
 
-  html[data-nav-open="true"] .nav-toggle span:nth-child(1) {
-    transform: translateY(5px) rotate(45deg);
-  }
+  /* ボトムナビでフッター末尾が隠れないようにする */
 
-  html[data-nav-open="true"] .nav-toggle span:nth-child(2) {
-    opacity: 0;
-  }
-
-  html[data-nav-open="true"] .nav-toggle span:nth-child(3) {
-    transform: translateY(-5px) rotate(-45deg);
+  body {
+    padding-bottom: calc(64px + env(safe-area-inset-bottom));
   }
 
   .theme-trigger {


### PR DESCRIPTION
## 概要

スマホ表示でヘッダーがハンバーガーメニューになり、楽曲やリリースの一覧に辿り着くまでに 1 タップ余計にかかっていた
ハンバーガーを廃止して画面下部固定のボトムナビに置き換え、主要ページへ常に 1 タップで届くようにする

## やったこと

- `BottomNav.astro` を追加し、720px 以下でヘッダーの代わりに画面下部固定のタブバー (アイコン + ラベル) を表示
- ハンバーガーボタンと開閉用スクリプト・CSS (`nav-toggle` / `data-nav-open` 一式) を削除
- Home はブランドロゴから遷移できるため `navLinks` から削除 (デスクトップのヘッダーリンクからも消える)
- Hero の Songs / Releases 統計行を各一覧へのリンクに変更し、タップ可能と分かるよう矢印を常時表示
- ボトムナビは z-index 60 とし、DetailDrawer のオーバーレイ (100) が上に被さる関係を維持
- iOS のホームバー対策として `env(safe-area-inset-bottom)` を考慮

## やってないこと

- Event / Media / Profile タブの追加 (`navLinks` にリンクを足し `BottomNav.astro` の `iconPaths` にアイコンを追加すれば反映される)
- 検討時に使った比較プロトタイプの同梱 (ローカルのみで破棄予定)

## 関連

- 特になし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014wdJoam3xrArKH5d21hQ1g