### PR TITLE
楽曲一覧から関連数の表示を削除する

### DIFF
--- a/src/viewer/src/components/viewer/SongTile.astro
+++ b/src/viewer/src/components/viewer/SongTile.astro
@@ -6,7 +6,6 @@ import { JACKET_WIDTHS, assetImageSrcset, assetImageUrl } from '../../shared/ima
 interface Props {
   songId: string;
   title: string;
-  mediaCount: number;
   index: number;
   media?: SongMedia[];
   releaseGroups?: SongReleaseGroup[];
@@ -15,7 +14,7 @@ interface Props {
   loading?: 'lazy' | 'eager';
 }
 
-const { mediaCount, index, media = [], releaseGroups = [], aspectRatio = '16 / 9', loading = 'lazy' } = Astro.props;
+const { index, media = [], releaseGroups = [], aspectRatio = '16 / 9', loading = 'lazy' } = Astro.props;
 
 // プラットフォームとサムネイルは状態として保持せず url から導出する。
 // メディアがあれば最初にサムネイルを導出できたものを採用する。
@@ -61,9 +60,6 @@ const sequence = String(index + 1).padStart(2, '0');
                 <path d="M9 17.5V6.2l9-1.8v9.4a2.6 2.6 0 1 1-1.5-2.36V6.1L10.5 7.3v9.1A2.6 2.6 0 1 1 9 14.05z" />
               </svg>
             </span>
-            <div class="song-tile-bottom">
-              <span class="song-tile-meta-text">{mediaCount} MEDIA</span>
-            </div>
           </>
         )
   }

--- a/src/viewer/src/pages/index.astro
+++ b/src/viewer/src/pages/index.astro
@@ -49,7 +49,6 @@ const siteStats = await siteStatsRepository.get();
             <SongTile
               songId={latestSong.songId}
               title={latestSong.title}
-              mediaCount={latestSong.counts.mediaCount}
               index={0}
               media={latestSong.media}
               releaseGroups={latestSong.releaseGroups}

--- a/src/viewer/src/pages/songs/index.astro
+++ b/src/viewer/src/pages/songs/index.astro
@@ -51,7 +51,6 @@ const songs = await songContentRepository.all();
               <SongTile
                 songId={song.songId}
                 title={song.title}
-                mediaCount={song.counts.mediaCount}
                 index={index}
                 media={song.media}
                 releaseGroups={song.releaseGroups}
@@ -60,9 +59,6 @@ const songs = await songContentRepository.all();
               <div class="song-grid-body">
                 <div class="song-grid-meta">
                   <span class="pill" data-song-type={song.type.value}>{song.type.name}</span>
-                  <div class="song-meta-inline">
-                    <span>{song.counts.mediaCount} media</span>
-                  </div>
                 </div>
                 <div class="song-grid-title">{song.title}</div>
               </div>

--- a/src/viewer/src/styles/viewer.css
+++ b/src/viewer/src/styles/viewer.css
@@ -1764,15 +1764,6 @@ body.drawer-lock {
   border-bottom: 1px solid var(--line-soft);
 }
 
-.song-meta-inline {
-  display: inline-flex;
-  gap: 10px;
-  font-family: "JetBrains Mono", monospace;
-  font-size: 9px;
-  color: var(--fg-muted);
-  letter-spacing: 0.08em;
-}
-
 .media-list-thumb {
   aspect-ratio: 16 / 9;
   overflow: hidden;
@@ -2161,8 +2152,7 @@ body.drawer-lock {
   object-fit: cover;
 }
 
-.song-tile-top,
-.song-tile-bottom {
+.song-tile-top {
   display: flex;
   gap: 12px;
   align-items: center;
@@ -2181,8 +2171,11 @@ body.drawer-lock {
 }
 
 .song-tile-icon {
+  position: absolute;
+  inset: 0;
   display: flex;
-  align-self: center;
+  align-items: center;
+  justify-content: center;
   color: color-mix(in oklab, var(--fg) 30%, transparent);
 }
 


### PR DESCRIPTION
## 概要

楽曲一覧のカードから関連数の表示を削除し, メタ行を種別のみにします

今後イベント等の関連軸が増えるとメタ行が数字の羅列になるため, 一覧では関連数を出さない方針にします
関連数は楽曲詳細のセクション見出し (`収録リリース (2)` など) で確認できます

## やったこと

- `pages/songs/index.astro`: カードのメタ行から `{mediaCount} media` を削除し, 種別 pill のみにした
- `components/viewer/SongTile.astro`: サムネイル代替タイルの `N MEDIA` を削除し, 未使用になった `mediaCount` prop も削除した (`pages/index.astro` の呼び出しも追随)
- `styles/viewer.css`: 不要になった `.song-meta-inline` と `.song-tile-bottom` を削除し, 下段が消えてもアイコンが中央に来るよう `.song-tile-icon` を絶対配置にした

## やってないこと

- 関連数を見せる別形式 (table 等) の追加
  - イベントの関連軸が固まってから列設計ごと作るほうが手戻りが少ないため, 今回は見送る
- `counts.releaseCount` / `counts.mediaCount` の契約からの削除
  - viewer では未使用になるが, 上記の別形式で使う想定のため残す

## 関連

- 特になし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Nm7kmxqR4nfYKY4VcHTBT