### PR TITLE
viewer 楽曲一覧 API の返却順を新しい順に変更する

### DIFF
--- a/src/server/packages/Song/Infrastructures/Viewer/SongQueryService.php
+++ b/src/server/packages/Song/Infrastructures/Viewer/SongQueryService.php
@@ -39,9 +39,9 @@ readonly class SongQueryService implements SongQueryServiceInterface
         if (is_string($cursor)) {
             $decoded = SongListCursor::decode($cursor);
 
-            // キーセットページング: (order_no, song_id) の昇順で cursor より後ろを取る
+            // キーセットページング: (order_no 降順, song_id 昇順) で cursor より後ろを取る
             $query = $query->where(Sql::format(
-                '(order_no > %s OR (order_no = %s AND song_id > %s))',
+                '(order_no < %s OR (order_no = %s AND song_id > %s))',
                 Sql::value($decoded->orderNo),
                 Sql::value($decoded->orderNo),
                 Sql::value($this->converter->toBin($decoded->songId)),
@@ -49,7 +49,7 @@ readonly class SongQueryService implements SongQueryServiceInterface
         }
 
         $songRows = $this->queryFactory->fetchAll(
-            $query->orderBy('order_no')
+            $query->orderBy('order_no', 'desc')
                 ->orderBy('song_id')
                 ->limit($limit + 1),
         );

--- a/src/server/tests/Feature/Api/Viewer/V1/Song/ListSongTest.php
+++ b/src/server/tests/Feature/Api/Viewer/V1/Song/ListSongTest.php
@@ -165,6 +165,50 @@ class ListSongTest extends DatabaseTestCase
             ->assertExactJson([
                 'songs' => [
                     [
+                        'songId' => $secondSongId,
+                        'title' => '海月のうた',
+                        'type' => [
+                            'name' => 'カバー曲',
+                            'value' => 2,
+                        ],
+                        'description' => '2 曲目',
+                        'lyricists' => [],
+                        'composers' => [],
+                        'arrangers' => [],
+                        'counts' => [
+                            'releaseCount' => 0,
+                            'mediaCount' => 1,
+                        ],
+                        'media' => [
+                            [
+                                'mediaId' => $visibleMediaId,
+                                'title' => '公開 MV',
+                                'type' => [
+                                    'name' => 'MV',
+                                    'value' => 1,
+                                ],
+                                'url' => 'https://example.com/public',
+                                'publishedAt' => '2024-03-01T12:00:00+09:00',
+                            ],
+                        ],
+                        'releaseGroups' => [],
+                    ],
+                ],
+                'nextCursor' => base64_encode((string)json_encode([
+                    'orderNo' => 2,
+                    'songId' => $secondSongId,
+                ], JSON_THROW_ON_ERROR)),
+            ]);
+
+        $cursor = $response->json('nextCursor');
+
+        $this->assertIsString($cursor);
+
+        $this->get(route(ViewerSongRouteMap::List, ['limit' => 1, 'cursor' => $cursor]))
+            ->assertStatus(200)
+            ->assertExactJson([
+                'songs' => [
+                    [
                         'songId' => $visibleSongId,
                         'title' => 'テスト楽曲',
                         'type' => [
@@ -213,50 +257,6 @@ class ListSongTest extends DatabaseTestCase
                                 'jacketArtUrl' => null,
                             ],
                         ],
-                    ],
-                ],
-                'nextCursor' => base64_encode((string)json_encode([
-                    'orderNo' => 1,
-                    'songId' => $visibleSongId,
-                ], JSON_THROW_ON_ERROR)),
-            ]);
-
-        $cursor = $response->json('nextCursor');
-
-        $this->assertIsString($cursor);
-
-        $this->get(route(ViewerSongRouteMap::List, ['limit' => 1, 'cursor' => $cursor]))
-            ->assertStatus(200)
-            ->assertExactJson([
-                'songs' => [
-                    [
-                        'songId' => $secondSongId,
-                        'title' => '海月のうた',
-                        'type' => [
-                            'name' => 'カバー曲',
-                            'value' => 2,
-                        ],
-                        'description' => '2 曲目',
-                        'lyricists' => [],
-                        'composers' => [],
-                        'arrangers' => [],
-                        'counts' => [
-                            'releaseCount' => 0,
-                            'mediaCount' => 1,
-                        ],
-                        'media' => [
-                            [
-                                'mediaId' => $visibleMediaId,
-                                'title' => '公開 MV',
-                                'type' => [
-                                    'name' => 'MV',
-                                    'value' => 1,
-                                ],
-                                'url' => 'https://example.com/public',
-                                'publishedAt' => '2024-03-01T12:00:00+09:00',
-                            ],
-                        ],
-                        'releaseGroups' => [],
                     ],
                 ],
             ]);

--- a/src/viewer/src/features/songs/content.ts
+++ b/src/viewer/src/features/songs/content.ts
@@ -8,7 +8,7 @@ async function all(): Promise<Song[]> {
 }
 
 async function latest(): Promise<Song | null> {
-  return latestFromCollection<SongCollectionItem>(await getCollection('songs'), 'last');
+  return latestFromCollection<SongCollectionItem>(await getCollection('songs'), 'first');
 }
 
 export const songContentRepository = {


### PR DESCRIPTION
## 概要

Viewer 向け楽曲一覧 API の返却順を `order_no` 降順（新しい順）に変更し、トップページの最新楽曲表示もそれに合わせて修正する。

## やったこと

- `SongQueryService` の一覧取得を `order_no` 降順 + キーセットページングに変更
- `ListSongTest` の期待順序を新しい順に更新
- トップの最新楽曲取得を `latestFromCollection(..., 'first')` に変更

## やってないこと

- OpenAPI 契約の変更（レスポンス shape は同一）

## 関連

- 特になし

Made with [Cursor](https://cursor.com)