### PR TITLE
画像の読み込み属性を整備して一覧の描画コストを下げる

### DIFF
--- a/src/viewer/src/components/viewer/JacketArt.astro
+++ b/src/viewer/src/components/viewer/JacketArt.astro
@@ -7,6 +7,8 @@ interface Props {
   label: string;
   aspectRatio?: string;
   sizes?: string;
+  /** ファーストビューに入る画像だけ eager にする。遅延したままだと LCP が伸びる */
+  loading?: 'lazy' | 'eager';
 }
 
 // sizes は呼び出し側が表示枠に合わせて渡す
@@ -17,6 +19,7 @@ const {
   color = 'var(--accent)',
   label,
   aspectRatio = '1 / 1',
+  loading = 'lazy',
   sizes = '(max-width: 1100px) calc(100vw - 40px), calc((min(1480px, 100vw) - 160px) / 3)',
 } = Astro.props;
 ---
@@ -30,7 +33,9 @@ const {
           src={assetImageUrl(imageUrl, 640)}
           srcset={assetImageSrcset(imageUrl, JACKET_WIDTHS)}
           sizes={sizes}
-          loading="lazy"
+          loading={loading}
+          fetchpriority={loading === 'eager' ? 'high' : undefined}
+          decoding="async"
           alt={label}
         />
       )

--- a/src/viewer/src/components/viewer/SongTile.astro
+++ b/src/viewer/src/components/viewer/SongTile.astro
@@ -11,9 +11,11 @@ interface Props {
   media?: SongMedia[];
   releaseGroups?: SongReleaseGroup[];
   aspectRatio?: string;
+  /** ファーストビューに入る画像だけ eager にする。遅延したままだと LCP が伸びる */
+  loading?: 'lazy' | 'eager';
 }
 
-const { mediaCount, index, media = [], releaseGroups = [], aspectRatio = '16 / 9' } = Astro.props;
+const { mediaCount, index, media = [], releaseGroups = [], aspectRatio = '16 / 9', loading = 'lazy' } = Astro.props;
 
 // プラットフォームとサムネイルは状態として保持せず url から導出する。
 // メディアがあれば最初にサムネイルを導出できたものを採用する。
@@ -43,7 +45,9 @@ const sequence = String(index + 1).padStart(2, '0');
             src={thumbnailUrl}
             srcset={thumbnailSrcset}
             sizes="(max-width: 720px) calc(100vw - 40px), (max-width: 1100px) calc((100vw - 124px) / 2), calc((min(1480px, 100vw) - 180px) / 4)"
-            loading="lazy"
+            loading={loading}
+            fetchpriority={loading === 'eager' ? 'high' : undefined}
+            decoding="async"
             alt=""
           />
         )

--- a/src/viewer/src/components/viewer/details/MediaDetailContent.astro
+++ b/src/viewer/src/components/viewer/details/MediaDetailContent.astro
@@ -27,7 +27,9 @@ const formatPublishedAt = (value: string): string =>
               src={thumbnailUrl}
               srcset={youtubeThumbnailSrcset(thumbnailUrl)}
               sizes="(max-width: 720px) 100vw, 640px"
-              loading="lazy"
+              loading="eager"
+              fetchpriority="high"
+              decoding="async"
               alt={media.title}
             />
           )

--- a/src/viewer/src/components/viewer/details/ReleaseDetailContent.astro
+++ b/src/viewer/src/components/viewer/details/ReleaseDetailContent.astro
@@ -25,7 +25,8 @@ const isSingleReleaseGroup = releaseGroup.releases.length === 1;
                 <span class="label-mono">{release.formats.map(format => format.name).join('・')}</span>
               </div>
               <div class="release-version-body">
-                <ReleaseVersionBody release={release} releaseGroupTitle={releaseGroup.title} />
+                {/* 単一リリースのジャケットは常に開いた状態でファーストビューに入るため eager にする */}
+                <ReleaseVersionBody release={release} releaseGroupTitle={releaseGroup.title} loading="eager" />
               </div>
             </section>
           )

