### PR TITLE
Web フォントを self-host 化して未使用バリアントを削減する

### DIFF
--- a/src/pnpm-lock.yaml
+++ b/src/pnpm-lock.yaml
@@ -28,6 +28,22 @@ catalogs:
     wrangler:
       specifier: 4.107.0
       version: 4.107.0
+  fonts:
+    '@fontsource/eb-garamond':
+      specifier: 5.3.0
+      version: 5.3.0
+    '@fontsource/jetbrains-mono':
+      specifier: 5.3.0
+      version: 5.3.0
+    '@fontsource/noto-serif-jp':
+      specifier: 5.3.0
+      version: 5.3.0
+    '@fontsource/shippori-mincho':
+      specifier: 5.3.0
+      version: 5.3.0
+    '@fontsource/spectral':
+      specifier: 5.3.0
+      version: 5.3.0
   gen:
     '@hey-api/openapi-ts':
       specifier: 0.99.0
@@ -239,6 +255,21 @@ importers:
       '@astrojs/solid-js':
         specifier: catalog:astro
         version: 7.0.1(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(solid-js@1.9.13)(supports-color@10.2.2)(yaml@2.9.0)
+      '@fontsource/eb-garamond':
+        specifier: catalog:fonts
+        version: 5.3.0
+      '@fontsource/jetbrains-mono':
+        specifier: catalog:fonts
+        version: 5.3.0
+      '@fontsource/noto-serif-jp':
+        specifier: catalog:fonts
+        version: 5.3.0
+      '@fontsource/shippori-mincho':
+        specifier: catalog:fonts
+        version: 5.3.0
+      '@fontsource/spectral':
+        specifier: catalog:fonts
+        version: 5.3.0
       '@tailwindcss/vite':
         specifier: catalog:ui
         version: 4.3.2(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
@@ -931,6 +962,21 @@ packages:
   '@eslint/plugin-kit@0.7.2':
     resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@fontsource/eb-garamond@5.3.0':
+    resolution: {integrity: sha512-VplwHpB8FLuzl+4G5LDci1b3Z4SghiuXH8XEgaxjnOb5aue5mEt1njmDKeO6iyLeGa73LffU7PC7hzncLRx0ZA==}
+
+  '@fontsource/jetbrains-mono@5.3.0':
+    resolution: {integrity: sha512-fqDfB5I9f1p1TV486aUgB9t8zP84P0O1FtQR5Ol9vjwPy+S+EIGlVYm1cvj2W5shcZMTg2nZFdVMoH5wFu8a1A==}
+
+  '@fontsource/noto-serif-jp@5.3.0':
+    resolution: {integrity: sha512-7dRFleN7F+uuJdcMW/fJmnl6KLZSn9dHCjAVTaWjTcT4hg5V4ECbi2qgIamI6rS/+yTt16KDLU+9aJi74r6ZxQ==}
+
+  '@fontsource/shippori-mincho@5.3.0':
+    resolution: {integrity: sha512-S41kRxQuubAaYss+LeXu0IOc02RQwsPaJbR1cWZx4VV15hXaYZViH3WAve9HpDVFqKYd/BVk86Bg7lp9ytV3KQ==}
+
+  '@fontsource/spectral@5.3.0':
+    resolution: {integrity: sha512-2TL5WWGOZj4SIsBmPFEzKeA60tXXd1Qp1OqaaVEWkJL8IfSGLk6YmiusmC441iFkdJDIuFelu1r8lhCmQUU3mw==}
 
   '@hey-api/codegen-core@0.9.1':
     resolution: {integrity: sha512-s97jL1dgTMuiMHv2BZ1X4Tgd99Mf9GOvGdNqNcGwIMmnR+PgYNoraj4Zvp134MKsNCap/m7k0r0vKKnl56pj4w==}
@@ -5053,6 +5099,16 @@ snapshots:
     dependencies:
       '@eslint/core': 1.2.1
       levn: 0.4.1
+
+  '@fontsource/eb-garamond@5.3.0': {}
+
+  '@fontsource/jetbrains-mono@5.3.0': {}
+
+  '@fontsource/noto-serif-jp@5.3.0': {}
+
+  '@fontsource/shippori-mincho@5.3.0': {}
+
+  '@fontsource/spectral@5.3.0': {}
 
   '@hey-api/codegen-core@0.9.1(magicast@0.5.3)':
     dependencies:

--- a/src/pnpm-workspace.yaml
+++ b/src/pnpm-workspace.yaml
@@ -13,6 +13,12 @@ catalog:
   wrangler: 4.107.0
 
 catalogs:
+  fonts:
+    "@fontsource/eb-garamond": 5.3.0
+    "@fontsource/jetbrains-mono": 5.3.0
+    "@fontsource/noto-serif-jp": 5.3.0
+    "@fontsource/shippori-mincho": 5.3.0
+    "@fontsource/spectral": 5.3.0
   astro:
     astro: 7.1.3
     "@astrojs/sitemap": 3.7.3

--- a/src/viewer/astro.config.mjs
+++ b/src/viewer/astro.config.mjs
@@ -7,6 +7,20 @@ import { defineConfig } from 'astro/config';
 const port = Number(import.meta.env.PORT ?? '3000');
 const site = process.env.SITE_URL ?? 'https://local.isekaijoucho.fan';
 
+// @fontsource の @font-face は woff2 と woff を並記するが、woff2 に対応しないブラウザは対象外
+// Vite が URL を解決する前に woff の参照を落とし、ビルド成果物から woff ファイルごと除く
+const dropLegacyWoffSource = () => ({
+  name: 'drop-legacy-woff-source',
+  enforce: 'pre',
+  transform(code, id) {
+    if (!id.includes('@fontsource') || !id.endsWith('.css')) {
+      return null;
+    }
+
+    return code.replace(/,\s*url\([^)]+\.woff\)\s*format\('woff'\)/g, '');
+  },
+});
+
 // https://astro.build/config
 export default defineConfig({
   site: site,
@@ -27,5 +41,6 @@ export default defineConfig({
       // 小さなスクリプトも全ページへのインライン展開ではなくハッシュ付きファイルとしてキャッシュさせる
       assetsInlineLimit: 0,
     },
+    plugins: [dropLegacyWoffSource()],
   },
 });

--- a/src/viewer/package.json
+++ b/src/viewer/package.json
@@ -26,6 +26,11 @@
   "dependencies": {
     "@astrojs/sitemap": "catalog:astro",
     "@astrojs/solid-js": "catalog:astro",
+    "@fontsource/eb-garamond": "catalog:fonts",
+    "@fontsource/jetbrains-mono": "catalog:fonts",
+    "@fontsource/noto-serif-jp": "catalog:fonts",
+    "@fontsource/shippori-mincho": "catalog:fonts",
+    "@fontsource/spectral": "catalog:fonts",
     "@tailwindcss/vite": "catalog:ui",
     "astro": "catalog:astro",
     "daisyui": "catalog:ui",

--- a/src/viewer/src/layouts/Layout.astro
+++ b/src/viewer/src/layouts/Layout.astro
@@ -4,6 +4,7 @@ import Footer from '../components/common/Footer.astro';
 import Header from '../components/common/Header.astro';
 import { DetailDrawer } from '../components/viewer/DetailDrawer';
 import { DEFAULT_PALETTE, PALETTE_STORAGE_KEY, THEMES } from '../shared/themes';
+import '../styles/fonts';
 import '../styles/reset.css';
 import '../styles/viewer.css';
 

--- a/src/viewer/src/styles/fonts.ts
+++ b/src/viewer/src/styles/fonts.ts
@@ -1,0 +1,30 @@
+/**
+ * Web フォント定義
+ *
+ * self-host して HTML → CSS → Google Fonts の CSS → woff2 という直列の取得を 1 段短くする
+ * 読み込むのは viewer.css で実際に指定しているバリアントだけに絞る
+ * 日本語 2 ファミリーは unicode-range で分割された CSS を選び、必要な字形の分だけ転送させる
+ */
+
+// Noto Serif JP: 本文 400 / サイトポリシーの見出し 600 / 見出し 700
+import '@fontsource/noto-serif-jp/400.css';
+import '@fontsource/noto-serif-jp/600.css';
+import '@fontsource/noto-serif-jp/700.css';
+
+// Shippori Mincho: 小見出し 400 / セクション見出し 500 / ブランド表記 600
+import '@fontsource/shippori-mincho/400.css';
+import '@fontsource/shippori-mincho/500.css';
+import '@fontsource/shippori-mincho/600.css';
+
+// EB Garamond: 欧文の添え書きは italic のみで、normal 400 は .font-en 用
+import '@fontsource/eb-garamond/400.css';
+import '@fontsource/eb-garamond/400-italic.css';
+import '@fontsource/eb-garamond/500-italic.css';
+
+// JetBrains Mono: ラベル 400 / サムネイル上のオーバーレイ 500
+import '@fontsource/jetbrains-mono/400.css';
+import '@fontsource/jetbrains-mono/500.css';
+
+// Spectral: 数値表記に使う normal 500 と italic 400 のみ
+import '@fontsource/spectral/500.css';
+import '@fontsource/spectral/400-italic.css';

--- a/src/viewer/src/styles/viewer.css
+++ b/src/viewer/src/styles/viewer.css
@@ -1,6 +1,6 @@
 /* ヰ世界情緒ファンサイト - 共通スタイル */
 
-@import url("https://fonts.googleapis.com/css2?family=Noto+Serif+JP:wght@300;400;500;600;700&family=Cormorant+Garamond:ital,wght@0,300;0,400;0,500;0,600;1,300;1,400&family=EB+Garamond:wght@400;500;600&family=JetBrains+Mono:wght@300;400;500&family=Shippori+Mincho:wght@400;500;600&family=Spectral:ital,wght@0,400;0,500;1,400;1,500&display=swap");
+/* Web フォントの読み込みは styles/fonts.ts に置き、Layout.astro から参照する */
 
 :root {
   --bg: #0e0e10;
@@ -216,12 +216,8 @@ a {
   font-family: "JetBrains Mono", monospace;
 }
 
-.font-cormorant {
-  font-family: "EB Garamond", "Cormorant Garamond", serif;
-}
-
 .font-en {
-  font-family: "EB Garamond", "Cormorant Garamond", serif;
+  font-family: "EB Garamond", serif;
   letter-spacing: 0.02em;
 }
 
@@ -1011,7 +1007,7 @@ image-slot:hover {
 }
 
 .footer-tagline {
-  font-family: "Cormorant Garamond", serif;
+  font-family: "EB Garamond", serif;
   font-size: 14px;
   font-style: italic;
   line-height: 1.6;
@@ -1173,7 +1169,7 @@ image-slot:hover {
 }
 
 .detail-title-en {
-  font-family: "Cormorant Garamond", serif;
+  font-family: "EB Garamond", serif;
   font-size: 18px;
   font-style: italic;
   color: var(--accent-2);
@@ -1603,7 +1599,7 @@ image-slot:hover {
 
 .hero-en {
   margin-top: 24px;
-  font-family: "Cormorant Garamond", serif;
+  font-family: "EB Garamond", serif;
   font-size: 22px;
   font-style: italic;
   color: var(--accent);
@@ -1812,7 +1808,7 @@ image-slot:hover {
 
 .song-grid-title-en {
   margin-top: 2px;
-  font-family: "Cormorant Garamond", serif;
+  font-family: "EB Garamond", serif;
   font-size: 12px;
   font-style: italic;
   color: var(--accent-2);
@@ -1976,7 +1972,7 @@ image-slot:hover {
 }
 
 .upcoming-date div {
-  font-family: "Cormorant Garamond", serif;
+  font-family: "EB Garamond", serif;
   font-size: 14px;
   font-style: italic;
   color: var(--accent);
@@ -2116,7 +2112,7 @@ image-slot:hover {
 
 .feature-subtitle {
   margin-bottom: 24px;
-  font-family: "Cormorant Garamond", serif;
+  font-family: "EB Garamond", serif;
   font-size: 18px;
   font-style: italic;
   color: var(--accent);


### PR DESCRIPTION
## 概要

Google Fonts の `@import` をやめ、`@fontsource` で self-host に切り替える
描画をブロックする CSS 取得が 2 リクエスト / 3 オリジンから 1 リクエスト / 同一オリジンになり、googleapis と gstatic への DNS + TLS が不要になる

実測では ISSUE の期待効果のうち RTT 削減は得られるが、転送量はほぼ変わらない
ブラウザは実際に使うバリアントの woff2 しか取得しないため、未使用の 22 バリアントは元から転送されていなかった
CSS も brotli 後で 29KB → 32.7KB とほぼ横ばい (Google 側の 929KB は brotli で 21KB まで縮むため)
実転送が減るのは Cormorant Garamond を統合した分の欧文 1 ファイルだけになる

## やったこと

- `@fontsource` で self-host 化する。読み込みは `src/viewer/src/styles/fonts.ts` に集約し `Layout.astro` から参照する
- バリアントを 6 ファミリー 22 個から 5 ファミリー 13 個に絞る。未使用だった weight 300 系などを外した
- Cormorant Garamond を EB Garamond に統一し、未使用の `.font-cormorant` を削除する
- 日本語 2 ファミリーは unicode-range で分割された CSS を選び、必要な字形の分だけ転送させる。`japanese-400.css` は 1.4MB を一括で取得するため採用していない
- `@fontsource` が並記する woff の参照を Vite plugin で落とす。woff2 で足りるうえ、そのままだと dist に 27MB の woff が生成されるため

## やってないこと

- Spectral の italic 削除: ISSUE には使用ゼロとあるが `.detail-index` `.chronology-grid` `.num-cell` が italic 指定のため italic 400 は残す。代わりに未使用の normal 400 と italic 500 を外した
- Noto Serif JP 600 の削除: `.policy-doc h2` が使っており、落とすと見た目が変わるため残す
- preload の追加: 日本語フォントは unicode-range で 124 分割されており、どの分割を使うか事前に決められない

## 関連

- #923