### PR TITLE
hydration 戦略と prefetch を最適化する

### DIFF
--- a/src/viewer/astro.config.mjs
+++ b/src/viewer/astro.config.mjs
@@ -30,6 +30,11 @@ export default defineConfig({
     port: port,
     allowedHosts: ['local.isekaijoucho.fan'],
   },
+  // 一覧カードのクリックは DetailDrawer が fragment を取りに行くので、ページ全体の先読みは
+  // 実際に遷移するリンク (ナビ) だけに絞る。opt-in にするため prefetchAll は既定の false のまま
+  prefetch: {
+    defaultStrategy: 'hover',
+  },
   integrations: [
     solidJs(),
     sitemap({

--- a/src/viewer/src/components/common/BottomNav.astro
+++ b/src/viewer/src/components/common/BottomNav.astro
@@ -18,6 +18,7 @@ const { currentPath } = Astro.props;
           href={link.href}
           class={isActive ? 'is-active' : undefined}
           aria-current={isActive ? 'page' : undefined}
+          data-astro-prefetch
         >
           <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
             {link.iconPaths.map(d => (

--- a/src/viewer/src/components/common/Header.astro
+++ b/src/viewer/src/components/common/Header.astro
@@ -34,6 +34,7 @@ const defaultTheme = themeByValue(DEFAULT_PALETTE);
               href={link.href}
               class={isActive ? 'is-active' : undefined}
               aria-current={isActive ? 'page' : undefined}
+              data-astro-prefetch
             >
               {link.label}
             </a>

--- a/src/viewer/src/components/viewer/DetailDrawer.tsx
+++ b/src/viewer/src/components/viewer/DetailDrawer.tsx
@@ -11,6 +11,8 @@ interface DrawerTarget {
 }
 
 const maxCachedFragments = 8;
+// 指してすぐには取りにいかない Astro の prefetch (hover) と同じ猶予に揃える
+const hoverPrefetchDelay = 80;
 const fragmentHtmlCache = new Map<string, string>();
 const fragmentRequestCache = new Map<string, Promise<string>>();
 
@@ -109,6 +111,8 @@ export const DetailDrawer = () => {
   const [shareLabel, setShareLabel] = createSignal('共有');
   let loadSequence = 0;
   let bodyRef: HTMLDivElement | undefined;
+  let prefetchTimer = 0;
+  let prefetchPath = '';
 
   const current = createMemo(() => {
     const items = stack();
@@ -214,14 +218,23 @@ export const DetailDrawer = () => {
     }
   };
 
+  // 一覧の上を横切っただけのカードは、次のカードに入った時点で予約が取り消されるので取得しない
   // 取得済み / 取得中なら fetchTargetFragment 側のキャッシュで即返るので、同じリンクを何度指しても無害
   const handlePrefetch = (event: Event) => {
     if (!prefetchAllowed()) return;
 
     const target = resolveAnchorTarget(event.target);
-    if (!target) return;
+    // 同じリンクの中での移動では取り直さない
+    if (target !== null && target.fragmentPath === prefetchPath) return;
 
-    void fetchTargetFragment(target).catch(() => {});
+    window.clearTimeout(prefetchTimer);
+    prefetchPath = target?.fragmentPath ?? '';
+
+    if (target === null) return;
+
+    prefetchTimer = window.setTimeout(() => {
+      void fetchTargetFragment(target).catch(() => {});
+    }, hoverPrefetchDelay);
   };
 
   onMount(() => {
@@ -235,6 +248,7 @@ export const DetailDrawer = () => {
       document.removeEventListener('pointerover', handlePrefetch);
       document.removeEventListener('focusin', handlePrefetch);
       window.removeEventListener('keydown', handleKeyDown);
+      window.clearTimeout(prefetchTimer);
     };
   });
 

--- a/src/viewer/src/components/viewer/DetailDrawer.tsx
+++ b/src/viewer/src/components/viewer/DetailDrawer.tsx
@@ -89,6 +89,19 @@ const fetchTargetFragment = (target: DrawerTarget): Promise<string> => {
   return request;
 };
 
+// 一覧カードのクリックはページ遷移ではなく fragment の取得になるので、先読みも fragment を対象にする
+// Save-Data と低速回線では通信を増やさない
+const prefetchAllowed = (): boolean => {
+  const { connection } = navigator as Navigator & {
+    connection?: { saveData?: boolean; effectiveType?: string };
+  };
+
+  if (connection === undefined) return true;
+  if (connection.saveData === true) return false;
+
+  return connection.effectiveType === undefined || !connection.effectiveType.includes('2g');
+};
+
 export const DetailDrawer = () => {
   const [stack, setStack] = createSignal<DrawerTarget[]>([]);
   const [content, setContent] = createSignal('');
@@ -201,12 +214,26 @@ export const DetailDrawer = () => {
     }
   };
 
+  // 取得済み / 取得中なら fetchTargetFragment 側のキャッシュで即返るので、同じリンクを何度指しても無害
+  const handlePrefetch = (event: Event) => {
+    if (!prefetchAllowed()) return;
+
+    const target = resolveAnchorTarget(event.target);
+    if (!target) return;
+
+    void fetchTargetFragment(target).catch(() => {});
+  };
+
   onMount(() => {
     document.addEventListener('click', handleDocumentClick);
+    document.addEventListener('pointerover', handlePrefetch);
+    document.addEventListener('focusin', handlePrefetch);
     window.addEventListener('keydown', handleKeyDown);
 
     return () => {
       document.removeEventListener('click', handleDocumentClick);
+      document.removeEventListener('pointerover', handlePrefetch);
+      document.removeEventListener('focusin', handlePrefetch);
       window.removeEventListener('keydown', handleKeyDown);
     };
   });

--- a/src/viewer/src/components/viewer/EntryStatus.tsx
+++ b/src/viewer/src/components/viewer/EntryStatus.tsx
@@ -3,6 +3,8 @@ import { createSignal, onCleanup, onMount } from 'solid-js';
 type Props = {
   entrySelector: string;
   emptySelector?: string;
+  // SSR 時点の件数 hydration が遅れても 0 件と表示しないために渡す
+  initialCount?: number;
 };
 
 function countMatchedEntries(selector: string): number {
@@ -12,7 +14,7 @@ function countMatchedEntries(selector: string): number {
 }
 
 export default function EntryStatus(props: Props) {
-  const [count, setCount] = createSignal(0);
+  const [count, setCount] = createSignal(props.initialCount ?? 0);
 
   const updateCount = () => {
     const nextCount = countMatchedEntries(props.entrySelector);

--- a/src/viewer/src/components/viewer/FilterBar.tsx
+++ b/src/viewer/src/components/viewer/FilterBar.tsx
@@ -17,10 +17,19 @@ type Props = {
 export default function FilterBar(props: Props) {
   const [filter, setFilter] = createSignal(props.defaultFilter ?? 'all');
   const [query, setQuery] = createSignal('');
+  // 絞り込みのない初回は SSR の DOM と結果が同じなので、全 entry の走査ごと省く
+  let firstRun = true;
 
   createEffect(() => {
     const f = filter();
     const q = query().trim().toLowerCase();
+    const skipInitialScan = firstRun && f === 'all' && q === '';
+    firstRun = false;
+
+    if (skipInitialScan) {
+      return;
+    }
+
     const entries = document.querySelectorAll(props.entrySelector);
 
     for (const entry of entries) {

--- a/src/viewer/src/layouts/Layout.astro
+++ b/src/viewer/src/layouts/Layout.astro
@@ -84,6 +84,7 @@ const trail: readonly BreadcrumbItem[] = breadcrumbs.length > 0 ? [{ label: 'ホ
     </main>
     <Footer />
     <BottomNav currentPath={Astro.url.pathname} />
-    <DetailDrawer client:load />
+    {/* 初期状態は何も描画しないので初回ペイントには不要 遅れている間のクリックは通常遷移になる */}
+    <DetailDrawer client:idle />
   </body>
 </html>

--- a/src/viewer/src/pages/releases/index.astro
+++ b/src/viewer/src/pages/releases/index.astro
@@ -16,7 +16,7 @@ const releaseGroups = await releaseGroupContentRepository.all();
     <SectionHead title="リリース" level={1} />
 
     <FilterBar
-      client:load
+      client:idle
       filters={[
         { value: 'all', label: `すべて` },
         { value: '2', label: 'アルバム' },
@@ -30,7 +30,12 @@ const releaseGroups = await releaseGroupContentRepository.all();
       searchPlaceholder="タイトル・種別・収録曲を検索..."
     />
 
-    <EntryStatus client:load entrySelector="[data-release-entry]" emptySelector="[data-release-empty]" />
+    <EntryStatus
+      client:idle
+      entrySelector="[data-release-entry]"
+      emptySelector="[data-release-empty]"
+      initialCount={releaseGroups.length}
+    />
 
     <div class="release-grid">
       <div class="entry-empty entry-empty-panel" data-release-empty hidden>

--- a/src/viewer/src/pages/songs/index.astro
+++ b/src/viewer/src/pages/songs/index.astro
@@ -14,7 +14,7 @@ const songs = await songContentRepository.all();
     <SectionHead title="楽曲" level={1} />
 
     <FilterBar
-      client:load
+      client:idle
       filters={[
         { value: 'all', label: `すべて` },
         { value: '1', label: 'オリジナル曲' },
@@ -26,7 +26,12 @@ const songs = await songContentRepository.all();
       searchPlaceholder="タイトル・作者を検索..."
     />
 
-    <EntryStatus client:load entrySelector="[data-song-entry]" emptySelector="[data-song-empty]" />
+    <EntryStatus
+      client:idle
+      entrySelector="[data-song-entry]"
+      emptySelector="[data-song-empty]"
+      initialCount={songs.length}
+    />
 
     <div class="song-grid">
       <div class="entry-empty entry-empty-panel" data-song-empty hidden>


### PR DESCRIPTION
## 概要

一覧ページの初期表示を塞いでいた JS の実行タイミングを後ろに倒し、一覧 → 詳細の動線に先読みを入れる

## やったこと

- `DetailDrawer` / `FilterBar` / `EntryStatus` を `client:idle` に変更した
  - いずれも初回ペイントに寄与しないため、`client:load` で最優先ロードする必要がなかった
  - `FilterBar` は一覧のファーストビュー内にあり `client:visible` が実質 `client:load` と同着になるので `client:idle` を選んだ
- `EntryStatus` に `initialCount` を渡し、hydration 前に「0 件」と表示しないようにした
  - hydration を遅らせると誤った件数の表示時間が延びるため、SSR 時点の件数を初期値にした
- `FilterBar` の初回 effect で、絞り込みがない場合は全 entry の走査を省くようにした
  - 走査結果が SSR 済みの DOM と一致するため、楽曲一覧では 369 件の `querySelectorAll` と `style` 書き換えがまるごと不要になる
- `prefetch` を `defaultStrategy: 'hover'` で有効にし、Header / BottomNav のナビリンクだけ `data-astro-prefetch` で opt-in させた
- 一覧カードの hover / focus で詳細 fragment を先読みするようにした
  - カードのクリックは `DetailDrawer` が横取りして `/fragments/...` を取得するため、Astro の prefetch で詳細ページ全体を先読みしても使われない
  - 既存の fragment キャッシュをそのまま使うので、クリック時はキャッシュヒットになりスケルトンの表示時間が縮む
  - 指してから 80ms 経過したものだけ取得する。別のカードに入った時点で前の予約は取り消されるので、一覧の上を横切っただけのカードは取得しない (Astro の hover 戦略と同じ猶予)
  - Save-Data と低速回線では先読みしない

## やってないこと

- `prefetchAll: true` にはしていない
  - 一覧カードのリンクを Astro に先読みさせると、実際には使われない詳細ページ全体を取得することになるため
- 一覧カードへの `data-astro-prefetch` 付与はしていない
  - 先読みしたい対象が `href` (詳細ページ) ではなく fragment のため、Astro の仕組みには乗せられない
- `media/_index.astro` の `client:load` は変更していない
  - `_` 始まりでルートに含まれない未提供ページの雛形であり、ビルド成果物に入らないため
- ブラウザでの実挙動の確認
  - hydration 前のクリックが通常遷移になること、hover 先読みが効くことは未確認

## 関連

- Closes #924