### PR TITLE
viewer.css を棚卸ししてブレークポイントを 4 個に整理する

### DIFF
--- a/src/pnpm-lock.yaml
+++ b/src/pnpm-lock.yaml
@@ -270,21 +270,12 @@ importers:
       '@fontsource/spectral':
         specifier: catalog:fonts
         version: 5.3.0
-      '@tailwindcss/vite':
-        specifier: catalog:ui
-        version: 4.3.2(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
       astro:
         specifier: catalog:astro
         version: 7.1.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@25.9.1)(@upstash/redis@1.38.0)(jiti@2.7.0)(rollup@4.62.0)(yaml@2.9.0)
-      daisyui:
-        specifier: catalog:ui
-        version: 5.6.10
       solid-js:
         specifier: catalog:astro
         version: 1.9.13
-      tailwindcss:
-        specifier: catalog:ui
-        version: 4.3.2
       wrangler:
         specifier: 'catalog:'
         version: 4.107.0(@types/node@25.9.1)

--- a/src/viewer/package.json
+++ b/src/viewer/package.json
@@ -31,11 +31,8 @@
     "@fontsource/noto-serif-jp": "catalog:fonts",
     "@fontsource/shippori-mincho": "catalog:fonts",
     "@fontsource/spectral": "catalog:fonts",
-    "@tailwindcss/vite": "catalog:ui",
     "astro": "catalog:astro",
-    "daisyui": "catalog:ui",
     "solid-js": "catalog:astro",
