### PR TITLE
ブレークポイントを 4 個に整理して降順に統一する

### DIFF
--- a/src/viewer/src/styles/viewer.css
+++ b/src/viewer/src/styles/viewer.css
@@ -2181,7 +2181,9 @@ image-slot:hover {
   margin-top: 6px;
 }
 
-@media (width <= 1100px) {
+/* ブレークポイントは max-width を降順に並べ、狭い側の指定が後勝ちになるようにする */
+
+@media (width <= 1280px) {
 
   .profile-grid,
   .feature-grid-link,
@@ -2189,7 +2191,10 @@ image-slot:hover {
     grid-template-columns: 1fr;
   }
 
-  .song-grid,
+  .song-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
   .release-grid,
   .media-card-grid,
   .recent-posts-grid {
@@ -2197,7 +2202,8 @@ image-slot:hover {
   }
 
   .media-mosaic {
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: repeat(3, 1fr);
+    grid-auto-rows: 164px;
   }
 
   /* 1 カラム時はジャケット縦幅に固定せず、リスト自身の高さで切る */
@@ -2220,20 +2226,20 @@ image-slot:hover {
   }
 }
 
-@media (width <= 1280px) {
-
-  .song-grid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
-
-  .media-mosaic {
-    grid-template-columns: repeat(3, 1fr);
-    grid-auto-rows: 164px;
-  }
-}
-
 @media (width <= 960px) {
 
+  .shell,
+  .nav-inner {
+    padding-right: 20px;
+    padding-left: 20px;
+  }
+
+  .nav-links {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .song-grid,
   .release-grid,
   .media-card-grid,
   .recent-posts-grid {
@@ -2245,6 +2251,14 @@ image-slot:hover {
     grid-auto-rows: 148px;
   }
 
+  .media-list-row {
+    grid-template-columns: 1fr;
+  }
+
+  .chronology-grid {
+    grid-template-columns: 1fr;
+  }
+
   .viewer-filters-spacer {
     display: none;
   }
@@ -2254,6 +2268,24 @@ image-slot:hover {
     order: 10;
     width: 100%;
     min-width: 100%;
+  }
+
+  .hero-actions {
+    flex-direction: column;
+  }
+
+  .hero-data .hero-actions {
+    margin-top: 48px;
+  }
+
+  .hero-ledger {
+    margin-top: 48px;
+  }
+
+  .section-head,
+  .section-head-left {
+    flex-direction: column;
+    align-items: flex-start;
   }
 }
 
@@ -2350,54 +2382,6 @@ image-slot:hover {
 
   .footer-grid > :first-child {
     grid-column: 1 / -1;
-  }
-}
-
-@media (width <= 800px) {
-
-  .shell,
-  .nav-inner {
-    padding-right: 20px;
-    padding-left: 20px;
-  }
-
-  .hero-actions {
-    flex-direction: column;
-  }
-
-  .nav-links {
-    flex-wrap: wrap;
-    justify-content: center;
-  }
-
-  .song-grid,
-  .release-grid,
-  .media-card-grid,
-  .recent-posts-grid,
-  .media-mosaic {
-    grid-template-columns: 1fr;
-  }
-
-  .hero-ledger {
-    margin-top: 48px;
-  }
-
-  .hero-data .hero-actions {
-    margin-top: 48px;
-  }
-
-  .media-list-row {
-    grid-template-columns: 1fr;
-  }
-
-  .chronology-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .section-head,
-  .section-head-left {
-    flex-direction: column;
-    align-items: flex-start;
   }
 }
 


### PR DESCRIPTION
## 概要

#934 のうち、表示が変わるブレークポイント整理を扱う
`1100 → 1280 → 960 → 720 → 800 → 420px` と非単調に並んでおり、狭い側の指定が広い側の指定に上書きされる帯があった

実害として `(width <= 1280px)` が `1100px` ブロックより後ろにあるため、1100px 以下で `.song-grid` と `.media-mosaic` を 2 カラムにする指定は一度も効いていなかった

**#943 の上に積んでいます。#943 がマージされるまで、この PR の差分には #943 の変更も含まれます**

## やったこと

- `1280 / 960 / 720 / 420px` の 4 個に集約し、max-width を降順に並べる
- `1100px` ブロックを `1280px` に、`800px` ブロックを `960px` に寄せる
- `1280px` 帯は `.song-grid` を 3 カラム、その他のカードグリッドを 2 カラムに揃える
- `960px` 帯に `.song-grid` の 2 カラム指定を足し、4 → 3 → 2 → 1 カラムの段階を通す

## 表示が変わる帯

幅ごとに「最終的に効く値」を変更前後で突き合わせた。変化は下記 4 帯に収まり、1400 / 1300 / 1050 / 1000px では変化しない

| 帯 | 変化 |
| --- | --- |
| 1101-1280px | 2 カラムセクションと detail panel が 1 段階早く畳まれる (`1100px` ブロックを寄せたため) |
| 801-960px | `.shell` の左右余白が 20px に、`.section-head` が縦積みに、`.chronology-grid` が 1 カラムになる (`800px` ブロックを寄せたため) |
| 721-800px | カードグリッドが 1 カラムではなく 2 カラムになる。1 カラム化は 720px 以下に統一した |
| 720px 以下 | `.media-list-row` が `800px` ブロックの 1 カラム指定ではなく、`720px` ブロック本来のサムネイル + 本文の 2 カラムになる。このクラスは未提供セクションの雛形 `_index.astro` でしか使っていないため実表示への影響はない |

## やってないこと

- min-width のモバイルファーストへの書き換え: max-width 記法のままなので、降順に並べるのが正しい cascade になる。全面書き換えは差分と回帰リスクが大きいため見送った
- ブレークポイント値そのものの見直し: 既存の値から 4 個を選ぶに留めた

## 関連

- #934
- #943 (先にマージする)