--- a/src/viewer/src/components/viewer/details/ReleaseVersionBody.astro
+++ b/src/viewer/src/components/viewer/details/ReleaseVersionBody.astro
@@ -5,16 +5,18 @@ import JacketArt from '../JacketArt.astro';
 interface Props {
   release: Release;
   releaseGroupTitle: string;
+  /** ファーストビューに入る画像だけ eager にする。遅延したままだと LCP が伸びる */
+  loading?: 'lazy' | 'eager';
 }
 
-const { release, releaseGroupTitle } = Astro.props;
+const { release, releaseGroupTitle, loading = 'lazy' } = Astro.props;
 ---
 
 <div class={release.jacketArtUrl ? 'release-version-content has-jacket' : 'release-version-content'}>
   {
     release.jacketArtUrl && (
       <div class="release-version-art">
-        <JacketArt imageUrl={release.jacketArtUrl} label={`${releaseGroupTitle} ${release.name}`} aspectRatio="auto" sizes="160px" />
+        <JacketArt imageUrl={release.jacketArtUrl} label={`${releaseGroupTitle} ${release.name}`} aspectRatio="auto" sizes="160px" loading={loading} />
       </div>
     )
   }

--- a/src/viewer/src/components/viewer/details/SongDetailContent.astro
+++ b/src/viewer/src/components/viewer/details/SongDetailContent.astro
@@ -67,7 +67,10 @@ const formatPublishedAt = (value: string): string =>
                           src={assetImageUrl(releaseGroup.jacketArtUrl, 320)}
                           srcset={assetImageSrcset(releaseGroup.jacketArtUrl, JACKET_WIDTHS)}
                           sizes="96px"
+                          width="96"
+                          height="54"
                           loading="lazy"
+                          decoding="async"
                           alt={releaseGroup.title}
                         />
                       )
@@ -116,7 +119,10 @@ const formatPublishedAt = (value: string): string =>
                           src={thumbnailUrl}
                           srcset={youtubeThumbnailSrcset(thumbnailUrl)}
                           sizes="96px"
+                          width="96"
+                          height="54"
                           loading="lazy"
+                          decoding="async"
                           alt={entry.title}
                         />
                       )

--- a/src/viewer/src/pages/index.astro
+++ b/src/viewer/src/pages/index.astro
@@ -57,6 +57,7 @@ const siteStats = await siteStatsRepository.get();
               media={latestSong.media}
               releaseGroups={latestSong.releaseGroups}
               aspectRatio="1 / 1"
+              loading="eager"
             />
           </a>
           <div class="feature-body">
@@ -82,7 +83,6 @@ const siteStats = await siteStatsRepository.get();
               imageUrl={representativeJacketArtUrl(latestReleaseGroup)}
               label={latestReleaseGroup.title}
               sizes="(max-width: 1100px) calc(100vw - 40px), 320px"
-              loading="eager"
             />
           </a>
           <div class="feature-body">

--- a/src/viewer/src/pages/index.astro
+++ b/src/viewer/src/pages/index.astro
@@ -82,6 +82,7 @@ const siteStats = await siteStatsRepository.get();
               imageUrl={representativeJacketArtUrl(latestReleaseGroup)}
               label={latestReleaseGroup.title}
               sizes="(max-width: 1100px) calc(100vw - 40px), 320px"
+              loading="eager"
             />
           </a>
           <div class="feature-body">

