### PR TITLE
Hero の経過年数表示を削除する

### DIFF
--- a/src/viewer/src/pages/index.astro
+++ b/src/viewer/src/pages/index.astro
@@ -16,24 +16,6 @@ const songs = (await songContentRepository.all());
 const latestSong = songs[songs.length - 1] ?? null;
 
 const siteStats = await siteStatsRepository.get();
-
-const observationYears = (() => {
-  const OBSERVATION_START = new Date('2019-12-09');
-
-  const now = new Date();
-
-  let years = now.getFullYear() - OBSERVATION_START.getFullYear();
-
-  const beforeAnniversary = now.getMonth() < OBSERVATION_START.getMonth()
-    || (now.getMonth() === OBSERVATION_START.getMonth() && now.getDate() < OBSERVATION_START.getDate());
-
-  if (beforeAnniversary) {
-    years -= 1;
-  }
-
-  return years;
-})();
-
 ---
 
 <Layout pageTitle="">
@@ -45,7 +27,7 @@ const observationYears = (() => {
         <div class="hero-ledger-row">
           <span class="hero-ledger-label">観測開始</span>
           <span class="hero-ledger-leader"></span>
-          <span class="hero-ledger-value">2019.12.09 <small>— {observationYears}年</small></span>
+          <span class="hero-ledger-value">2019.12.09</span>
         </div>
         <a class="hero-ledger-row hero-ledger-link" href="/songs">
           <span class="hero-ledger-label">楽曲</span>

--- a/src/viewer/src/styles/viewer.css
+++ b/src/viewer/src/styles/viewer.css
@@ -1510,13 +1510,6 @@ image-slot:hover {
   letter-spacing: 0.04em;
 }
 
-.hero-ledger-value small {
-  font-family: "Noto Serif JP", serif;
-  font-size: 11px;
-  color: var(--fg-faint);
-  letter-spacing: 0.12em;
-}
-
 .hero-ledger-link {
   text-decoration: none;
 }


### PR DESCRIPTION
## 概要

Hero レジャーの「観測開始 2019.12.09 — 6年」の経過年数がビルド時刻依存で、次の問題を抱えていたため表示ごと削除する

- date-only 文字列 (`new Date('2019-12-09')`) は UTC としてパースされる一方、比較はローカル getter のため、UTC より西の TZ でビルドすると基準日が 12/8 にずれて年 1 日だけ 1 年多く表示される
- 「今日」がビルドマシンの TZ 基準で、JST の閲覧者と周年境界で最大 9 時間ずれる

開始日の表示だけで情報として十分であり、サイト唯一の現在時刻依存コードを消すことを優先した

## やったこと

- `observationYears` の計算と `— N年` の表示を削除 (レジャーは「観測開始 …… 2019.12.09」のみに)
- 未使用になった `.hero-ledger-value small` の CSS を削除

## やってないこと

- 経過年数の代替表示 (閲覧時のクライアント計算等)。必要になったときに JST 明示の実装で追加する

## 関連

- closes #926

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TQNZn7XKjbbnCeYgvUmotc