### PR TITLE
astro.config の vite プラグインに戻り値の型注釈を付ける

### DIFF
--- a/src/viewer/astro.config.mjs
+++ b/src/viewer/astro.config.mjs
@@ -9,6 +9,7 @@ const site = process.env.SITE_URL ?? 'https://local.isekaijoucho.fan';
 
 // @fontsource の @font-face は woff2 と woff を並記するが、woff2 に対応しないブラウザは対象外
 // Vite が URL を解決する前に woff の参照を落とし、ビルド成果物から woff ファイルごと除く
+/** @type {() => NonNullable<import('astro').ViteUserConfig['plugins']>[number]} */
 const dropLegacyWoffSource = () => ({
   name: 'drop-legacy-woff-source',
   enforce: 'pre',


### PR DESCRIPTION
## 概要

`src/viewer/astro.config.mjs` の `dropLegacyWoffSource` で `transform` の引数が implicit any になっていたので, プラグインファクトリの戻り値に型注釈を付けて解消する

## やったこと

- `dropLegacyWoffSource` の戻り値を `NonNullable<import('astro').ViteUserConfig['plugins']>[number]` として注釈した
  - `vite` は viewer の依存に含まれず `import('vite').Plugin` は解決できないため, astro が公開する `ViteUserConfig` から plugin の要素型を導出している
  - これで `code` / `id` が `string` と推論され, `this` も `TransformPluginContext` になる
  - 併せてプラグインオブジェクト自体も検査対象になり, `enforce` や `name` の誤りを型で検出できる

## やってないこと

- `vite` の devDependencies 追加: 型のためだけに依存を増やす必要がなくなったため見送った
- `@param` による個別注釈: implicit any は消えるが戻り値が検査されず, `enforce: 'bogus'` のような誤りが素通りするため採用しなかった

## 関連

- 特になし