### PR TITLE
Valinor mapper のキャッシュを warmup し Docker イメージに焼き込む

### DIFF
--- a/infra/development/docker/api/Dockerfile
+++ b/infra/development/docker/api/Dockerfile
@@ -33,6 +33,7 @@ COPY src/server ./
 RUN composer dump-autoload --optimize --no-dev --no-interaction \
 	# OpenAPI schema の Filesystem キャッシュをイメージに焼き込む
 	&& php artisan openapi:cache \
+	&& php artisan valinor:cache \
 	&& setcap CAP_NET_BIND_SERVICE=+eip /usr/local/bin/frankenphp \
 	# /config/caddy および /data/caddy への書き込み権限を付与
 	&& chown -R www-data:www-data /config/caddy /data/caddy \

--- a/infra/production/docker/api/Dockerfile
+++ b/infra/production/docker/api/Dockerfile
@@ -33,6 +33,7 @@ COPY src/server ./
 RUN composer dump-autoload --optimize --no-dev --no-interaction \
 	# OpenAPI schema の Filesystem キャッシュをイメージに焼き込む
 	&& php artisan openapi:cache \
+	&& php artisan valinor:cache \
 	&& setcap CAP_NET_BIND_SERVICE=+eip /usr/local/bin/frankenphp \
 	# /config/caddy および /data/caddy への書き込み権限を付与
 	&& chown -R www-data:www-data /config/caddy /data/caddy \

--- a/infra/staging/docker/api/Dockerfile
+++ b/infra/staging/docker/api/Dockerfile
@@ -33,6 +33,7 @@ COPY src/server ./
 RUN composer dump-autoload --optimize --no-dev --no-interaction \
 	# OpenAPI schema の Filesystem キャッシュをイメージに焼き込む
 	&& php artisan openapi:cache \
+	&& php artisan valinor:cache \
 	&& setcap CAP_NET_BIND_SERVICE=+eip /usr/local/bin/frankenphp \
 	# /config/caddy および /data/caddy への書き込み権限を付与
 	&& chown -R www-data:www-data /config/caddy /data/caddy \

