### PR TITLE
見出し構造とサイト全体の a11y を改善する

### DIFF
--- a/src/viewer/src/components/common/BottomNav.astro
+++ b/src/viewer/src/components/common/BottomNav.astro
@@ -11,15 +11,22 @@ const { currentPath } = Astro.props;
 
 <nav class="bottom-nav" aria-label="モバイルナビゲーション">
   {
-    navLinks.map(link => (
-      <a href={link.href} class={isActivePath(currentPath, link.href) ? 'is-active' : undefined}>
-        <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-          {link.iconPaths.map(d => (
-            <path d={d} />
-          ))}
-        </svg>
-        {link.label}
-      </a>
-    ))
+    navLinks.map((link) => {
+      const isActive = isActivePath(currentPath, link.href);
+      return (
+        <a
+          href={link.href}
+          class={isActive ? 'is-active' : undefined}
+          aria-current={isActive ? 'page' : undefined}
+        >
+          <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            {link.iconPaths.map(d => (
+              <path d={d} />
+            ))}
+          </svg>
+          {link.label}
+        </a>
+      );
+    })
   }
 </nav>

--- a/src/viewer/src/components/common/Footer.astro
+++ b/src/viewer/src/components/common/Footer.astro
@@ -15,8 +15,8 @@ import { navLinks } from '../../shared/nav';
           当サイトは非公式ファンサイトです。<br />ヰ世界情緒および関係各社とは一切関係ありません。<br />当サイトで扱う楽曲・画像・映像などの著作権等はすべて各権利者に帰属します。
         </p>
       </div>
-      <div class="footer-col">
-        <h4>Archive</h4>
+      <nav class="footer-col" aria-label="サイトマップ">
+        <h2 class="footer-col-title">Archive</h2>
         <ul>
           {
             navLinks.map(link => (
@@ -26,9 +26,9 @@ import { navLinks } from '../../shared/nav';
             ))
           }
         </ul>
-      </div>
-      <div class="footer-col">
-        <h4>External</h4>
+      </nav>
+      <nav class="footer-col" aria-label="外部リンク">
+        <h2 class="footer-col-title">External</h2>
         <ul>
           <li><a href="https://www.youtube.com/@isekaijoucho" target="_blank" rel="noopener noreferrer">YouTube</a></li>
           <li><a href="https://www.youtube.com/@isekaijoucho_sub" target="_blank" rel="noopener noreferrer">YouTube(sub)</a></li>
@@ -38,14 +38,14 @@ import { navLinks } from '../../shared/nav';
           <li><a href="https://kamitsubaki.jp/artist/isekaijoucho" target="_blank" rel="noopener noreferrer">Official Site</a></li>
           <li><a href="https://linktr.ee/isekaijoucho" target="_blank" rel="noopener noreferrer">Linktree</a></li>
         </ul>
-      </div>
-      <div class="footer-col">
-        <h4>About</h4>
+      </nav>
+      <nav class="footer-col" aria-label="サイト情報">
+        <h2 class="footer-col-title">About</h2>
         <ul>
           <li><a href="/site-policy">サイトポリシー</a></li>
           <li><a href="/contact">お問い合わせ</a></li>
         </ul>
-      </div>
+      </nav>
     </div>
   </div>
 </footer>

--- a/src/viewer/src/components/common/Header.astro
+++ b/src/viewer/src/components/common/Header.astro
@@ -14,7 +14,7 @@ const { currentPath } = Astro.props;
 const defaultTheme = themeByValue(DEFAULT_PALETTE);
 ---
 
-<nav class="site-nav">
+<nav class="site-nav" aria-label="メインナビゲーション">
   <div class="nav-inner">
     <a class="brand" href="/">
       <img class="brand-logo brand-logo-dark" src="/logo-dark.svg" alt="" width="300" height="200" />
@@ -27,11 +27,18 @@ const defaultTheme = themeByValue(DEFAULT_PALETTE);
     <EnvironmentBadge />
     <div class="nav-links">
       {
-        navLinks.map(link => (
-          <a href={link.href} class={isActivePath(currentPath, link.href) ? 'is-active' : undefined}>
-            {link.label}
-          </a>
-        ))
+        navLinks.map((link) => {
+          const isActive = isActivePath(currentPath, link.href);
+          return (
+            <a
+              href={link.href}
+              class={isActive ? 'is-active' : undefined}
+              aria-current={isActive ? 'page' : undefined}
+            >
+              {link.label}
+            </a>
+          );
+        })
       }
     </div>
     <div class="nav-utils">

