### PR TITLE
viewer の楽曲クレジットから英語表記を削除

### DIFF
--- a/src/viewer/src/components/viewer/details/SongDetailContent.astro
+++ b/src/viewer/src/components/viewer/details/SongDetailContent.astro
@@ -12,9 +12,9 @@ const { song } = Astro.props;
 const media = song.media;
 const releaseGroups = song.releaseGroups;
 const creditItems = [
-  { en: 'LYRICS', label: '作詞', names: song.lyricists },
-  { en: 'MUSIC', label: '作曲', names: song.composers },
-  { en: 'ARRANGE', label: '編曲', names: song.arrangers },
+  { label: '作詞', names: song.lyricists },
+  { label: '作曲', names: song.composers },
+  { label: '編曲', names: song.arrangers },
 ].map(item => item.names.length > 0 ? item : { ...item, names: ['-'] });
 
 const formatPublishedAt = (value: string): string =>
@@ -31,10 +31,7 @@ const formatPublishedAt = (value: string): string =>
     {
       creditItems.map(item => (
         <div class="song-credit-item">
-          <dt class="song-credit-label">
-            <span class="song-credit-en label-mono">{item.en}</span>
-            <span class="song-credit-jp">{item.label}</span>
-          </dt>
+          <dt class="song-credit-label">{item.label}</dt>
           <dd class="song-credit-value">{item.names.join(' / ')}</dd>
         </div>
       ))

--- a/src/viewer/src/styles/viewer.css
+++ b/src/viewer/src/styles/viewer.css
@@ -1977,19 +1977,7 @@ body.drawer-lock {
 }
 
 .song-credit-label {
-  display: flex;
-  gap: 8px;
-  align-items: baseline;
   margin: 0 0 8px;
-}
-
-.song-credit-en {
-  font-size: 10px;
-  color: color-mix(in oklab, var(--accent) 80%, var(--fg-muted));
-  letter-spacing: 0.12em;
-}
-
-.song-credit-jp {
   font-family: "Shippori Mincho", serif;
   font-size: 13px;
   font-weight: 500;


### PR DESCRIPTION
## 概要

楽曲詳細のクレジット欄に併記していた英語表記を削除し, 日本語ラベルのみの表示にします

## やったこと

- `SongDetailContent.astro` のクレジット定義から `en` フィールド (LYRICS / MUSIC / ARRANGE) を削除
- ラベルの DOM を `dt` 直下のテキストへ整理し, 不要になった flex ラッパーを解消
- `viewer.css` から `.song-credit-en` を削除し, `.song-credit-jp` のスタイルを `.song-credit-label` に統合

## やってないこと

- クレジット以外の英語表記の見直し

## 関連

- 特になし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Nm7kmxqR4nfYKY4VcHTBT