--- a/src/server/app/Console/Commands/Valinor/CacheCommand.php
+++ b/src/server/app/Console/Commands/Valinor/CacheCommand.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\Valinor;
+
+use CuyZ\Valinor\MapperBuilder;
+use Illuminate\Console\Command;
+use Override;
+use Support\Infrastructures\Valinor\MapperBuilderFactory;
+
+class CacheCommand extends Command
+{
+    #[Override]
+    protected $signature = 'valinor:cache';
+
+    #[Override]
+    protected $description = 'Valinor mapper のキャッシュを生成する';
+
+    public function handle(MapperBuilderFactory $factory, MapperBuilder $builder): int
+    {
+        if (! $factory->isCacheEnabled()) {
+            $this->warn('この環境では Valinor のキャッシュは無効です');
+
+            return Command::SUCCESS;
+        }
+
+        /** @var list<class-string> $signatures */
+        $signatures = config()->array('valinor.warmup');
+
+        $builder->warmupCacheFor(...$signatures);
+
+        foreach ($signatures as $signature) {
+            $this->info(sprintf('%s の mapper キャッシュを生成しました', $signature));
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/server/app/Providers/Domain/SupportServiceProvider.php
+++ b/src/server/app/Providers/Domain/SupportServiceProvider.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Providers\Domain;
 
+use CuyZ\Valinor\MapperBuilder;
+use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
 use Override;
 use Support\Contracts\ClockInterface;
@@ -18,6 +20,7 @@ use Support\Infrastructures\Mapper;
 use Support\Infrastructures\Query\AuditLog\AuditLogQueryService;
 use Support\Infrastructures\Uuid\UuidConverter;
 use Support\Infrastructures\Uuid\UuidGenerator;
+use Support\Infrastructures\Valinor\MapperBuilderFactory;
 use Support\UseCase\AuditLog\AuditLogRecorderInterface;
 use Support\UseCase\AuditLog\Query\AuditLogQueryServiceInterface;
 
@@ -26,6 +29,10 @@ class SupportServiceProvider extends ServiceProvider
     #[Override]
     public function register(): void
     {
+        $this->app->singleton(
+            MapperBuilder::class,
+            static fn (Application $app): MapperBuilder => $app->make(MapperBuilderFactory::class)->create(),
+        );
         $this->app->bind(MapperInterface::class, Mapper::class);
         $this->app->bind(UuidGeneratorInterface::class, UuidGenerator::class);
         $this->app->bind(UuidConverterInterface::class, UuidConverter::class);

--- a/src/server/baseline.php
+++ b/src/server/baseline.php
@@ -2,9 +2,28 @@
 
 $ignoreErrors = [];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\.\\.\\.\\$constructors of method CuyZ\\\\Valinor\\\\MapperBuilder\\:\\:registerConstructor\\(\\) expects \\(pure\\-callable\\(\\)\\: mixed\\)\\|class\\-string, Closure\\(.*\\)\\: .*\\.$#',
+	'message' => '#^Parameter \\#1 \\.\\.\\.\\$constructors of method CuyZ\\\\Valinor\\\\MapperBuilder\\:\\:registerConstructor\\(\\) expects \\(pure\\-callable\\(\\)\\: mixed\\)\\|class\\-string, Closure\\(string, string, int\\)\\: Person\\\\Domain\\\\Models\\\\Person given\\.$#',
 	'identifier' => 'argument.type',
-	'path' => __DIR__ . '/packages/Support/Infrastructures/Mapper.php',
+	'count' => 1,
+	'path' => __DIR__ . '/packages/Support/Infrastructures/Valinor/ApplicationMapperConfigurator.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Parameter \\#1 \\.\\.\\.\\$constructors of method CuyZ\\\\Valinor\\\\MapperBuilder\\:\\:registerConstructor\\(\\) expects \\(pure\\-callable\\(\\)\\: mixed\\)\\|class\\-string, Closure\\(string, string, string, DateTimeImmutable, int\\)\\: Auth\\\\Domain\\\\Models\\\\Token\\\\RefreshToken\\\\RefreshToken given\\.$#',
+	'identifier' => 'argument.type',
+	'count' => 1,
+	'path' => __DIR__ . '/packages/Support/Infrastructures/Valinor/ApplicationMapperConfigurator.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Parameter \\#1 \\.\\.\\.\\$constructors of method CuyZ\\\\Valinor\\\\MapperBuilder\\:\\:registerConstructor\\(\\) expects \\(pure\\-callable\\(\\)\\: mixed\\)\\|class\\-string, Closure\\(string, string, string, DateTimeImmutable, int, list\\<string\\>\\)\\: AdminUser\\\\Domain\\\\Models\\\\AdminUser given\\.$#',
+	'identifier' => 'argument.type',
+	'count' => 1,
+	'path' => __DIR__ . '/packages/Support/Infrastructures/Valinor/ApplicationMapperConfigurator.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Parameter \\#1 \\.\\.\\.\\$constructors of method CuyZ\\\\Valinor\\\\MapperBuilder\\:\\:registerConstructor\\(\\) expects \\(pure\\-callable\\(\\)\\: mixed\\)\\|class\\-string, Closure\\(string, string, string, string\\|null, int, bool, int, list\\<array\\{songTagId\\: string\\}\\>, list\\<array\\{personId\\: string, role\\: int, orderNo\\: int\\}\\>, list\\<array\\{mediaId\\: string, orderNo\\: int\\}\\>\\)\\: Song\\\\Domain\\\\Models\\\\Song given\\.$#',
+	'identifier' => 'argument.type',
+	'count' => 1,
+	'path' => __DIR__ . '/packages/Support/Infrastructures/Valinor/ApplicationMapperConfigurator.php',
 ];
 
 return ['parameters' => ['ignoreErrors' => $ignoreErrors]];

--- a/src/server/config/valinor.php
+++ b/src/server/config/valinor.php
@@ -1,32 +1,22 @@
 <?php
 
 declare(strict_types=1);
-use Auth\Application\Admin\UseCase\Refresh\RefreshInputData;
-use Auth\Domain\Services\Token\AccessToken\AccessTokenPayload;
-use Media\Application\Admin\UseCase\Create\CreateInputData;
-use Person\Application\Admin\UseCase\Update\UpdateInputData;
-use Support\UseCase\AuditLog\Search\SearchInputData;
 
 return [
     'cache_path' => base_path('bootstrap/cache/valinor'),
 
-    /*
-    |--------------------------------------------------------------------------
-    | Warmup signatures
-    |--------------------------------------------------------------------------
-    |
-    | MapperInterface::map() に渡される型。warmupCacheFor() は再帰的に
-    | プロパティ型もキャッシュする。
-    |
-    */
+    /**
+     * MapperInterface::map() に渡される型
+     * warmupCacheFor() は再帰的にプロパティ型もキャッシュする
+     */
     'warmup' => [
-        RefreshInputData::class,
-        AccessTokenPayload::class,
-        CreateInputData::class,
+        \Auth\Application\Admin\UseCase\Refresh\RefreshInputData::class,
+        \Auth\Domain\Services\Token\AccessToken\AccessTokenPayload::class,
+        \Media\Application\Admin\UseCase\Create\CreateInputData::class,
         \Media\Application\Admin\UseCase\Search\SearchInputData::class,
         \Person\Application\Admin\UseCase\Create\CreateInputData::class,
         \Person\Application\Admin\UseCase\Search\SearchInputData::class,
-        UpdateInputData::class,
+        \Person\Application\Admin\UseCase\Update\UpdateInputData::class,
         \Release\Application\Admin\UseCase\Create\CreateInputData::class,
         \Release\Application\Admin\UseCase\Group\Create\CreateInputData::class,
         \Release\Application\Admin\UseCase\Group\Search\SearchInputData::class,
@@ -38,6 +28,6 @@ return [
         \Song\Application\Admin\UseCase\Tag\Search\SearchInputData::class,
         \Song\Application\Admin\UseCase\Tag\Update\UpdateInputData::class,
         \Song\Application\Admin\UseCase\Update\UpdateInputData::class,
-        SearchInputData::class,
+        \Support\UseCase\AuditLog\Search\SearchInputData::class,
     ],
 ];

--- a/src/server/config/valinor.php
+++ b/src/server/config/valinor.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+use Auth\Application\Admin\UseCase\Refresh\RefreshInputData;
+use Auth\Domain\Services\Token\AccessToken\AccessTokenPayload;
+use Media\Application\Admin\UseCase\Create\CreateInputData;
+use Person\Application\Admin\UseCase\Update\UpdateInputData;
+use Support\UseCase\AuditLog\Search\SearchInputData;
+
+return [
+    'cache_path' => base_path('bootstrap/cache/valinor'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Warmup signatures
+    |--------------------------------------------------------------------------
+    |
+    | MapperInterface::map() に渡される型。warmupCacheFor() は再帰的に
+    | プロパティ型もキャッシュする。
+    |
+    */
+    'warmup' => [
+        RefreshInputData::class,
+        AccessTokenPayload::class,
+        CreateInputData::class,
+        \Media\Application\Admin\UseCase\Search\SearchInputData::class,
+        \Person\Application\Admin\UseCase\Create\CreateInputData::class,
+        \Person\Application\Admin\UseCase\Search\SearchInputData::class,
+        UpdateInputData::class,
+        \Release\Application\Admin\UseCase\Create\CreateInputData::class,
+        \Release\Application\Admin\UseCase\Group\Create\CreateInputData::class,
+        \Release\Application\Admin\UseCase\Group\Search\SearchInputData::class,
+        \Release\Application\Admin\UseCase\Group\Update\UpdateInputData::class,
+        \Release\Application\Admin\UseCase\Update\UpdateInputData::class,
+        \Song\Application\Admin\UseCase\Create\CreateInputData::class,
+        \Song\Application\Admin\UseCase\Search\SearchInputData::class,
+        \Song\Application\Admin\UseCase\Tag\Create\CreateInputData::class,
+        \Song\Application\Admin\UseCase\Tag\Search\SearchInputData::class,
+        \Song\Application\Admin\UseCase\Tag\Update\UpdateInputData::class,
+        \Song\Application\Admin\UseCase\Update\UpdateInputData::class,
+        SearchInputData::class,
+    ],
+];

--- a/src/server/ecs.php
+++ b/src/server/ecs.php
@@ -204,5 +204,6 @@ return ECSConfig::configure()
             __DIR__ . '/bootstrap/providers.php',
             __DIR__ . '/app/Providers/EnvProviders',
             __DIR__ . '/app/Providers/WebRequestServiceProvider.php',
+            __DIR__ . '/config/valinor.php',
         ],
     ]);

--- a/src/server/packages/Support/Infrastructures/Mapper.php
+++ b/src/server/packages/Support/Infrastructures/Mapper.php
@@ -4,13 +4,9 @@ declare(strict_types=1);
 
 namespace Support\Infrastructures;
 
-use AdminUser\Domain\Models\AdminUser;
-use Auth\Domain\Models\Token\RefreshToken\RefreshToken;
 use CuyZ\Valinor\Mapper\Source\Source;
 use CuyZ\Valinor\MapperBuilder;
 use Override;
-use Person\Domain\Models\Person;
-use Song\Domain\Models\Song;
 use Support\Contracts\MapperInterface;
 
 readonly class Mapper implements MapperInterface
@@ -27,15 +23,6 @@ readonly class Mapper implements MapperInterface
             : $source;
 
         return $this->builder
-            // TODO コンストラクタの設定を別のところでできるとよさそう
-            ->registerConstructor(AdminUser::reconstruct(...))
-            ->registerConstructor(RefreshToken::reconstruct(...))
-            ->registerConstructor(Person::reconstruct(...))
-            ->registerConstructor(Song::reconstruct(...))
-            ->allowSuperfluousKeys()
-            // 場合によって builder を DI できるようにして適宜変えるのがよさそう
-            ->allowScalarValueCasting()
-            ->supportDateFormats('Y-m-d', 'Y-m-d H:i:s')
             ->mapper()
             ->map($signature, Source::json($json)->camelCaseKeys());
     }

--- a/src/server/packages/Support/Infrastructures/Valinor/ApplicationMapperConfigurator.php
+++ b/src/server/packages/Support/Infrastructures/Valinor/ApplicationMapperConfigurator.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Support\Infrastructures\Valinor;
+
+use AdminUser\Domain\Models\AdminUser;
+use Auth\Domain\Models\Token\RefreshToken\RefreshToken;
+use CuyZ\Valinor\Mapper\Configurator\MapperBuilderConfigurator;
+use CuyZ\Valinor\MapperBuilder;
+use Override;
+use Person\Domain\Models\Person;
+use Song\Domain\Models\Song;
+
+final class ApplicationMapperConfigurator implements MapperBuilderConfigurator
+{
+    #[Override]
+    public function configureMapperBuilder(MapperBuilder $builder): MapperBuilder
+    {
+        return $builder
+            ->registerConstructor(AdminUser::reconstruct(...))
+            ->registerConstructor(RefreshToken::reconstruct(...))
+            ->registerConstructor(Person::reconstruct(...))
+            ->registerConstructor(Song::reconstruct(...))
+            ->allowSuperfluousKeys()
+            ->allowScalarValueCasting()
+            ->supportDateFormats('Y-m-d', 'Y-m-d H:i:s');
+    }
+}

--- a/src/server/packages/Support/Infrastructures/Valinor/MapperBuilderFactory.php
+++ b/src/server/packages/Support/Infrastructures/Valinor/MapperBuilderFactory.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Support\Infrastructures\Valinor;
 
 use CuyZ\Valinor\Cache\FileSystemCache;
-use CuyZ\Valinor\Cache\FileWatchingCache;
 use CuyZ\Valinor\MapperBuilder;
 use Support\App\Environment;
 
@@ -20,13 +19,7 @@ final class MapperBuilderFactory
             return $builder;
         }
 
