### PR TITLE
viewer のお問い合わせページに受付内容を追記する

### DIFF
--- a/src/viewer/src/pages/contact.astro
+++ b/src/viewer/src/pages/contact.astro
@@ -10,8 +10,20 @@ import { CONTACT_X_HANDLE, CONTACT_X_URL } from '../shared/contact';
 
     <div class="policy-doc">
       <p>
-        当サイトに関するお問い合わせは、
-        <a href={CONTACT_X_URL} target="_blank" rel="noopener noreferrer">X(旧 Twitter) {CONTACT_X_HANDLE}</a> までご連絡ください。
+        当サイトに関するご連絡は、
+        <a href={CONTACT_X_URL} target="_blank" rel="noopener noreferrer">X(旧 Twitter) {CONTACT_X_HANDLE}</a> までお願いします。
+      </p>
+
+      <h2>ご指摘・ご要望</h2>
+      <p>
+        掲載内容の誤りのご指摘、掲載してほしい情報や機能のご要望を受け付けています。<br />
+        すべてにお応えできるとは限りませんが、いただいた内容は今後の更新の参考にします。
+      </p>
+
+      <h2>権利者の方へ</h2>
+      <p>
+        掲載内容の修正・削除のご要望は、確認のうえ速やかに対応します。<br />
+        ご連絡の際は、対象のページと該当箇所をお知らせください。
       </p>
     </div>
   </section>

--- a/src/viewer/src/pages/site-policy.astro
+++ b/src/viewer/src/pages/site-policy.astro
@@ -1,7 +1,6 @@
 ---
 import SectionHead from '../components/viewer/SectionHead.astro';
 import Layout from '../layouts/Layout.astro';
-import { CONTACT_X_HANDLE, CONTACT_X_URL } from '../shared/contact';
 
 const LAST_UPDATED = '2026年6月14日';
 ---
@@ -16,7 +15,8 @@ const LAST_UPDATED = '2026年6月14日';
       <h2>当サイトについて</h2>
       <p>
         当サイトは、ヰ世界情緒に関する情報を、いちファンが個人的に整理・記録している非公式のファンサイトです。<br />
-        ヰ世界情緒、所属事務所、その他の関係各社とは一切関係がありません。当サイトの内容について、これらの公式に問い合わせることはおやめください。
+        ヰ世界情緒、所属事務所、その他の関係各社とは一切関係がありません。<br />
+        当サイトの内容について、これらの公式に問い合わせることはおやめください。<br />
         最新かつ正確な情報は、必ず各公式の発表・チャンネルをご確認ください。
       </p>
       <p>
@@ -38,8 +38,8 @@ const LAST_UPDATED = '2026年6月14日';
 
       <h2>お問い合わせ・権利者の方へ</h2>
       <p>
-        当サイトの内容に関するお問い合わせ、および権利者の方からの掲載内容の修正・削除のご要望は、
-        <a href={CONTACT_X_URL} target="_blank" rel="noopener noreferrer">X(旧 Twitter) {CONTACT_X_HANDLE}</a> までご連絡ください。
+        当サイトの内容に関するお問い合わせ、ご指摘・ご要望、権利者の方からの掲載内容の修正・削除のご要望は、
+        いずれも <a href="/contact">お問い合わせ</a> ページの窓口で受け付けています。
       </p>
     </div>
   </section>


### PR DESCRIPTION
## 概要

お問い合わせページが連絡先の 1 文のみだったため、何を受け付けているかと対応方針を追記した
サイトポリシー側は詳細を持たせず、窓口への案内に集約した

## やったこと

- お問い合わせページに「ご指摘・ご要望」と「権利者の方へ」の見出しを追加
  - ご指摘・ご要望: すべてに対応できるとは限らないが今後の更新の参考にする旨を明記
  - 権利者の方: 修正・削除のご要望は確認のうえ速やかに対応する旨と、対象ページの明記を依頼
- サイトポリシーの問い合わせ節をお問い合わせページへの案内 1 文にまとめ、連絡先の重複表記を解消
  - あわせて未使用となった `CONTACT_X_HANDLE` / `CONTACT_X_URL` の import を削除
- 同ファイル内の `<br>` を `<br />` に修正 (eslint の `@stylistic/jsx-tag-spacing` 違反)

## やってないこと

- 問い合わせフォームの設置など窓口自体の変更
- 英語表記の併記

## 関連

- 特になし