### PR TITLE
viewer に 404 ページを追加する

### DIFF
--- a/src/viewer/src/layouts/Layout.astro
+++ b/src/viewer/src/layouts/Layout.astro
@@ -18,9 +18,17 @@ interface Props {
   ogImage?: OgImage | null;
   /** ホームは自動で先頭に付くので、一覧から現在地までを渡す。空なら導線を出さない */
   breadcrumbs?: readonly BreadcrumbItem[];
+  /** エラーページのように、実体のある URL として索引させたくないページで立てる */
+  noindex?: boolean;
 }
 
-const { pageTitle, pageDescription = SITE_DESCRIPTION, ogImage = null, breadcrumbs = [] } = Astro.props;
+const {
+  pageTitle,
+  pageDescription = SITE_DESCRIPTION,
+  ogImage = null,
+  breadcrumbs = [],
+  noindex: pageNoindex = false,
+} = Astro.props;
 
 const generateTitle = (title: string) => {
   return title ? `${title} | ${SITE_TITLE}` : SITE_TITLE;
@@ -32,7 +40,7 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site);
 const cardImage = ogImage ?? DEFAULT_OG_IMAGE;
 const cardImageUrl = new URL(cardImage.url, Astro.site).href;
 const twitterCard = ogImage === null ? 'summary' : 'summary_large_image';
-const noindex = import.meta.env.SITE_NOINDEX === 'true';
+const noindex = pageNoindex || import.meta.env.SITE_NOINDEX === 'true';
 
 const trail: readonly BreadcrumbItem[] = breadcrumbs.length > 0 ? [{ label: 'ホーム', href: '/' }, ...breadcrumbs] : [];
 ---

--- a/src/viewer/src/pages/404.astro
+++ b/src/viewer/src/pages/404.astro
@@ -1,0 +1,18 @@
+---
+import Layout from '../layouts/Layout.astro';
+import { navLinks } from '../shared/nav';
+---
+
+<Layout pageTitle="ページが見つかりません" pageDescription="指定された URL のページは見つかりませんでした" noindex>
+  <section class="shell page-section error-page">
+    <div class="label-mono error-code">404</div>
+    <h1 class="error-title">ページが見つかりません</h1>
+    <p class="error-description">
+      指定された URL のページは、削除されたか場所が変わった可能性があります
+    </p>
+    <div class="error-actions">
+      <a class="btn" href="/">ホーム</a>
+      {navLinks.map(link => <a class="btn" href={link.href}>{link.label}</a>)}
+    </div>
+  </section>
+</Layout>

--- a/src/viewer/src/pages/404.astro
+++ b/src/viewer/src/pages/404.astro
@@ -1,6 +1,5 @@
 ---
 import Layout from '../layouts/Layout.astro';
-import { navLinks } from '../shared/nav';
 ---
 
 <Layout pageTitle="ページが見つかりません" pageDescription="指定された URL のページは見つかりませんでした" noindex>
@@ -10,9 +9,5 @@ import { navLinks } from '../shared/nav';
     <p class="error-description">
       指定された URL のページは、削除されたか場所が変わった可能性があります
     </p>
-    <div class="error-actions">
-      <a class="btn" href="/">ホーム</a>
-      {navLinks.map(link => <a class="btn" href={link.href}>{link.label}</a>)}
-    </div>
   </section>
 </Layout>

--- a/src/viewer/src/styles/viewer.css
+++ b/src/viewer/src/styles/viewer.css
@@ -2550,3 +2550,47 @@ body.drawer-lock {
   text-decoration: underline;
   text-underline-offset: 3px;
 }
+
+/* エラーページ (404) */
+
+.error-page {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-top: 96px;
+  padding-bottom: 96px;
+  text-align: center;
+}
+
+.error-code {
+  font-size: 56px;
+  line-height: 1;
+  color: var(--fg-faint);
+  letter-spacing: 0.12em;
+}
+
+.error-title {
+  margin: 24px 0 0;
+  font-family: "Shippori Mincho", serif;
+  font-size: 28px;
+  font-weight: 500;
+  line-height: 1.4;
+  color: var(--fg);
+  letter-spacing: 0.08em;
+}
+
+.error-description {
+  max-width: 560px;
+  margin: 16px 0 0;
+  font-size: 14px;
+  line-height: 1.9;
+  color: var(--fg-muted);
+}
+
+.error-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: center;
+  margin-top: 40px;
+}

--- a/src/viewer/src/styles/viewer.css
+++ b/src/viewer/src/styles/viewer.css
@@ -2586,11 +2586,3 @@ body.drawer-lock {
   line-height: 1.9;
   color: var(--fg-muted);
 }
-
-.error-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-  justify-content: center;
-  margin-top: 40px;
-}

--- a/src/viewer/wrangler.jsonc
+++ b/src/viewer/wrangler.jsonc
@@ -3,6 +3,8 @@
   "workers_dev": false,
   "preview_urls": false,
   "assets": {
-    "directory": "./dist"
+    "directory": "./dist",
+    // 静的アセットに無い URL は Astro が出力した 404.html を 404 で返す
+    "not_found_handling": "404-page"
   }
 }


### PR DESCRIPTION
## 概要

viewer で存在しない URL にアクセスしたとき、Cloudflare の既定エラー画面ではなく
サイトのレイアウトを保った 404 ページを返すようにします

## やったこと

- `src/pages/404.astro` を追加した
  内容は `404` のステータス表記・「ページが見つかりません」の見出し・説明文のみで、
  移動手段はヘッダー / ボトムナビ / フッターに任せてページ本体には導線を置いていない
- `Layout` に `noindex` prop を追加した
  `SITE_NOINDEX` 環境変数とは別に、エラーページ単位で索引対象から外せるようにしている
- `wrangler.jsonc` の `assets` に `not_found_handling: "404-page"` を指定した
  既定の `none` のままだと 404.html を出力しても配信されないため、この指定が必須
- `viewer.css` に `.error-page` 系のスタイルを追加した
  既存の `.label-mono` / `.shell.page-section` に乗せており、新しい色やフォントは足していない

確認したこと

- `mise run viewer:check` と `bun --filter viewer build` が通ること
- ビルド成果物が `dist/404.html` として出ること (`404/index.html` ではないので Cloudflare の `404-page` が拾える)
- sitemap に `/404/` が含まれないこと
- 出力 HTML に `<meta name="robots" content="noindex, nofollow">` が入ること

## やってないこと

- 500 ページは作っていない
  viewer は `wrangler.jsonc` に `main` を持たない assets 専用 Worker (完全な静的配信) なので、
  オリジンが 500 を返す経路がなく、`not_found_handling` に相当する 500 用の設定も存在しない
  `500.astro` を置いても誰にも配信されないファイルが残るだけになるため見送った
  対応するなら assets のフェッチを包む Worker スクリプトを足す構成変更が必要になる

## 関連

- #968