### PR TITLE
viewer の表記を日本語に統一し Hero にサイト説明を表示する

### DIFF
--- a/src/viewer/src/components/common/Footer.astro
+++ b/src/viewer/src/components/common/Footer.astro
@@ -19,11 +19,11 @@ import LightLogo from '../../assets/logo-light.svg';
       <div class="footer-col">
         <h4>Archive</h4>
         <ul>
-          <li><a href="/songs">Songs</a></li>
-          <li><a href="/releases">Releases</a></li>
+          <li><a href="/songs">楽曲</a></li>
+          <li><a href="/releases">リリース</a></li>
           {/*
-          <li><a href="/media">Media</a></li>
-          <li><a href="/profile">Profile</a></li>
+          <li><a href="/media">メディア</a></li>
+          <li><a href="/profile">人物</a></li>
           */}
         </ul>
       </div>

--- a/src/viewer/src/pages/index.astro
+++ b/src/viewer/src/pages/index.astro
@@ -40,20 +40,20 @@ const observationYears = (() => {
   <section class="hero-data">
     <div class="shell">
       <div class="hero-mark hero-mark-data">ヰ世界観測所</div>
-      <div class="hero-en hero-en-whisper">Isekai Observatory</div>
+      <div class="hero-tagline">ヰ世界情緒の非公式ファンサイト</div>
       <div class="hero-ledger">
         <div class="hero-ledger-row">
-          <span class="hero-ledger-label">Observation Since</span>
+          <span class="hero-ledger-label">観測開始</span>
           <span class="hero-ledger-leader"></span>
-          <span class="hero-ledger-value">2019.12.09 <small>— {observationYears}TH YEAR</small></span>
+          <span class="hero-ledger-value">2019.12.09 <small>— {observationYears}年</small></span>
         </div>
         <a class="hero-ledger-row hero-ledger-link" href="/songs">
-          <span class="hero-ledger-label">Songs</span>
+          <span class="hero-ledger-label">楽曲</span>
           <span class="hero-ledger-leader"></span>
           <span class="hero-ledger-value">{siteStats.songCount}</span>
         </a>
         <a class="hero-ledger-row hero-ledger-link" href="/releases">
-          <span class="hero-ledger-label">Releases</span>
+          <span class="hero-ledger-label">リリース</span>
           <span class="hero-ledger-leader"></span>
           <span class="hero-ledger-value">{siteStats.releaseCount}</span>
         </a>

--- a/src/viewer/src/shared/nav.ts
+++ b/src/viewer/src/shared/nav.ts
@@ -1,7 +1,7 @@
 // Home はブランドロゴから遷移できるためナビには含めない
 export const navLinks = [
-  { href: '/songs', label: 'Songs', jp: '楽曲' },
-  { href: '/releases', label: 'Releases', jp: 'リリース' },
-  // { href: '/media', label: 'Media', jp: 'メディア' },
-  // { href: '/profile', label: 'Profile', jp: '人物' },
+  { href: '/songs', label: '楽曲' },
+  { href: '/releases', label: 'リリース' },
+  // { href: '/media', label: 'メディア' },
+  // { href: '/profile', label: '人物' },
 ] as const;

--- a/src/viewer/src/styles/viewer.css
+++ b/src/viewer/src/styles/viewer.css
@@ -1465,10 +1465,11 @@ image-slot:hover {
   letter-spacing: 0.14em;
 }
 
-.hero-en.hero-en-whisper {
+.hero-tagline {
   margin-top: 24px;
-  font-size: 20px;
-  color: var(--fg-faint);
+  font-size: 15px;
+  color: var(--fg-muted);
+  letter-spacing: 0.12em;
 }
 
 .hero-ledger {
@@ -1489,10 +1490,9 @@ image-slot:hover {
 }
 
 .hero-ledger-label {
-  font-family: "JetBrains Mono", monospace;
-  font-size: 11px;
+  font-family: "Noto Serif JP", serif;
+  font-size: 12px;
   color: var(--fg-muted);
-  text-transform: uppercase;
   letter-spacing: 0.16em;
 }
 
@@ -1511,8 +1511,8 @@ image-slot:hover {
 }
 
 .hero-ledger-value small {
-  font-family: "JetBrains Mono", monospace;
-  font-size: 10px;
+  font-family: "Noto Serif JP", serif;
+  font-size: 11px;
   color: var(--fg-faint);
   letter-spacing: 0.12em;
 }


### PR DESCRIPTION
## 概要

viewer の英語/日本語の使い分けを整理し、ユーザーが読む・クリックする語をすべて日本語に統一する
あわせて Hero のヘッダーと重複していた英語表記を、これまで meta description にしかなかったサイト説明に置き換える

## やったこと

- ヘッダー・ボトムナビ・フッターのナビリンクを「楽曲」「リリース」に変更 (コメントアウト中の Media / Profile も表記を揃えた)
- Hero レジャーのラベルを「観測開始」「楽曲」「リリース」に変更し、書体を JetBrains Mono から Noto Serif JP に切り替え
- 「6TH YEAR」の注記を経過年数として正確な「6年」表記に変更
- Hero の "Isekai Observatory" ウィスパーを「ヰ世界情緒の非公式ファンサイト」(hero-tagline) に置き換え

## やってないこと

- カウント表記 (`3 media` 等)・フッター列見出し (Archive / External / About)・ヘッダーの "Isekai Observatory" の日本語化 (装飾的なメタ表記として意図的に英語を残した)
- `<title>` の変更 (日本語検索向けに従来どおり「楽曲」「リリース」を維持)

## 関連

- 特になし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TQNZn7XKjbbnCeYgvUmotc