### PR TITLE
ナビ定義を一元化して UI 描画の重複を解消する

### DIFF
--- a/src/viewer/src/components/common/BottomNav.astro
+++ b/src/viewer/src/components/common/BottomNav.astro
@@ -7,12 +7,6 @@ interface Props {
 }
 
 const { currentPath } = Astro.props;
-
-// navLinks の href に対応するアイコン
-const iconPaths: Record<string, string[]> = {
-  '/songs': ['M9 18V5l12-2v13', 'M6 21a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z', 'M18 19a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z'],
-  '/releases': ['M12 21a9 9 0 1 0 0-18 9 9 0 0 0 0 18Z', 'M12 14.5a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5Z'],
-};
 ---
 
 <nav class="bottom-nav" aria-label="モバイルナビゲーション">
@@ -20,7 +14,7 @@ const iconPaths: Record<string, string[]> = {
     navLinks.map(link => (
       <a href={link.href} class={isActivePath(currentPath, link.href) ? 'active' : undefined}>
         <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-          {(iconPaths[link.href] ?? []).map(d => (
+          {link.iconPaths.map(d => (
             <path d={d} />
           ))}
         </svg>

--- a/src/viewer/src/components/common/Footer.astro
+++ b/src/viewer/src/components/common/Footer.astro
@@ -1,3 +1,7 @@
+---
+import { navLinks } from '../../shared/nav';
+---
+
 <footer class="site-footer">
   <div class="shell">
     <div class="footer-grid">
@@ -14,12 +18,13 @@
       <div class="footer-col">
         <h4>Archive</h4>
         <ul>
-          <li><a href="/songs">楽曲</a></li>
-          <li><a href="/releases">リリース</a></li>
-          {/*
-          <li><a href="/media">メディア</a></li>
-          <li><a href="/profile">人物</a></li>
-          */}
+          {
+            navLinks.map(link => (
+              <li>
+                <a href={link.href}>{link.label}</a>
+              </li>
+            ))
+          }
         </ul>
       </div>
       <div class="footer-col">

--- a/src/viewer/src/components/viewer/TrackChip.astro
+++ b/src/viewer/src/components/viewer/TrackChip.astro
@@ -1,0 +1,32 @@
+---
+import type { ReleaseTrack } from '../../features/releases/types';
+import { isLinkableTrack } from '../../features/releases/types';
+
+interface Props {
+  track: ReleaseTrack;
+}
+
+const { track } = Astro.props;
+const trackNo = String(track.trackNo).padStart(2, '0');
+---
+
+{
+  isLinkableTrack(track)
+    ? (
+        <a class="rel-chip" href={`/songs/${track.songId}`}>
+          <span class="detail-index">{trackNo}</span>
+          <div class="rel-copy">
+            <div class="rel-main">{track.title}</div>
+          </div>
+          <span class="rel-arrow">→</span>
+        </a>
+      )
+    : (
+        <div class="rel-chip" aria-disabled="true">
+          <span class="detail-index">{trackNo}</span>
+          <div class="rel-copy">
+            <div class="rel-main">{track.title}</div>
+          </div>
+        </div>
+      )
+}

--- a/src/viewer/src/components/viewer/details/DetailSectionHead.astro
+++ b/src/viewer/src/components/viewer/details/DetailSectionHead.astro
@@ -1,0 +1,13 @@
+---
+interface Props {
+  title: string;
+  count?: number;
+}
+
+const { title, count } = Astro.props;
+---
+
+<div class="detail-section-head">
+  <span class="detail-section-head-title">{title}</span>
+  {count !== undefined && <span class="detail-section-head-count">{count}</span>}
+</div>

--- a/src/viewer/src/components/viewer/details/MediaDetailContent.astro
+++ b/src/viewer/src/components/viewer/details/MediaDetailContent.astro
@@ -1,6 +1,7 @@
 ---
 import { mediaPlatformLabel, youtubeThumbnailFromUrl, youtubeThumbnailSrcset } from '../../../features/media/labels';
 import type { MediaDetail } from '../../../features/media/types';
+import DetailSectionHead from './DetailSectionHead.astro';
 
 interface Props {
   media: MediaDetail;
@@ -52,22 +53,16 @@ const formatPublishedAt = (value: string): string =>
   {
     songs.length > 0 && (
       <>
-        <div style="display:flex;align-items:baseline;justify-content:space-between;padding-bottom:8px;margin-top:36px;margin-bottom:16px;border-bottom:1px solid var(--line);">
-          <div>
-            <span class="label-mono">SONGS</span>
-            <span style="margin-left:12px;font-family:'Shippori Mincho',serif;font-size:14px;color:var(--fg);">関連楽曲</span>
-          </div>
-          <span style="font-family:Spectral,serif;font-size:18px;font-weight:500;color:var(--accent);">{songs.length}</span>
-        </div>
+        <DetailSectionHead title="関連楽曲" count={songs.length} />
         <div class="rel-list">
           {
             songs.map(song => (
               <a class="rel-chip" href={`/songs/${song.songId}`}>
                 <div class="rel-copy">
                   <div class="rel-main">{song.title}</div>
-                  <div class="label-mono" style=" margin-top: 2px;font-size: 10px;">{song.type.name}</div>
+                  <div class="label-mono rel-sub">{song.type.name}</div>
                 </div>
-                <span style="font-size:14px;color:var(--fg-faint);">→</span>
+                <span class="rel-arrow rel-arrow-muted">→</span>
               </a>
             ))
           }

--- a/src/viewer/src/components/viewer/details/ReleaseVersionBody.astro
+++ b/src/viewer/src/components/viewer/details/ReleaseVersionBody.astro
@@ -1,6 +1,7 @@
 ---
 import type { Release } from '../../../features/releases/types';
 import JacketArt from '../JacketArt.astro';
+import TrackChip from '../TrackChip.astro';
 
 interface Props {
   release: Release;
@@ -35,24 +36,7 @@ const { release, releaseGroupTitle } = Astro.props;
               ? (
                   <div class="rel-list">
                     {medium.tracks.map(track => (
-                      track.songId !== null && track.isDisplay
-                        ? (
-                            <a class="rel-chip" href={`/songs/${track.songId}`}>
-                              <span class="detail-index" style="min-width:28px;">{String(track.trackNo).padStart(2, '0')}</span>
-                              <div class="rel-copy">
-                                <div class="rel-main">{track.title}</div>
-                              </div>
-                              <span class="rel-arrow">→</span>
-                            </a>
-                          )
-                        : (
-                            <div class="rel-chip" aria-disabled="true">
-                              <span class="detail-index" style="min-width:28px;">{String(track.trackNo).padStart(2, '0')}</span>
-                              <div class="rel-copy">
-                                <div class="rel-main">{track.title}</div>
-                              </div>
-                            </div>
-                          )
+                      <TrackChip track={track} />
                     ))}
                   </div>
                 )

--- a/src/viewer/src/components/viewer/details/SongDetailContent.astro
+++ b/src/viewer/src/components/viewer/details/SongDetailContent.astro
@@ -2,6 +2,7 @@
 import { mediaPlatformLabel, youtubeThumbnailFromUrl, youtubeThumbnailSrcset } from '../../../features/media/labels';
 import type { SongDetail } from '../../../features/songs/types';
 import { JACKET_WIDTHS, assetImageSrcset, assetImageUrl } from '../../../shared/image';
+import DetailSectionHead from './DetailSectionHead.astro';
 
 interface Props {
   song: SongDetail;
@@ -25,12 +26,7 @@ const formatPublishedAt = (value: string): string =>
   <h1 class="detail-title">{song.title}</h1>
   <p class="detail-description" style="margin-top: 24px;">{song.description}</p>
 
-  <div style="display:flex;align-items:baseline;justify-content:space-between;padding-bottom:8px;margin-top:36px;margin-bottom:16px;border-bottom:1px solid var(--line);">
-    <div>
-      <span class="label-mono">CREDITS</span>
-      <span style="margin-left:12px;font-family:'Shippori Mincho',serif;font-size:14px;color:var(--fg);">クレジット</span>
-    </div>
-  </div>
+  <DetailSectionHead title="クレジット" />
   <dl class="song-credit-grid">
     {
       creditItems.map(item => (
@@ -48,13 +44,7 @@ const formatPublishedAt = (value: string): string =>
   {
     releaseGroups.length > 0 && (
       <>
-        <div style="display:flex;align-items:baseline;justify-content:space-between;padding-bottom:8px;margin-top:36px;margin-bottom:16px;border-bottom:1px solid var(--line);">
-          <div>
-            <span class="label-mono">RELEASES</span>
-            <span style="margin-left:12px;font-family:'Shippori Mincho',serif;font-size:14px;color:var(--fg);">収録リリース</span>
-          </div>
-          <span style="font-family:Spectral,serif;font-size:18px;font-weight:500;color:var(--accent);">{releaseGroups.length}</span>
-        </div>
+        <DetailSectionHead title="収録リリース" count={releaseGroups.length} />
         <div class="rel-list">
           {
             releaseGroups.map(releaseGroup => (
@@ -79,9 +69,9 @@ const formatPublishedAt = (value: string): string =>
                 }
                 <div class="rel-copy">
                   <div class="rel-main">{releaseGroup.title}</div>
-                  <div class="label-mono" style=" margin-top: 2px;font-size: 10px;">{releaseGroup.firstReleasedOn} · {releaseGroup.type.name}</div>
+                  <div class="label-mono rel-sub">{releaseGroup.firstReleasedOn} · {releaseGroup.type.name}</div>
                 </div>
-                <span style="font-size:14px;color:var(--fg-faint);">→</span>
+                <span class="rel-arrow rel-arrow-muted">→</span>
               </a>
             ))
           }
@@ -93,13 +83,7 @@ const formatPublishedAt = (value: string): string =>
   {
     media.length > 0 && (
       <>
-        <div style="display:flex;align-items:baseline;justify-content:space-between;padding-bottom:8px;margin-top:36px;margin-bottom:16px;border-bottom:1px solid var(--line);">
-          <div>
-            <span class="label-mono">MEDIA</span>
-            <span style="margin-left:12px;font-family:'Shippori Mincho',serif;font-size:14px;color:var(--fg);">関連メディア</span>
-          </div>
-          <span style="font-family:Spectral,serif;font-size:18px;font-weight:500;color:var(--accent);">{media.length}</span>
-        </div>
+        <DetailSectionHead title="関連メディア" count={media.length} />
         <div class="rel-list">
           {media.map((entry) => {
             // プラットフォームとサムネイルは状態として保持せず url から導出する。
@@ -128,9 +112,9 @@ const formatPublishedAt = (value: string): string =>
                 }
                 <div class="rel-copy">
                   <div class="rel-main">{entry.title}</div>
-                  <div class="label-mono" style=" margin-top: 2px;font-size: 10px;">{formatPublishedAt(entry.publishedAt)} · {mediaPlatformLabel(entry.url)} · {entry.type.name}</div>
+                  <div class="label-mono rel-sub">{formatPublishedAt(entry.publishedAt)} · {mediaPlatformLabel(entry.url)} · {entry.type.name}</div>
                 </div>
-                <span style="font-size:14px;color:var(--fg-faint);">→</span>
+                <span class="rel-arrow rel-arrow-muted">→</span>
               </a>
             );
           })}

--- a/src/viewer/src/features/releases/types.ts
+++ b/src/viewer/src/features/releases/types.ts
@@ -8,6 +8,11 @@ export type ReleaseMedium = ReleaseMediumItem;
 
 export type ReleaseTrack = ReleaseTrackItem;
 
+/** トラック詳細へのリンク可否。楽曲未紐づけまたは非表示のトラックはリンクしない。 */
+export function isLinkableTrack(track: ReleaseTrack): track is ReleaseTrack & { songId: string } {
+  return track.songId !== null && track.isDisplay;
+}
+
 /** 代表ジャケット: 公開リリースを発売日順に見て最初に設定されているもの。 */
 export function representativeJacketArtUrl(releaseGroup: ReleaseGroup): string | null {
   return releaseGroup.releases.find(release => release.jacketArtUrl !== null)?.jacketArtUrl ?? null;

--- a/src/viewer/src/pages/index.astro
+++ b/src/viewer/src/pages/index.astro
@@ -2,6 +2,7 @@
 import JacketArt from '../components/viewer/JacketArt.astro';
 import SectionHead from '../components/viewer/SectionHead.astro';
 import SongTile from '../components/viewer/SongTile.astro';
+import TrackChip from '../components/viewer/TrackChip.astro';
 import { releaseGroupContentRepository } from '../features/releases/content';
 import { representativeJacketArtUrl } from '../features/releases/types';
 import { siteStatsRepository } from '../features/site-stats/api';
@@ -93,19 +94,7 @@ const siteStats = await siteStatsRepository.get();
             <div class="rel-list feature-track-list">
               {
                 (latestReleaseGroup.releases[0]?.media.flatMap(medium => medium.tracks) ?? []).slice(0, 8).map(track => (
-                  track.songId !== null && track.isDisplay
-                    ? (
-                        <a class="rel-chip" href={`/songs/${track.songId}`}>
-                          <span class="detail-index">{String(track.trackNo).padStart(2, '0')}</span>
-                          <div class="rel-main">{track.title}</div>
-                        </a>
-                      )
-                    : (
-                        <div class="rel-chip" aria-disabled="true">
-                          <span class="detail-index">{String(track.trackNo).padStart(2, '0')}</span>
-                          <div class="rel-main">{track.title}</div>
-                        </div>
-                      )
+                  <TrackChip track={track} />
                 ))
               }
             </div>

--- a/src/viewer/src/shared/nav.ts
+++ b/src/viewer/src/shared/nav.ts
@@ -1,7 +1,25 @@
 // Home はブランドロゴから遷移できるためナビには含めない
-export const navLinks = [
-  { href: '/songs', label: '楽曲' },
-  { href: '/releases', label: 'リリース' },
-  // { href: '/media', label: 'メディア' },
-  // { href: '/profile', label: '人物' },
-] as const;
+// ナビの知識 (リンク先・ラベル・アイコン) はここが Source of Truth で、Header / BottomNav / Footer はここから導出する
+
+export type NavLink = {
+  href: string;
+  label: string;
+  // BottomNav で描画する 24x24 stroke アイコンのパス
+  iconPaths: readonly string[];
+};
+
+export const navLinks: readonly NavLink[] = [
+  {
+    href: '/songs',
+    label: '楽曲',
+    iconPaths: ['M9 18V5l12-2v13', 'M6 21a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z', 'M18 19a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z'],
+  },
+  {
+    href: '/releases',
+    label: 'リリース',
+    iconPaths: ['M12 21a9 9 0 1 0 0-18 9 9 0 0 0 0 18Z', 'M12 14.5a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5Z'],
+  },
+  // 未提供ページの雛形。公開時にアイコンを決めてコメントを外す
+  // { href: '/media', label: 'メディア', iconPaths: [] },
+  // { href: '/profile', label: '人物', iconPaths: [] },
+];

--- a/src/viewer/src/styles/viewer.css
+++ b/src/viewer/src/styles/viewer.css
@@ -1341,6 +1341,43 @@ image-slot:hover {
   color: var(--accent);
 }
 
+.rel-arrow-muted {
+  color: var(--fg-faint);
+}
+
+/* チップ内の補足行 (日付・種別など) */
+
+.rel-sub {
+  margin-top: 2px;
+  font-size: 10px;
+}
+
+/* 詳細ページのセクション見出し */
+
+.detail-section-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  padding-bottom: 8px;
+  margin-top: 36px;
+  margin-bottom: 16px;
+  border-bottom: 1px solid var(--line);
+}
+
+.detail-section-head-title {
+  font-family: "Shippori Mincho", serif;
+  font-size: 14px;
+  color: var(--fg);
+  letter-spacing: 0.08em;
+}
+
+.detail-section-head-count {
+  font-family: Spectral, serif;
+  font-size: 18px;
+  font-weight: 500;
+  color: var(--accent);
+}
+
 /* ユーティリティ */
 
 .spacer-lg {
@@ -1618,6 +1655,10 @@ image-slot:hover {
   font-family: Spectral, serif;
   font-style: italic;
   color: var(--accent);
+}
+
+.rel-chip .detail-index {
+  min-width: 28px;
 }
 
 .hero-stats-grid strong {


### PR DESCRIPTION
## 概要

closes #933

base は #961 (ロゴ SVG) です

ナビゲーションの定義がヘッダーとボトムナビに重複していたため一元化する
詳細ページのセクション見出しとトラックチップもコンポーネントに切り出す

## 補足

パフォーマンス施策としては中立の想定で、単体では計測していない

#934 (`viewer.css` の棚卸し) が削除するクラスのうち 7 つがこの変更で再構成されるため、
#934 の前提として先に入れる必要がある

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0144Sq4m8X69oz1PZZt2C6QT