### PR TITLE
テーマ機構を整理して既定パレットをアネモネ I にする

### DIFF
--- a/src/viewer/astro.config.mjs
+++ b/src/viewer/astro.config.mjs
@@ -22,4 +22,10 @@ export default defineConfig({
       filter: page => !page.includes('/fragments/'),
     }),
   ],
+  vite: {
+    build: {
+      // 小さなスクリプトも全ページへのインライン展開ではなくハッシュ付きファイルとしてキャッシュさせる
+      assetsInlineLimit: 0,
+    },
+  },
 });

--- a/src/viewer/src/components/common/Header.astro
+++ b/src/viewer/src/components/common/Header.astro
@@ -1,7 +1,7 @@
 ---
 import { navLinks } from '../../shared/nav';
 import { isActivePath } from '../../shared/routing';
-import { THEMES } from '../../shared/themes';
+import { DEFAULT_PALETTE, THEMES, themeByValue, themeLabel, themeSubLabel } from '../../shared/themes';
 import EnvironmentBadge from './EnvironmentBadge.astro';
 
 interface Props {
@@ -9,6 +9,9 @@ interface Props {
 }
 
 const { currentPath } = Astro.props;
+
+// SSR は既定パレットのテーマで描画し、保存パレットの反映はスクリプトが行う
+const defaultTheme = themeByValue(DEFAULT_PALETTE);
 ---
 
 <nav class="site-nav">
@@ -33,38 +36,36 @@ const { currentPath } = Astro.props;
     </div>
     <div class="nav-utils">
       <div class="theme-picker" data-theme-picker>
-        <button class="theme-trigger" type="button" title="衣装テーマを選ぶ" aria-haspopup="true" aria-expanded="false" data-theme-trigger>
+        <button class="theme-trigger" type="button" title="衣装テーマを選ぶ" aria-haspopup="dialog" aria-expanded="false" data-theme-trigger>
           <svg class="hanger-icon" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
             <path d="M12 8.5C12 7 13 6 14 6C15 6 15.8 6.7 15.8 7.6" />
             <circle cx="12" cy="9.2" r="0.9" />
             <path d="M12 10.1L3.5 16.2C3 16.6 3.3 17.5 4 17.5H20C20.7 17.5 21 16.6 20.5 16.2L12 10.1Z" />
           </svg>
           <span class="label">
-            <span class="jp" data-theme-current-jp>{THEMES[0].costume ?? THEMES[0].jp}</span>
-            <span class="en" data-theme-current-en>{THEMES[0].costume ? `${THEMES[0].jp} · ${THEMES[0].en}` : THEMES[0].en}</span>
+            <span class="jp" data-theme-current-jp>{themeLabel(defaultTheme)}</span>
+            <span class="en" data-theme-current-en>{themeSubLabel(defaultTheme)}</span>
           </span>
           <span class="caret">▾</span>
         </button>
         <div class="theme-pop-overlay" hidden data-theme-overlay></div>
-        <div class="theme-pop" role="menu" hidden data-theme-pop>
+        <div class="theme-pop" role="dialog" aria-labelledby="theme-pop-title" hidden data-theme-pop>
           <div class="theme-pop-head">
-            <span class="theme-pop-title">カラーテーマ</span>
+            <span class="theme-pop-title" id="theme-pop-title">カラーテーマ</span>
             <span class="theme-pop-title-en">Color Themes</span>
           </div>
           <div class="theme-grid">
             {
               THEMES.map(theme => (
                 <button
-                  class="theme-opt"
+                  class:list={['theme-opt', theme.value === DEFAULT_PALETTE && 'active']}
                   type="button"
+                  aria-pressed={theme.value === DEFAULT_PALETTE ? 'true' : 'false'}
                   data-palette-option={theme.value}
-                  data-jp={theme.jp}
-                  data-en={theme.en}
-                  data-costume={theme.costume ?? ''}
                 >
                   <span class="meta">
-                    <span class="name">{theme.costume ?? theme.jp}</span>
-                    <span class="sub">{theme.costume ? `${theme.jp} · ${theme.en}` : theme.en}</span>
+                    <span class="name">{themeLabel(theme)}</span>
+                    <span class="sub">{themeSubLabel(theme)}</span>
                   </span>
                   <span class="check">●</span>
                 </button>
@@ -76,3 +77,100 @@ const { currentPath } = Astro.props;
     </div>
   </div>
 </nav>
+
+<script>
+  import { DEFAULT_PALETTE, PALETTE_STORAGE_KEY, themeByValue, themeLabel, themeSubLabel } from '../../shared/themes';
+
+  const initThemePicker = () => {
+    const root = document.documentElement;
+    const picker = document.querySelector<HTMLElement>('[data-theme-picker]');
+
+    if (picker === null || picker.dataset.themeReady === 'true') {
+      return;
+    }
+
+    const trigger = picker.querySelector<HTMLButtonElement>('[data-theme-trigger]');
+    const overlay = picker.querySelector<HTMLElement>('[data-theme-overlay]');
+    const pop = picker.querySelector<HTMLElement>('[data-theme-pop]');
+    const currentLabel = picker.querySelector<HTMLElement>('[data-theme-current-jp]');
+    const currentSubLabel = picker.querySelector<HTMLElement>('[data-theme-current-en]');
+    const options = [...picker.querySelectorAll<HTMLButtonElement>('[data-palette-option]')];
+
+    if (trigger === null || overlay === null || pop === null || currentLabel === null || currentSubLabel === null || options.length === 0) {
+      return;
+    }
+
+    const setOpen = (open: boolean) => {
+      trigger.setAttribute('aria-expanded', String(open));
+      overlay.hidden = !open;
+      pop.hidden = !open;
+
+      if (open) {
+        (options.find(option => option.classList.contains('active')) ?? options[0]).focus();
+      }
+    };
+
+    const close = (restoreFocus: boolean) => {
+      setOpen(false);
+
+      if (restoreFocus) {
+        trigger.focus();
+      }
+    };
+
+    const applyPalette = (value: string) => {
+      const theme = themeByValue(value);
+
+      root.dataset.palette = theme.value;
+      localStorage.setItem(PALETTE_STORAGE_KEY, theme.value);
+      currentLabel.textContent = themeLabel(theme);
+      currentSubLabel.textContent = themeSubLabel(theme);
+
+      for (const option of options) {
+        const isActive = option.dataset.paletteOption === theme.value;
+        option.classList.toggle('active', isActive);
+        option.setAttribute('aria-pressed', String(isActive));
+      }
+    };
+
+    trigger.addEventListener('click', () => {
+      setOpen(pop.hidden);
+    });
+
+    overlay.addEventListener('click', () => close(false));
+
+    picker.addEventListener('keydown', (event) => {
+      if (pop.hidden) {
+        return;
+      }
+
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        close(true);
+        return;
+      }
+
+      if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+        const index = options.findIndex(option => option === document.activeElement);
+
+        if (index !== -1) {
+          event.preventDefault();
+          const delta = event.key === 'ArrowDown' ? 1 : -1;
+          options[(index + delta + options.length) % options.length].focus();
+        }
+      }
+    });
+
+    for (const option of options) {
+      option.addEventListener('click', () => {
+        applyPalette(option.dataset.paletteOption ?? DEFAULT_PALETTE);
+        close(true);
+      });
+    }
+
+    applyPalette(root.dataset.palette ?? DEFAULT_PALETTE);
+    picker.dataset.themeReady = 'true';
+  };
+
+  initThemePicker();
+</script>

--- a/src/viewer/src/layouts/Layout.astro
+++ b/src/viewer/src/layouts/Layout.astro
@@ -3,6 +3,7 @@ import BottomNav from '../components/common/BottomNav.astro';
 import Footer from '../components/common/Footer.astro';
 import Header from '../components/common/Header.astro';
 import { DetailDrawer } from '../components/viewer/DetailDrawer';
+import { DEFAULT_PALETTE, PALETTE_STORAGE_KEY, THEMES } from '../shared/themes';
 import '../styles/reset.css';
 import '../styles/viewer.css';
 
@@ -44,13 +45,24 @@ const noindex = import.meta.env.SITE_NOINDEX === 'true';
     {ogImage && <meta property="og:image" content={ogImage} />}
     <meta name="twitter:card" content="summary" />
     <title>{title}</title>
-    <script is:inline>
-      (() => {
-        const paletteKey = 'isekai-observatory-palette';
-        const root = document.documentElement;
-        const savedPalette = localStorage.getItem(paletteKey) ?? 'nemophila-2';
-        root.dataset.palette = savedPalette;
-      })();
+    {/* FOUC 防止のため描画前に palette を適用する。保存値は既知のテーマのみ許可し、廃止テーマ等の不正値は既定に修復する */}
+    <script
+      define:vars={{
+        paletteKey: PALETTE_STORAGE_KEY,
+        defaultPalette: DEFAULT_PALETTE,
+        validPalettes: THEMES.map(theme => theme.value),
+      }}
+    >
+      {
+        const saved = localStorage.getItem(paletteKey);
+        const palette = saved !== null && validPalettes.includes(saved) ? saved : defaultPalette;
+
+        if (saved !== null && saved !== palette) {
+          localStorage.setItem(paletteKey, palette);
+        }
+
+        document.documentElement.dataset.palette = palette;
+      }
     </script>
   </head>
   <body>
@@ -61,75 +73,5 @@ const noindex = import.meta.env.SITE_NOINDEX === 'true';
     <Footer />
     <BottomNav currentPath={Astro.url.pathname} />
     <DetailDrawer client:load />
-    <script is:inline>
-      (() => {
-        const paletteKey = 'isekai-observatory-palette';
-        const defaultPalette = 'nemophila-2';
-
-        const initThemeControls = () => {
-          const root = document.documentElement;
-          const picker = document.querySelector('[data-theme-picker]');
-
-          if (!(picker instanceof HTMLElement) || picker.dataset.themeReady === 'true') {
-            return;
-          }
-
-          const trigger = picker.querySelector('[data-theme-trigger]');
-          const overlay = picker.querySelector('[data-theme-overlay]');
-          const pop = picker.querySelector('[data-theme-pop]');
-          const jp = picker.querySelector('[data-theme-current-jp]');
-          const en = picker.querySelector('[data-theme-current-en]');
-          const options = [...picker.querySelectorAll('[data-palette-option]')];
-
-          if (!(trigger instanceof HTMLButtonElement) || !(overlay instanceof HTMLElement) || !(pop instanceof HTMLElement) || !(jp instanceof HTMLElement) || !(en instanceof HTMLElement) || options.length === 0) {
-            return;
-          }
-
-          const setOpen = (open) => {
-            trigger.setAttribute('aria-expanded', String(open));
-            overlay.hidden = !open;
-            pop.hidden = !open;
-          };
-
-          const applyPalette = (palette) => {
-            root.dataset.palette = palette;
-            localStorage.setItem(paletteKey, palette);
-            const active = options.find(option => option instanceof HTMLElement && option.dataset.paletteOption === palette) ?? options[0];
-            if (!(active instanceof HTMLElement)) return;
-
-            jp.textContent = active.dataset.costume || active.dataset.jp || defaultPalette;
-            en.textContent = active.dataset.costume ? `${active.dataset.jp} · ${active.dataset.en}` : active.dataset.en || '';
-
-            for (const option of options) {
-              if (!(option instanceof HTMLElement)) continue;
-              option.classList.toggle('active', option.dataset.paletteOption === palette);
-            }
-          };
-
-          trigger.addEventListener('click', () => {
-            setOpen(pop.hidden);
-          });
-
-          overlay.addEventListener('click', () => setOpen(false));
-
-          for (const option of options) {
-            if (!(option instanceof HTMLButtonElement)) continue;
-            option.addEventListener('click', () => {
-              applyPalette(option.dataset.paletteOption || defaultPalette);
-              setOpen(false);
-            });
-          }
-
-          applyPalette(root.dataset.palette || defaultPalette);
-          picker.dataset.themeReady = 'true';
-        };
-
-        if (document.readyState === 'loading') {
-          document.addEventListener('DOMContentLoaded', initThemeControls, { once: true });
-        } else {
-          initThemeControls();
-        }
-      })();
-    </script>
   </body>
 </html>

--- a/src/viewer/src/shared/themes.ts
+++ b/src/viewer/src/shared/themes.ts
@@ -67,3 +67,17 @@ export const THEMES: Theme[] = [
 export const LIGHT_PALETTES: Set<string> = new Set(
   THEMES.filter(theme => theme.tone === 'light').map(theme => theme.value),
 );
+
+export const DEFAULT_PALETTE = 'anemone-1';
+
+export const PALETTE_STORAGE_KEY = 'isekai-observatory-palette';
+
+// 未知の値 (廃止テーマ等) は既定テーマに落とす
+export const themeByValue = (value: string): Theme =>
+  THEMES.find(theme => theme.value === value)
+  ?? THEMES.find(theme => theme.value === DEFAULT_PALETTE)
+  ?? THEMES[0];
+
+export const themeLabel = (theme: Theme): string => theme.costume ?? theme.jp;
+
+export const themeSubLabel = (theme: Theme): string => (theme.costume ? `${theme.jp} · ${theme.en}` : theme.en);

--- a/src/viewer/src/styles/viewer.css
+++ b/src/viewer/src/styles/viewer.css
@@ -140,6 +140,8 @@
   --shadow: 0 20px 60px rgba(40, 40, 60, 0.07);
 }
 
+/* sunflower-2 は現在 THEMES から外しているが将来再提供する予定のため配色定義を残す */
+
 [data-palette="sunflower-2"] {
   --bg: #0f0f11;
   --bg-elev: #18181c;


### PR DESCRIPTION
## 概要

テーマの知識 (既定パレット・ストレージキー・ラベル整形) が Layout のインラインスクリプト 2 つと Header に分散し、既定パレットの重複定義・SSR 初期ラベルの不一致・localStorage 保存値の無検証適用が起きていたため、shared/themes.ts に集約して整理する
あわせて既定パレットを nemophila-2 から anemone-1 に変更する

## やったこと

- `DEFAULT_PALETTE` / `PALETTE_STORAGE_KEY` / `themeByValue` / `themeLabel` / `themeSubLabel` を `shared/themes.ts` に集約 (オプションの `data-jp/en/costume` 属性も不要化)
- FOUC 防止スクリプト (head) は `define:vars` で定数を注入し、保存値を既知テーマのみに検証。廃止テーマ等の不正値は既定に修復して保存し直す
- ピッカーの実装 (~70 行) を Layout のインラインスクリプトから Header.astro のバンドル対象 script (TypeScript) に移動。`assetsInlineLimit: 0` を設定し、全ページへのインライン展開ではなくハッシュ付き JS として 1 回キャッシュさせる (トップの HTML 17.5KB → 15.2KB)
- Header の SSR 初期ラベルを `THEMES[0]` 固定から既定パレットのテーマ描画に変更 (JS 無効時・適用前の表示不一致を解消)
- a11y: `role="menu"` の ARIA 違反 (menuitem のない menu) を解消して `role="dialog"` + `aria-labelledby` に変更。オプションに `aria-pressed`、Esc 閉じ + トリガーへのフォーカス復帰、開時の選択中オプションへのフォーカス移動、↑↓ でのオプション巡回を実装
- 既定パレットを anemone-1 に変更 (保存済みの選択は影響を受けず、初回訪問者と不正値の端末のみ)

## やってないこと

- sunflower-2 の配色 CSS の削除: 将来再提供する予定のため意図をコメントで明記して残した (THEMES 非掲載のため選択・適用はされない)
- ピッカーの Tab フォーカストラップ (dialog 内への閉じ込め): Esc とフォーカス復帰で実用上足りると判断。DetailDrawer のモーダル化 (#928) とあわせて検討

## 関連

- closes #927

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TQNZn7XKjbbnCeYgvUmotc