-        $cache = new FileSystemCache(config()->string('valinor.cache_path'));
-
-        if (Environment::getEnv() === Environment::Development) {
-            $cache = new FileWatchingCache($cache);
-        }
-
-        return $builder->withCache($cache);
+        return $builder->withCache(new FileSystemCache(config()->string('valinor.cache_path')));
     }
 
     public function isCacheEnabled(): bool

--- a/src/server/packages/Support/Infrastructures/Valinor/MapperBuilderFactory.php
+++ b/src/server/packages/Support/Infrastructures/Valinor/MapperBuilderFactory.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Support\Infrastructures\Valinor;
+
+use CuyZ\Valinor\Cache\FileSystemCache;
+use CuyZ\Valinor\Cache\FileWatchingCache;
+use CuyZ\Valinor\MapperBuilder;
+use Support\App\Environment;
+
+final class MapperBuilderFactory
+{
+    public function create(): MapperBuilder
+    {
+        $builder = new MapperBuilder()
+            ->configureWith(new ApplicationMapperConfigurator());
+
+        if (! $this->isCacheEnabled()) {
+            return $builder;
+        }
+
+        $cache = new FileSystemCache(config()->string('valinor.cache_path'));
+
+        if (Environment::getEnv() === Environment::Development) {
+            $cache = new FileWatchingCache($cache);
+        }
+
+        return $builder->withCache($cache);
+    }
+
+    public function isCacheEnabled(): bool
+    {
+        return ! in_array(Environment::getEnv(), [Environment::Local, Environment::Testing], true);
+    }
+}


### PR DESCRIPTION
## 概要

Valinor の mapper キャッシュをビルド時に事前生成し、API コンテナのコールドスタート時の reflection コストを削減する。

## やったこと

- `valinor:cache` artisan コマンドを追加し、`MapperInterface::map()` で使う型を `warmupCacheFor()` で事前コンパイルする
- `ApplicationMapperConfigurator` / `MapperBuilderFactory` を追加し、Mapper 共通設定と環境別キャッシュ（`FileSystemCache` / `FileWatchingCache`）を DI 経由で注入する
- `config/valinor.php` にキャッシュパスと warmup 対象の型一覧を定義する
- production / staging / development の API Dockerfile で `openapi:cache` の直後に `valinor:cache` を実行する

## やってないこと

- CLI コンテナへの warmup 追加（API コンテナのみが Valinor mapper を HTTP リクエスト処理で使用するため）
- Valinor 以外の mapper 利用箇所の追加（既存の `MapperInterface` 利用箇所のみ対象）

## 関連

- 特になし

Made with [Cursor](https://cursor.com)