--- a/src/viewer/src/pages/releases/index.astro
+++ b/src/viewer/src/pages/releases/index.astro
@@ -38,7 +38,7 @@ const releaseGroups = await releaseGroupContentRepository.all();
         <div class="entry-empty-description">検索語句や種別フィルタを変えて確認してください。</div>
       </div>
       {
-        releaseGroups.map((releaseGroup) => {
+        releaseGroups.map((releaseGroup, index) => {
           const trackTitles = releaseGroup.releases
             .flatMap(release => release.media.flatMap(medium => medium.tracks.map(track => track.title)));
           const formatNames = groupFormats(releaseGroup).map(format => format.name);
@@ -55,6 +55,7 @@ const releaseGroups = await releaseGroupContentRepository.all();
                 imageUrl={representativeJacketArtUrl(releaseGroup)}
                 label={releaseGroup.title}
                 sizes="(max-width: 720px) calc(100vw - 40px), (max-width: 1100px) calc((100vw - 128px) / 2), calc((min(1480px, 100vw) - 160px) / 3)"
+                loading={index === 0 ? 'eager' : 'lazy'}
               />
               <div class="release-card-body">
                 <div class="release-card-meta">

--- a/src/viewer/src/pages/songs/index.astro
+++ b/src/viewer/src/pages/songs/index.astro
@@ -50,6 +50,7 @@ const songs = await songContentRepository.all();
                 index={index}
                 media={song.media}
                 releaseGroups={song.releaseGroups}
+                loading={index === 0 ? 'eager' : 'lazy'}
               />
               <div class="song-grid-body">
                 <div class="song-grid-meta">

--- a/src/viewer/src/styles/viewer.css
+++ b/src/viewer/src/styles/viewer.css
@@ -1726,6 +1726,17 @@ image-slot:hover {
   display: block;
 }
 
+/* 一覧は 300 件超を一度に描くので、画面外のカードはレイアウトと描画を省く
+   高さは auto で実測値を再利用させ、初回だけ概算値を使う */
+
+.song-grid-card,
+.release-card {
+  /* auto 付きを解釈しないブラウザ向けに固定値を先に置く。未指定だと画面外カードが高さ 0 に潰れる */
+  contain-intrinsic-size: 260px;
+  contain-intrinsic-size: auto 260px;
+  content-visibility: auto;
+}
+
 .media-card-body,
 .song-grid-body,
 .release-card-body {


### PR DESCRIPTION
## 概要

closes #925

base は #958 (画像配信) です

LCP 要素が `loading="lazy"` のままだと発見が遅れて LCP が伸びる
ファーストビューに入る画像だけ `eager` + `fetchpriority="high"` にする

## 計測結果 (本番, n=9)

| ページ | mobile LCP | desktop LCP |
| --- | --- | --- |
| songs-index | 13109→**3466** (-74%) | 3427→**1039** (-70%) |
| media-detail | 7180→**2440** (-66%) | 2383→**850** (-64%) |
| release-detail | 5235→**2174** (-58%) | 1695→**640** (-62%) |
| releases-index | 9581→**4419** (-54%) | 2875→2443 (-15%) |

フォント self-host で FCP が 1.4 秒早まった結果、画像の取得が相対的にボトルネックとして前面に出ていた
その分をここで回収している

## eager は LCP 要素に付けないと逆効果になる

トップの LCP 要素は最新リリースのジャケットではなく、最新楽曲のサムネイル (`img.song-tile-image`) だった
最初にジャケットを eager にしたところ、そちらが優先されて本来の LCP 要素が後ろにずれた

| | 修正前 | 誤って eager にしたとき |
| --- | --- | --- |
| ジャケット | start=252ms | start=132ms |
| サムネイル (LCP 要素) | start=252ms | **start=287ms** |

付け替えた結果、top mobile の LCP は 7385→3357 (-55%)、IQR も 1222 まで下がった

## 変更点

- `JacketArt` / `SongTile` / `ReleaseVersionBody` に `loading` prop を追加
- media 詳細のサムネイル、トップのヒーロー、各一覧の先頭カード、単一リリースのジャケットを eager にする
  - 折りたたまれた `<details>` 内のジャケットは lazy のまま
- 全ての `img` に `decoding="async"`
- 96px 枠のサムネイルに `width` / `height` を明示して CLS を抑える
- 一覧カードに `content-visibility: auto` と `contain-intrinsic-size`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0144Sq4m8X69oz1PZZt2C6QT