--- a/src/viewer/src/components/viewer/FilterBar.tsx
+++ b/src/viewer/src/components/viewer/FilterBar.tsx
@@ -58,8 +58,9 @@ export default function FilterBar(props: Props) {
         <div class="viewer-filters-spacer" />
         <input
           class="viewer-search"
-          type="text"
+          type="search"
           placeholder={props.searchPlaceholder}
+          aria-label={props.searchPlaceholder}
           value={query()}
           onInput={event => setQuery(event.currentTarget.value)}
         />

--- a/src/viewer/src/components/viewer/SectionHead.astro
+++ b/src/viewer/src/components/viewer/SectionHead.astro
@@ -1,15 +1,17 @@
 ---
 interface Props {
   title: string;
+  level?: 1 | 2 | 3 | 4 | 5 | 6;
 }
 
-const { title } = Astro.props;
+const { title, level = 2 } = Astro.props;
+const HeadingTag = `h${level}` as 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 ---
 
 <div class="section-head">
   <div class="section-head-left">
     <div>
-      <h2 class="section-title">{title}</h2>
+      <HeadingTag class="section-title">{title}</HeadingTag>
     </div>
   </div>
   <div>

--- a/src/viewer/src/components/viewer/TrackChip.astro
+++ b/src/viewer/src/components/viewer/TrackChip.astro
@@ -22,7 +22,7 @@ const trackNo = String(track.trackNo).padStart(2, '0');
         </a>
       )
     : (
-        <div class="rel-chip" aria-disabled="true">
+        <div class="rel-chip" data-unlinked>
           <span class="detail-index">{trackNo}</span>
           <div class="rel-copy">
             <div class="rel-main">{track.title}</div>

--- a/src/viewer/src/layouts/Layout.astro
+++ b/src/viewer/src/layouts/Layout.astro
@@ -67,8 +67,9 @@ const noindex = import.meta.env.SITE_NOINDEX === 'true';
     </script>
   </head>
   <body>
+    <a class="skip-link" href="#main-content">メインコンテンツへスキップ</a>
     <Header currentPath={Astro.url.pathname} />
-    <main>
+    <main id="main-content">
       <slot />
     </main>
     <Footer />

--- a/src/viewer/src/pages/contact.astro
+++ b/src/viewer/src/pages/contact.astro
@@ -6,7 +6,7 @@ import { CONTACT_X_HANDLE, CONTACT_X_URL } from '../shared/contact';
 
 <Layout pageTitle="お問い合わせ" pageDescription="ヰ世界観測所のお問い合わせ">
   <section class="shell page-section">
-    <SectionHead title="お問い合わせ" />
+    <SectionHead title="お問い合わせ" level={1} />
 
     <div class="policy-doc">
       <p>

--- a/src/viewer/src/pages/index.astro
+++ b/src/viewer/src/pages/index.astro
@@ -22,7 +22,7 @@ const siteStats = await siteStatsRepository.get();
 <Layout pageTitle="">
   <section class="hero-data">
     <div class="shell">
-      <div class="hero-mark hero-mark-data">ヰ世界観測所</div>
+      <h1 class="hero-mark hero-mark-data">ヰ世界観測所</h1>
       <div class="hero-tagline">ヰ世界情緒の非公式ファンサイト</div>
       <div class="hero-ledger">
         <div class="hero-ledger-row">
@@ -49,7 +49,7 @@ const siteStats = await siteStatsRepository.get();
       <section class="shell">
         <SectionHead title="最新楽曲" />
         <div class="feature-grid-link">
-          <a href={`/songs/${latestSong.songId}`} class="feature-art-link">
+          <a href={`/songs/${latestSong.songId}`} class="feature-art-link" aria-label={latestSong.title}>
             <SongTile
               songId={latestSong.songId}
               title={latestSong.title}

--- a/src/viewer/src/pages/media/_index.astro
+++ b/src/viewer/src/pages/media/_index.astro
@@ -18,7 +18,7 @@ const featured = videos[0];
 
 <Layout pageTitle="メディア" pageDescription="ヰ世界情緒のメディア一覧">
   <section class="shell page-section">
-    <SectionHead title="メディア">
+    <SectionHead title="メディア" level={1}>
       <LayoutSwitcher
         client:load
         slot="right"

--- a/src/viewer/src/pages/releases/index.astro
+++ b/src/viewer/src/pages/releases/index.astro
@@ -13,7 +13,7 @@ const releaseGroups = await releaseGroupContentRepository.all();
 
 <Layout pageTitle="リリース" pageDescription="ヰ世界情緒のリリース一覧">
   <section class="shell page-section">
-    <SectionHead title="リリース" />
+    <SectionHead title="リリース" level={1} />
 
     <FilterBar
       client:load

--- a/src/viewer/src/pages/site-policy.astro
+++ b/src/viewer/src/pages/site-policy.astro
@@ -8,7 +8,7 @@ const LAST_UPDATED = '2026年6月14日';
 
 <Layout pageTitle="サイトポリシー" pageDescription="ヰ世界観測所のサイトポリシー">
   <section class="shell page-section">
-    <SectionHead title="サイトポリシー" />
+    <SectionHead title="サイトポリシー" level={1} />
 
     <div class="policy-doc">
       <div class="label-mono policy-updated">最終更新日：{LAST_UPDATED}</div>

--- a/src/viewer/src/pages/songs/index.astro
+++ b/src/viewer/src/pages/songs/index.astro
@@ -11,7 +11,7 @@ const songs = await songContentRepository.all();
 
 <Layout pageTitle="楽曲" pageDescription="ヰ世界情緒の楽曲一覧">
   <section class="shell page-section">
-    <SectionHead title="楽曲" />
+    <SectionHead title="楽曲" level={1} />
 
     <FilterBar
       client:load

--- a/src/viewer/src/styles/viewer.css
+++ b/src/viewer/src/styles/viewer.css
@@ -8,7 +8,7 @@
   --bg-elev-2: #1c1c21;
   --fg: #f4f4f5;
   --fg-muted: #939395;
-  --fg-faint: #5e5e60;
+  --fg-faint: #808082;
   --line: #353537;
   --line-soft: #232325;
   --accent: #d31b28;
@@ -31,7 +31,7 @@
   --bg-elev-2: #1c1c21;
   --fg: #f4f4f5;
   --fg-muted: #939395;
-  --fg-faint: #5e5e60;
+  --fg-faint: #808082;
   --line: #353537;
   --line-soft: #232325;
   --accent: #d31b28;
@@ -54,7 +54,7 @@
   --bg-elev-2: #e2d9dc;
   --fg: #1e1f22;
   --fg-muted: #777678;
-  --fg-faint: #a8a6a7;
+  --fg-faint: #727274;
   --line: #cfcbcb;
   --line-soft: #e0dbdc;
   --accent: #60c3d0;
@@ -77,7 +77,7 @@
   --bg-elev-2: #d2e6ff;
   --fg: #1a1d20;
   --fg-muted: #76797c;
-  --fg-faint: #a8abae;
+  --fg-faint: #727477;
   --line: #d0d2d5;
   --line-soft: #e1e3e6;
   --accent: #1c8bf4;
@@ -100,7 +100,7 @@
   --bg-elev-2: #1c2029;
   --fg: #f1f3f6;
   --fg-muted: #939599;
-  --fg-faint: #5f6166;
+  --fg-faint: #808284;
   --line: #37393e;
   --line-soft: #25272c;
   --accent: #1d70ec;
@@ -123,7 +123,7 @@
   --bg-elev-2: #fef9c3;
   --fg: #1e201e;
   --fg-muted: #7a7b79;
-  --fg-faint: #adadaa;
+  --fg-faint: #727774;
   --line: #d5d4d1;
   --line-soft: #e6e5e3;
   --accent: #fad423;
@@ -148,7 +148,7 @@
   --bg-elev-2: #222227;
   --fg: #f3f4f6;
   --fg-muted: #939496;
-  --fg-faint: #5f5f61;
+  --fg-faint: #808284;
   --line: #363638;
   --line-soft: #242426;
   --accent: #c5a358;
@@ -195,6 +195,47 @@ body {
 ::selection {
   color: var(--fg);
   background: color-mix(in oklab, var(--accent) 40%, transparent);
+}
+
+/* キーボード操作時のフォーカス表示 */
+
+.skip-link {
+  position: absolute;
+  top: -100%;
+  left: 16px;
+  z-index: 200;
+  padding: 10px 18px;
+  font-family: "Noto Serif JP", serif;
+  font-size: 14px;
+  color: var(--accent-contrast);
+  letter-spacing: 0.06em;
+  text-decoration: none;
+  background: var(--accent);
+  border-radius: 0 0 6px 6px;
+  transition: top 0.15s ease;
+}
+
+.skip-link:focus {
+  top: 0;
+}
+
+:focus {
+  outline: none;
+}
+
+:focus-visible {
+  outline: 2px solid var(--accent-strong);
+  outline-offset: 2px;
+}
+
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+[tabindex]:not([tabindex="-1"]):focus-visible {
+  outline: 2px solid var(--accent-strong);
+  outline-offset: 2px;
 }
 
 .font-en {
@@ -860,6 +901,7 @@ image-slot:hover {
   flex-wrap: wrap;
   gap: 8px;
   align-items: center;
+  max-width: 100%;
   margin-bottom: 32px;
 }
 
@@ -875,18 +917,17 @@ image-slot:hover {
 
 .viewer-search {
   min-width: 280px;
+  max-width: 100%;
   padding: 8px 16px;
   font-family: "Noto Serif JP", serif;
   font-size: 13px;
   color: var(--fg);
-  outline: none;
   background: var(--bg-elev);
   border: 1px solid var(--line);
 }
 
-.viewer-search,
-.viewer-filters {
-  max-width: 100%;
+.viewer-search:focus-visible {
+  border-color: var(--accent);
 }
 
 .footer-brand {
@@ -911,7 +952,7 @@ image-slot:hover {
   color: var(--fg-muted);
 }
 
-.footer-col h4 {
+.footer-col-title {
   margin: 0 0 16px;
   font-family: "JetBrains Mono", monospace;
   font-size: 11px;
@@ -1203,13 +1244,15 @@ image-slot:hover {
   transform: translateX(2px);
 }
 
-.rel-chip[aria-disabled="true"] {
+.rel-chip[data-unlinked] {
   cursor: default;
+  border-left: 2px dashed var(--line);
+  opacity: 0.72;
 }
 
-.rel-chip[aria-disabled="true"]:hover {
+.rel-chip[data-unlinked]:hover {
   background: var(--bg-elev-2);
-  border-color: transparent;
+  border-color: var(--line);
   transform: none;
 }
 
@@ -1395,6 +1438,7 @@ image-slot:hover {
 }
 
 .hero-mark {
+  margin: 0;
   font-family: "Shippori Mincho", serif;
   font-size: clamp(56px, 9vw, 128px);
   line-height: 1;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

閲覧サイトの見出し階層・キーボード操作・スクリーンリーダー対応を改善し、WCAG 観点での基本的なアクセシビリティを底上げします。

## やったこと

- `SectionHead` に `level` prop（既定 2）を追加し、一覧ページの主見出しを h1 に変更
- トップページのサイト名を `h1` 化し、最新楽曲のアートリンクに `aria-label` を付与
- スキップリンクと `main#main-content` を `Layout` に追加
- 共通の `:focus-visible` スタイルと検索欄のフォーカス表示を追加
- ヘッダー・ボトムナビの現在地リンクに `aria-current="page"` を付与し、ナビに `aria-label` を追加
- フッターのリンク集合を `nav` 要素化し、見出しを h2 に整理
- 非リンクのトラック行の `aria-disabled` を `data-unlinked` に置き換え、破線ボーダーと不透明度で視覚的手掛かりを追加
- 全パレットの `--fg-faint` トークンをコントラスト基準に合わせて調整

## やってないこと

- 詳細ページ（楽曲・リリース・メディア）の見出し構造変更（既に h1 あり）
- 自動 a11y 監査ツールの導入

## 関連

- #929

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7939b7fc-1b7c-42e6-b624-ab178e9db7e6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7939b7fc-1b7c-42e6-b624-ab178e9db7e6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

