### PR TITLE
sitemap と robots.txt から fragments を除外する

### DIFF
--- a/src/viewer/astro.config.mjs
+++ b/src/viewer/astro.config.mjs
@@ -15,5 +15,11 @@ export default defineConfig({
     port: port,
     allowedHosts: ['local.isekaijoucho.fan'],
   },
-  integrations: [solidJs(), sitemap()],
+  integrations: [
+    solidJs(),
+    sitemap({
+      // fragments はドロワー用の部分 HTML なのでクロール対象から外す
+      filter: page => !page.includes('/fragments/'),
+    }),
+  ],
 });

--- a/src/viewer/src/pages/robots.txt.ts
+++ b/src/viewer/src/pages/robots.txt.ts
@@ -5,7 +5,7 @@ const noindex = import.meta.env.SITE_NOINDEX === 'true';
 export const GET: APIRoute = ({ site }) => {
   const body = noindex
     ? ['User-agent: *', 'Disallow: /', ''].join('\n')
-    : ['User-agent: *', 'Disallow:', '', `Sitemap: ${new URL('sitemap-index.xml', site)}`, ''].join('\n');
+    : ['User-agent: *', 'Disallow: /fragments/', '', `Sitemap: ${new URL('sitemap-index.xml', site)}`, ''].join('\n');
 
   return new Response(body, {
     headers: { 'Content-Type': 'text/plain; charset=utf-8' },


### PR DESCRIPTION
## 概要

DetailDrawer 用の部分 HTML (`/fragments/`、1511 件) が sitemap に含まれ、クロール・インデックス対象として申告されていたため除外する
fragments は doctype や title を持たない裸の断片で、詳細ページと重複コンテンツになる恐れがあった

## やったこと

- `astro.config.mjs` の sitemap integration に `filter` を追加し `/fragments/` を除外 (sitemap は 3027 → 1516 URL)
- `robots.txt.ts` の通常時出力を `Disallow: /fragments/` に変更

ビルド出力で sitemap-0.xml に fragments が 0 件になること、robots.txt に `Disallow: /fragments/` が出力されることを確認済み

## やってないこと

- 既にインデックス済みの fragment ページへの noindex 付与 (partial HTML のため meta を持てず、必要なら配信側ヘッダーで対応)

## 関連

- closes #922

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TQNZn7XKjbbnCeYgvUmotc