-    "tailwindcss": "catalog:ui",
     "wrangler": "catalog:"
   },
   "devDependencies": {

--- a/src/viewer/src/components/common/BottomNav.astro
+++ b/src/viewer/src/components/common/BottomNav.astro
@@ -12,7 +12,7 @@ const { currentPath } = Astro.props;
 <nav class="bottom-nav" aria-label="モバイルナビゲーション">
   {
     navLinks.map(link => (
-      <a href={link.href} class={isActivePath(currentPath, link.href) ? 'active' : undefined}>
+      <a href={link.href} class={isActivePath(currentPath, link.href) ? 'is-active' : undefined}>
         <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
           {link.iconPaths.map(d => (
             <path d={d} />

--- a/src/viewer/src/components/common/Header.astro
+++ b/src/viewer/src/components/common/Header.astro
@@ -28,7 +28,7 @@ const defaultTheme = themeByValue(DEFAULT_PALETTE);
     <div class="nav-links">
       {
         navLinks.map(link => (
-          <a href={link.href} class={isActivePath(currentPath, link.href) ? 'active' : undefined}>
+          <a href={link.href} class={isActivePath(currentPath, link.href) ? 'is-active' : undefined}>
             {link.label}
           </a>
         ))
@@ -58,7 +58,7 @@ const defaultTheme = themeByValue(DEFAULT_PALETTE);
             {
               THEMES.map(theme => (
                 <button
-                  class:list={['theme-opt', theme.value === DEFAULT_PALETTE && 'active']}
+                  class:list={['theme-opt', theme.value === DEFAULT_PALETTE && 'is-active']}
                   type="button"
                   aria-pressed={theme.value === DEFAULT_PALETTE ? 'true' : 'false'}
                   data-palette-option={theme.value}
@@ -106,7 +106,7 @@ const defaultTheme = themeByValue(DEFAULT_PALETTE);
       pop.hidden = !open;
 
       if (open) {
-        (options.find(option => option.classList.contains('active')) ?? options[0]).focus();
+        (options.find(option => option.classList.contains('is-active')) ?? options[0]).focus();
       }
     };
 
@@ -128,7 +128,7 @@ const defaultTheme = themeByValue(DEFAULT_PALETTE);
 
       for (const option of options) {
         const isActive = option.dataset.paletteOption === theme.value;
-        option.classList.toggle('active', isActive);
+        option.classList.toggle('is-active', isActive);
         option.setAttribute('aria-pressed', String(isActive));
       }
     };

--- a/src/viewer/src/components/viewer/LayoutSwitcher.tsx
+++ b/src/viewer/src/components/viewer/LayoutSwitcher.tsx
@@ -33,7 +33,7 @@ export default function LayoutSwitcher(props: Props) {
         {option => (
           <button
             type="button"
-            class={value() === option.value ? 'active' : undefined}
+            class={value() === option.value ? 'is-active' : undefined}
             title={option.label}
             aria-label={option.label}
             onClick={() => setValue(option.value)}

--- a/src/viewer/src/styles/reset.css
+++ b/src/viewer/src/styles/reset.css
@@ -4,6 +4,7 @@
 }
 
 a {
+  color: inherit;
   text-decoration: none;
 }
 

--- a/src/viewer/src/styles/viewer.css
+++ b/src/viewer/src/styles/viewer.css
@@ -2181,7 +2181,9 @@ image-slot:hover {
   margin-top: 6px;
 }
 
-@media (width <= 1100px) {
+/* ブレークポイントは max-width を降順に並べ、狭い側の指定が後勝ちになるようにする */
+
+@media (width <= 1280px) {
 
   .profile-grid,
   .feature-grid-link,
@@ -2189,7 +2191,10 @@ image-slot:hover {
     grid-template-columns: 1fr;
   }
 
-  .song-grid,
+  .song-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
   .release-grid,
   .media-card-grid,
   .recent-posts-grid {
@@ -2197,7 +2202,8 @@ image-slot:hover {
   }
 
   .media-mosaic {
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: repeat(3, 1fr);
+    grid-auto-rows: 164px;
   }
 
   /* 1 カラム時はジャケット縦幅に固定せず、リスト自身の高さで切る */
@@ -2220,20 +2226,20 @@ image-slot:hover {
   }
 }
 
-@media (width <= 1280px) {
-
-  .song-grid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
-
-  .media-mosaic {
-    grid-template-columns: repeat(3, 1fr);
-    grid-auto-rows: 164px;
-  }
-}
-
 @media (width <= 960px) {
 
+  .shell,
+  .nav-inner {
+    padding-right: 20px;
+    padding-left: 20px;
+  }
+
+  .nav-links {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .song-grid,
   .release-grid,
   .media-card-grid,
   .recent-posts-grid {
@@ -2245,6 +2251,14 @@ image-slot:hover {
     grid-auto-rows: 148px;
   }
 
+  .media-list-row {
+    grid-template-columns: 1fr;
+  }
+
+  .chronology-grid {
+    grid-template-columns: 1fr;
+  }
+
   .viewer-filters-spacer {
     display: none;
   }
@@ -2254,6 +2268,24 @@ image-slot:hover {
     order: 10;
     width: 100%;
     min-width: 100%;
+  }
+
+  .hero-actions {
+    flex-direction: column;
+  }
+
+  .hero-data .hero-actions {
+    margin-top: 48px;
+  }
+
+  .hero-ledger {
+    margin-top: 48px;
+  }
+
+  .section-head,
+  .section-head-left {
+    flex-direction: column;
+    align-items: flex-start;
   }
 }
 
@@ -2350,54 +2382,6 @@ image-slot:hover {
 
   .footer-grid > :first-child {
     grid-column: 1 / -1;
-  }
-}
-
-@media (width <= 800px) {
-
-  .shell,
-  .nav-inner {
-    padding-right: 20px;
-    padding-left: 20px;
-  }
-
-  .hero-actions {
-    flex-direction: column;
-  }
-
-  .nav-links {
-    flex-wrap: wrap;
-    justify-content: center;
-  }
-
-  .song-grid,
-  .release-grid,
-  .media-card-grid,
-  .recent-posts-grid,
-  .media-mosaic {
-    grid-template-columns: 1fr;
-  }
-
-  .hero-ledger {
-    margin-top: 48px;
-  }
-
-  .hero-data .hero-actions {
-    margin-top: 48px;
-  }
-
-  .media-list-row {
-    grid-template-columns: 1fr;
-  }
-
-  .chronology-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .section-head,
-  .section-head-left {
-    flex-direction: column;
-    align-items: flex-start;
   }
 }
 

--- a/src/viewer/src/styles/viewer.css
+++ b/src/viewer/src/styles/viewer.css
@@ -171,8 +171,6 @@
 
 html,
 body {
-  padding: 0;
-  margin: 0;
   font-family: "Noto Serif JP", "Shippori Mincho", serif;
   font-size: 16px;
   font-weight: 400;
@@ -194,41 +192,13 @@ body {
   background-attachment: fixed;
 }
 
-a {
-  color: inherit;
-  text-decoration: none;
-}
-
 ::selection {
   color: var(--fg);
   background: color-mix(in oklab, var(--accent) 40%, transparent);
 }
 
-.font-serif {
-  font-family: "Noto Serif JP", "Shippori Mincho", serif;
-}
-
-.font-mincho {
-  font-family: "Shippori Mincho", "Noto Serif JP", serif;
-}
-
-.font-mono {
-  font-family: "JetBrains Mono", monospace;
-}
-
 .font-en {
   font-family: "EB Garamond", serif;
-  letter-spacing: 0.02em;
-}
-
-.num {
-  font-family: Spectral, serif;
-  font-style: normal;
-  font-weight: 500;
-  font-feature-settings:
-    "lnum" 1,
-    "tnum" 1;
-  font-variant-numeric: tabular-nums lining-nums;
   letter-spacing: 0.02em;
 }
 
@@ -368,10 +338,6 @@ a {
   display: block;
 }
 
-.hero-index-title:hover {
-  color: var(--accent-strong) !important;
-}
-
 /* モバイル用のボトムナビ。720px 以下でのみ表示する */
 
 .bottom-nav {
@@ -405,7 +371,7 @@ a {
   transition: color 0.2s ease;
 }
 
-.bottom-nav a.active {
+.bottom-nav a.is-active {
   --bottom-nav-icon: var(--accent);
 
   color: var(--fg);
@@ -431,11 +397,11 @@ a {
   color: var(--accent-2);
 }
 
-.nav-links a.active {
+.nav-links a.is-active {
   color: var(--fg);
 }
 
-.nav-links a.active::after {
+.nav-links a.is-active::after {
   position: absolute;
   bottom: -19px;
   left: 50%;
@@ -609,7 +575,7 @@ a {
   border-color: var(--line-soft);
 }
 
-.theme-opt.active {
+.theme-opt.is-active {
   background: color-mix(in oklab, var(--accent) 12%, transparent);
   border-color: var(--accent);
 }
@@ -649,7 +615,7 @@ a {
   opacity: 0;
 }
 
-.theme-opt.active .check {
+.theme-opt.is-active .check {
   opacity: 1;
 }
 
@@ -711,17 +677,6 @@ a {
   border-color: var(--accent);
 }
 
-.btn-primary {
-  color: var(--accent-contrast);
-  background: var(--accent);
-  border-color: var(--accent);
-}
-
-.btn-primary:hover {
-  background: var(--accent-strong);
-  border-color: var(--accent-strong);
-}
-
 /* ピル / バッジ */
 
 .pill {
@@ -735,12 +690,6 @@ a {
   white-space: nowrap;
   border: 1px solid var(--line);
   border-radius: 999px;
-}
-
-.pill.solid {
-  color: var(--accent-strong);
-  background: color-mix(in oklab, var(--accent) 18%, transparent);
-  border-color: transparent;
 }
 
 /* 楽曲種別バッジ: オリジナルはアクセント、カバーは中間色で一目で区別する。 */
@@ -834,7 +783,7 @@ a {
   stroke: none;
 }
 
-.seg button.active {
+.seg button.is-active {
   color: var(--accent-strong);
   background: color-mix(in oklab, var(--accent) 18%, var(--bg-elev-2));
   box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--accent) 55%, transparent);
@@ -844,7 +793,7 @@ a {
   transform: translateY(1px);
 }
 
-.seg button:not(.active):hover {
+.seg button:not(.is-active):hover {
   color: var(--fg);
   background: color-mix(in oklab, var(--fg) 5%, transparent);
 }
@@ -860,50 +809,6 @@ image-slot {
 
 image-slot:hover {
   border-color: var(--accent);
-}
-
-/* Songs / Events 用 */
-
-.song-meta {
-  display: flex;
-  gap: 10px;
-  align-items: center;
-}
-
-.song-meta-cell {
-  display: inline-flex;
-  gap: 3px;
-  align-items: baseline;
-}
-
-.timeline-row {
-  display: grid;
-  grid-template-columns: 56px 1fr auto auto auto;
-  gap: 24px;
-  align-items: center;
-  padding: 18px 0;
-  cursor: pointer;
-  border-bottom: 1px solid var(--line-soft);
-  transition: padding 0.15s;
-}
-
-.timeline-row:hover {
-  padding-left: 8px;
-}
-
-.num-cell {
-  font-family: Spectral, serif;
-  font-size: 16px;
-  font-style: italic;
-  color: var(--accent);
-  text-align: center;
-}
-
-.event-meta {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  text-align: right;
 }
 
 /* 罫線とディテール */
@@ -1003,14 +908,6 @@ image-slot:hover {
   margin: 0;
   font-size: 12px;
   line-height: 1.8;
-  color: var(--fg-muted);
-}
-
-.footer-tagline {
-  font-family: "EB Garamond", serif;
-  font-size: 14px;
-  font-style: italic;
-  line-height: 1.6;
   color: var(--fg-muted);
 }
 
@@ -1173,21 +1070,6 @@ image-slot:hover {
   font-size: 18px;
   font-style: italic;
   color: var(--accent-2);
-}
-
-.stat-bar {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 1px;
-  margin-top: 32px;
-  background: var(--line);
-  border: 1px solid var(--line);
-}
-
-.stat-cell {
-  padding: 18px 16px;
-  text-align: left;
-  background: var(--bg-elev);
 }
 
 .rel-list {
@@ -1378,25 +1260,7 @@ image-slot:hover {
   color: var(--accent);
 }
 
-/* ユーティリティ */
-
-.spacer-lg {
-  height: 96px;
-}
-
-.spacer-md {
-  height: 48px;
-}
-
-.spacer-sm {
-  height: 24px;
-}
-
 /* ページ間遷移 */
-
-.page {
-  animation: page-in 0.5s cubic-bezier(0.2, 0.7, 0.2, 1);
-}
 
 @keyframes page-in {
 
@@ -1411,54 +1275,14 @@ image-slot:hover {
   }
 }
 
-/* プレースホルダー画像（パターン付き） */
-
-.placeholder-art {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-  height: 100%;
-  font-family: "JetBrains Mono", monospace;
-  font-size: 11px;
-  color: var(--fg-faint);
-  text-transform: uppercase;
-  letter-spacing: 0.15em;
-  background:
-    repeating-linear-gradient(
-      135deg,
-      color-mix(in oklab, var(--accent) 6%, transparent) 0,
-      color-mix(in oklab, var(--accent) 6%, transparent) 12px,
-      transparent 12px,
-      transparent 24px
-    ),
-    color-mix(in oklab, var(--accent) 12%, var(--bg-elev-2));
-}
-
 .page-section {
   padding-top: 32px;
 }
 
-.two-col-section,
-.detail-hero-grid,
 .profile-grid {
   display: grid;
-  gap: 48px;
-}
-
-.two-col-section {
   grid-template-columns: 1fr 1.4fr;
   gap: 64px;
-}
-
-.detail-hero-grid {
-  grid-template-columns: minmax(280px, 420px) 1fr;
-  align-items: start;
-  margin-bottom: 28px;
-}
-
-.detail-hero-grid-wide {
-  grid-template-columns: minmax(320px, 1.2fr) 1fr;
 }
 
 /* hero: 観測台帳スタイル。数字は記録行として直立で置き、accent は CTA のみに使う */
@@ -1570,53 +1394,11 @@ image-slot:hover {
   transform: translateX(3px);
 }
 
-.hero-symbol {
-  position: relative;
-  padding: 120px 0 96px;
-  overflow: hidden;
-}
-
-.hero-stars {
-  position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
-  pointer-events: none;
-  opacity: 0.18;
-}
-
-.hero-symbol-inner {
-  position: relative;
-  text-align: center;
-}
-
 .hero-mark {
   font-family: "Shippori Mincho", serif;
   font-size: clamp(56px, 9vw, 128px);
   line-height: 1;
   letter-spacing: 0.18em;
-}
-
-.hero-en {
-  margin-top: 24px;
-  font-family: "EB Garamond", serif;
-  font-size: 22px;
-  font-style: italic;
-  color: var(--accent);
-  letter-spacing: 0.15em;
-}
-
-.hero-divider {
-  width: 64px;
-  height: 1px;
-  margin: 48px auto;
-  background: var(--line);
-}
-
-.hero-copy {
-  font-size: 14px;
-  color: var(--fg-muted);
-  letter-spacing: 0.2em;
 }
 
 .hero-actions {
@@ -1626,31 +1408,11 @@ image-slot:hover {
   margin-top: 40px;
 }
 
-.hero-symbol .hero-actions {
-  justify-content: center;
-}
-
 .hero-data .hero-actions {
   justify-content: center;
   margin-top: 64px;
 }
 
-.hero-stats-grid {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 1px;
-  max-width: 800px;
-  margin: 96px auto 0;
-  background: var(--line);
-  border: 1px solid var(--line);
-}
-
-.hero-stats-grid div {
-  padding: 24px;
-  background: var(--bg-elev);
-}
-
-.hero-stats-grid strong,
 .detail-index {
   font-family: Spectral, serif;
   font-style: italic;
@@ -1659,33 +1421,6 @@ image-slot:hover {
 
 .rel-chip .detail-index {
   min-width: 28px;
-}
-
-.hero-stats-grid strong {
-  display: block;
-  font-size: 40px;
-  line-height: 1;
-}
-
-.hero-symbol .hero-stats-grid span {
-  display: block;
-  margin-top: 8px;
-  font-size: 11px;
-  color: var(--fg-muted);
-}
-
-.news-list {
-  display: flex;
-  flex-direction: column;
-}
-
-.news-row {
-  display: grid;
-  grid-template-columns: auto auto 1fr;
-  gap: 20px;
-  align-items: center;
-  padding: 18px 0;
-  border-bottom: 1px solid var(--line-soft);
 }
 
 .feature-grid-link {
@@ -1733,9 +1468,7 @@ image-slot:hover {
 }
 
 .feature-summary,
-.detail-description,
-.event-row-description,
-.song-grid-description {
+.detail-description {
   line-height: 1.85;
   color: var(--fg-muted);
 }
@@ -1774,8 +1507,7 @@ image-slot:hover {
 }
 
 .media-card-title,
-.song-grid-title,
-.event-row-title {
+.song-grid-title {
   font-family: "Noto Serif JP", "Shippori Mincho", serif;
   letter-spacing: 0.04em;
 }
@@ -1794,29 +1526,6 @@ image-slot:hover {
 
 .song-grid-card:hover {
   transform: translateY(-2px);
-}
-
-.event-row-title {
-  font-size: 18px;
-}
-
-.timeline-title {
-  font-family: "Noto Serif JP", "Shippori Mincho", serif;
-  font-size: 22px;
-  letter-spacing: 0.04em;
-}
-
-.song-grid-title-en {
-  margin-top: 2px;
-  font-family: "EB Garamond", serif;
-  font-size: 12px;
-  font-style: italic;
-  color: var(--accent-2);
-}
-
-.song-grid-description {
-  margin: 12px 0 0;
-  font-size: 13px;
 }
 
 .song-grid-meta,
@@ -1907,8 +1616,7 @@ image-slot:hover {
   letter-spacing: 0.04em;
 }
 
-.post-card-text,
-.post-detail-text {
+.post-card-text {
   display: -webkit-box;
   overflow: hidden;
   -webkit-line-clamp: 6;
@@ -1923,8 +1631,7 @@ image-slot:hover {
   -webkit-line-clamp: 4;
 }
 
-.post-card-image,
-.post-detail-image {
+.post-card-image {
   aspect-ratio: 4 / 3;
   background:
     linear-gradient(
@@ -1935,8 +1642,7 @@ image-slot:hover {
     repeating-linear-gradient(45deg, rgba(255, 255, 255, 0.04) 0 2px, transparent 2px 8px);
 }
 
-.post-card-stats,
-.post-detail-stats {
+.post-card-stats {
   display: flex;
   gap: 16px;
   margin-top: auto;
@@ -1946,70 +1652,18 @@ image-slot:hover {
   letter-spacing: 0.1em;
 }
 
-.post-detail-card {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-  padding: 24px;
-  background: var(--bg-elev);
-  border: 1px solid var(--line);
-}
-
-.upcoming-event-card {
-  display: grid;
-  grid-template-columns: auto 1fr auto;
-  gap: 48px;
-  align-items: center;
-  padding: 48px;
-  background: linear-gradient(135deg, color-mix(in oklab, var(--accent) 8%, transparent), transparent);
-  border: 1px solid var(--line);
-}
-
-.upcoming-date {
-  padding-right: 48px;
-  text-align: center;
-  border-right: 1px solid var(--line);
-}
-
-.upcoming-date div {
-  font-family: "EB Garamond", serif;
-  font-size: 14px;
-  font-style: italic;
-  color: var(--accent);
-}
-
-.upcoming-date strong {
-  display: block;
-  font-family: "Shippori Mincho", serif;
-  font-size: 56px;
-  line-height: 1;
-}
-
-.upcoming-event-card .upcoming-date span {
-  display: block;
-  margin-top: 8px;
-  font-family: "JetBrains Mono", monospace;
-  font-size: 12px;
-  color: var(--fg-muted);
-}
-
-.media-list,
-.event-list {
+.media-list {
   display: flex;
   flex-direction: column;
 }
 
-.media-list-row,
-.event-row {
+.media-list-row {
   display: grid;
+  grid-template-columns: 80px 240px 1fr auto;
   gap: 24px;
   align-items: center;
   padding: 20px 0;
   border-bottom: 1px solid var(--line-soft);
-}
-
-.media-list-row {
-  grid-template-columns: 80px 240px 1fr auto;
 }
 
 .song-meta-inline {
@@ -2024,33 +1678,6 @@ image-slot:hover {
 .media-list-thumb {
   aspect-ratio: 16 / 9;
   overflow: hidden;
-}
-
-.event-row {
-  grid-template-columns: 140px 100px 1fr 200px auto auto;
-}
-
-.event-row-highlight {
-  padding-right: 24px;
-  padding-left: 24px;
-  background: color-mix(in oklab, var(--accent) 6%, transparent);
-  border-left: 2px solid var(--accent);
-}
-
-.event-row-date {
-  font-family: "Shippori Mincho", serif;
-  font-size: 22px;
-  letter-spacing: 0.04em;
-}
-
-.event-row-stats {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  font-family: "JetBrains Mono", monospace;
-  font-size: 11px;
-  color: var(--fg-muted);
-  text-align: right;
 }
 
 .entry-status {
@@ -2164,82 +1791,6 @@ image-slot:hover {
   color: rgba(255, 255, 255, 0.7);
 }
 
-.events-group {
-  margin-bottom: 64px;
-}
-
-.events-group-label {
-  margin-bottom: 16px;
-}
-
-.events-calendar {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 32px;
-}
-
-.events-year {
-  padding-bottom: 12px;
-  margin-bottom: 16px;
-  font-family: Spectral, serif;
-  font-size: 48px;
-  font-style: italic;
-  color: var(--accent);
-  border-bottom: 1px solid var(--line);
-}
-
-.events-month {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  padding: 12px 0;
-  border-bottom: 1px solid var(--line-soft);
-}
-
-.events-month-empty {
-  opacity: 0.35;
-}
-
-.events-month-link,
-.events-category-link {
-  display: block;
-}
-
-.events-category-grid {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 24px;
-}
-
-.events-category-card {
-  padding: 24px;
-  border: 1px solid var(--line);
-}
-
-.events-category-head {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  margin-bottom: 20px;
-}
-
-.events-category-title {
-  font-family: "Shippori Mincho", serif;
-  font-size: 20px;
-  letter-spacing: 0.08em;
-}
-
-.events-category-list {
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-}
-
-.profile-grid {
-  grid-template-columns: 1fr 1.4fr;
-  gap: 64px;
-}
-
 .profile-portrait {
   width: 100%;
   aspect-ratio: 3 / 4;
@@ -2312,24 +1863,6 @@ image-slot:hover {
   border-bottom: 1px solid var(--line-soft);
 }
 
-.detail-meta-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 16px 32px;
-  margin-top: 32px;
-}
-
-.detail-meta-grid div {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.detail-meta-grid strong {
-  font-size: 14px;
-  font-weight: 500;
-}
-
 .song-credit-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
@@ -2389,7 +1922,6 @@ image-slot:hover {
   white-space: nowrap;
 }
 
-.color-block,
 .jacket-art,
 .mv-thumb {
   position: relative;
@@ -2476,13 +2008,6 @@ image-slot:hover {
   font-size: 10px;
   color: var(--fg-muted);
   letter-spacing: 0.08em;
-}
-
-.color-block {
-  flex-shrink: 0;
-  width: 38px;
-  height: 38px;
-  background: linear-gradient(135deg, var(--tile-color), color-mix(in oklab, var(--tile-color) 50%, transparent));
 }
 
 .jacket-art {
@@ -2625,11 +2150,6 @@ image-slot:hover {
   fill: white;
 }
 
-.detail-panel .song-detail-content .detail-hero-grid {
-  grid-template-columns: 1fr;
-  gap: 24px;
-}
-
 .detail-panel .song-detail-content .jacket-art {
   max-width: 280px;
 }
@@ -2643,20 +2163,8 @@ image-slot:hover {
   margin-top: 6px;
 }
 
-.detail-panel .song-detail-content .detail-meta-grid {
-  grid-template-columns: 1fr;
-  gap: 14px;
-}
-
 .detail-panel .song-credit-grid {
   grid-template-columns: 1fr;
-}
-
-.detail-panel .release-detail-content .detail-hero-grid,
-.detail-panel .media-detail-content .detail-hero-grid,
-.detail-panel .media-detail-content .detail-hero-grid-wide {
-  grid-template-columns: 1fr;
-  gap: 24px;
 }
 
 .detail-panel .media-detail-content .mv-thumb {
@@ -2673,39 +2181,18 @@ image-slot:hover {
   margin-top: 6px;
 }
 
-.detail-panel .release-detail-content .detail-meta-grid {
-  grid-template-columns: 1fr;
-  gap: 14px;
-}
-
-.event-hero {
-  padding: 36px;
-  background: linear-gradient(
-    135deg,
-    color-mix(in oklab, var(--accent) 24%, var(--bg-elev-2)),
-    color-mix(in oklab, var(--accent) 8%, var(--bg-elev-2))
-  );
-  border: 1px solid var(--line);
-}
-
 @media (width <= 1100px) {
 
-  .two-col-section,
-  .detail-hero-grid,
   .profile-grid,
   .feature-grid-link,
-  .media-featured-grid,
-  .event-row,
-  .upcoming-event-card {
+  .media-featured-grid {
     grid-template-columns: 1fr;
   }
 
   .song-grid,
   .release-grid,
   .media-card-grid,
-  .recent-posts-grid,
-  .events-calendar,
-  .events-category-grid {
+  .recent-posts-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
@@ -2726,11 +2213,6 @@ image-slot:hover {
 
   .detail-panel {
     width: min(760px, 100vw);
-  }
-
-  .upcoming-date {
-    padding-right: 0;
-    border-right: 0;
   }
 
   .hero-data {
@@ -2862,12 +2344,6 @@ image-slot:hover {
     padding: 24px 20px 40px;
   }
 
-  .detail-meta-grid,
-  .detail-panel .song-detail-content .detail-meta-grid,
-  .detail-panel .release-detail-content .detail-meta-grid {
-    grid-template-columns: 1fr;
-  }
-
   .footer-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
@@ -2898,9 +2374,6 @@ image-slot:hover {
   .release-grid,
   .media-card-grid,
   .recent-posts-grid,
-  .hero-stats-grid,
-  .events-calendar,
-  .events-category-grid,
   .media-mosaic {
     grid-template-columns: 1fr;
   }
@@ -2917,13 +2390,7 @@ image-slot:hover {
     grid-template-columns: 1fr;
   }
 
-  .timeline-row {
-    grid-template-columns: 1fr;
-    justify-items: start;
-  }
-
-  .chronology-grid,
-  .detail-meta-grid {
+  .chronology-grid {
     grid-template-columns: 1fr;
   }
 


### PR DESCRIPTION
## 概要

#934 の対応をまとめた統合 PR で、子 PR 2 本を feature ブランチに集約したもの

`viewer.css` はマークアップから参照されない規則が生きている規則と交互に並び、どこまでが生きているのか分からない状態だった
メディアクエリも `1100 → 1280 → 960 → 720 → 800 → 420px` と非単調に 6 種混在しており、狭い側の指定が広い側に上書きされる帯があった

## やったこと

### #943 棚卸し (表示不変)

- 未参照の 76 ルール (約 490 行) を削除する。`events` 系 / `post-detail` 系 / `hero-symbol` 系 / `spacer` 系などが対象で、`media-mosaic-${size}` で動的生成される `media-mosaic-lg` `media-mosaic-md` は残した
- 生存セレクタと同居していた 14 ルールは、死んだセレクタだけをセレクタリストから落とす
- 削除の結果重複した `.profile-grid` `.media-list-row` を 1 ルールに統合する
- 状態クラスを `.active` から `.is-active` に統一する
- `html, body` の `padding` / `margin` と `a` のリセット指定を `reset.css` へ寄せる
- 参照ゼロの `tailwindcss` / `daisyui` / `@tailwindcss/vite` を viewer から外す。admin は `@import "tailwindcss"` と `tailwindcss()` plugin で実際に使っているため、admin 側と catalog 定義は残した

### #944 ブレークポイント整理 (表示変化あり)

- `1280 / 960 / 720 / 420px` の 4 個に集約し、max-width を降順に並べる
- `1100px` ブロックを `1280px` に、`800px` ブロックを `960px` に寄せる
- `960px` 帯に `.song-grid` の 2 カラム指定を足し、4 → 3 → 2 → 1 カラムの段階を通す

`(width <= 1280px)` が `1100px` ブロックより後ろにあったため、1100px 以下で `.song-grid` と `.media-mosaic` を 2 カラムにする指定は一度も効いていなかった。この順序バグもあわせて解消している

## 表示が変わる帯

幅ごとに「最終的に効く値」を変更前後で突き合わせた。変化は下記 4 帯に収まり、1400 / 1300 / 1050 / 1000px では変化しない

| 帯 | 変化 |
| --- | --- |
| 1101-1280px | 2 カラムセクションと detail panel が 1 段階早く畳まれる |
| 801-960px | `.shell` の左右余白が 20px に、`.section-head` が縦積みに、`.chronology-grid` が 1 カラムになる |
| 721-800px | カードグリッドが 1 カラムではなく 2 カラムになる。1 カラム化は 720px 以下に統一した |
| 720px 以下 | `.media-list-row` が `720px` ブロック本来のサムネイル + 本文の 2 カラムになる。このクラスは未提供セクションの雛形 `_index.astro` でしか使っておらず実表示への影響はない |

棚卸し分については、生きているセレクタごとに最終的に効く宣言を突き合わせ、差分が reset 集約の 2 件 (`html` と `body` の `padding` / `margin` が `reset.css` の `*` 由来に変わったのみで算出値は同じ) だけであること、生存セレクタの欠落が 0 件であることを確認した

## やってないこと

- min-width のモバイルファーストへの書き換え: max-width 記法のままなので降順に並べるのが正しい cascade になる。全面書き換えは差分と回帰リスクが大きいため見送った
- ブレークポイント値そのものの見直し: 既存の値から 4 個を選ぶに留めた
- 既存スタイルの CSS Modules / scoped style への移設: 今回は棚卸しに絞った。以後の新規スタイルを feature 単位に寄せる方針は Issue のまま残る

## 関連

- Closes #934
- #943
- #944