### PR TITLE
viewer からジャケットの表示を落とす

### DIFF
--- a/src/viewer/src/components/viewer/SongTile.astro
+++ b/src/viewer/src/components/viewer/SongTile.astro
@@ -1,36 +1,24 @@
 ---
 import { youtubeThumbnailFromUrl, youtubeThumbnailSrcset } from '../../features/media/labels';
-import type { SongMedia, SongReleaseGroup } from '../../features/songs/types';
-import { JACKET_WIDTHS, assetImageSrcset, assetImageUrl } from '../../shared/image';
+import type { SongMedia } from '../../features/songs/types';
 
 interface Props {
   songId: string;
   title: string;
   index: number;
   media?: SongMedia[];
-  releaseGroups?: SongReleaseGroup[];
   aspectRatio?: string;
   /** ファーストビューに入る画像だけ eager にする。遅延したままだと LCP が伸びる */
   loading?: 'lazy' | 'eager';
 }
 
-const { index, media = [], releaseGroups = [], aspectRatio = '16 / 9', loading = 'lazy' } = Astro.props;
+const { index, media = [], aspectRatio = '16 / 9', loading = 'lazy' } = Astro.props;
 
 // プラットフォームとサムネイルは状態として保持せず url から導出する。
 // メディアがあれば最初にサムネイルを導出できたものを採用する。
-const mediaThumbnailUrl = media.reduce<string | null>((found, entry) => found ?? youtubeThumbnailFromUrl(entry.url), null);
+const thumbnailUrl = media.reduce<string | null>((found, entry) => found ?? youtubeThumbnailFromUrl(entry.url), null);
 
-// メディアから導出できなければ収録リリースの最初の代表ジャケットで代替する
-const jacketArtUrl = releaseGroups.reduce<string | null>((found, entry) => found ?? entry.jacketArtUrl, null);
-
-const thumbnailUrl = mediaThumbnailUrl
-  ?? (jacketArtUrl === null ? null : assetImageUrl(jacketArtUrl, 640));
-
-const thumbnailSrcset = mediaThumbnailUrl !== null
-  ? youtubeThumbnailSrcset(mediaThumbnailUrl)
-  : jacketArtUrl !== null
-    ? assetImageSrcset(jacketArtUrl, JACKET_WIDTHS)
-    : undefined;
+const thumbnailSrcset = thumbnailUrl === null ? undefined : youtubeThumbnailSrcset(thumbnailUrl);
 
 const sequence = String(index + 1).padStart(2, '0');
 ---

--- a/src/viewer/src/components/viewer/details/ReleaseDetailContent.astro
+++ b/src/viewer/src/components/viewer/details/ReleaseDetailContent.astro
@@ -26,7 +26,7 @@ const isSingleReleaseGroup = releaseGroup.releases.length === 1;
               </div>
               <div class="release-version-body">
                 {/* 単一リリースのジャケットは常に開いた状態でファーストビューに入るため eager にする */}
-                <ReleaseVersionBody release={release} releaseGroupTitle={releaseGroup.title} loading="eager" />
+                <ReleaseVersionBody release={release} />
               </div>
             </section>
           )
@@ -43,7 +43,7 @@ const isSingleReleaseGroup = releaseGroup.releases.length === 1;
               </summary>
               <div class="release-version-body-shell">
                 <div class="release-version-body">
-                  <ReleaseVersionBody release={release} releaseGroupTitle={releaseGroup.title} />
+                  <ReleaseVersionBody release={release} />
                 </div>
               </div>
             </details>

--- a/src/viewer/src/components/viewer/details/ReleaseVersionBody.astro
+++ b/src/viewer/src/components/viewer/details/ReleaseVersionBody.astro
@@ -1,26 +1,15 @@
 ---
 import type { Release } from '../../../features/releases/types';
-import JacketArt from '../JacketArt.astro';
 import TrackChip from '../TrackChip.astro';
 
 interface Props {
   release: Release;
-  releaseGroupTitle: string;
-  /** ファーストビューに入る画像だけ eager にする。遅延したままだと LCP が伸びる */
-  loading?: 'lazy' | 'eager';
 }
 
-const { release, releaseGroupTitle, loading = 'lazy' } = Astro.props;
+const { release } = Astro.props;
 ---
 
-<div class={release.jacketArtUrl ? 'release-version-content has-jacket' : 'release-version-content'}>
-  {
-    release.jacketArtUrl && (
-      <div class="release-version-art">
-        <JacketArt imageUrl={release.jacketArtUrl} label={`${releaseGroupTitle} ${release.name}`} aspectRatio="auto" sizes="160px" loading={loading} />
-      </div>
-    )
-  }
+<div class="release-version-content">
   <div class="release-version-track-list">
     {release.description && <p class="detail-description release-version-description">{release.description}</p>}
     {

--- a/src/viewer/src/components/viewer/details/SongDetailContent.astro
+++ b/src/viewer/src/components/viewer/details/SongDetailContent.astro
@@ -1,7 +1,6 @@
 ---
 import { mediaPlatformLabel, youtubeThumbnailFromUrl, youtubeThumbnailSrcset } from '../../../features/media/labels';
 import type { Song } from '../../../features/songs/types';
-import { JACKET_WIDTHS, assetImageSrcset, assetImageUrl } from '../../../shared/image';
 import DetailSectionHead from './DetailSectionHead.astro';
 
 interface Props {
@@ -46,27 +45,9 @@ const formatPublishedAt = (value: string): string =>
           {
             releaseGroups.map(releaseGroup => (
               <a class="rel-chip" href={`/releases/${releaseGroup.releaseGroupId}`}>
-                {
-                  releaseGroup.jacketArtUrl
-                    ? (
-                        <img
-                          class="rel-thumb"
-                          src={assetImageUrl(releaseGroup.jacketArtUrl, 320)}
-                          srcset={assetImageSrcset(releaseGroup.jacketArtUrl, JACKET_WIDTHS)}
-                          sizes="96px"
-                          width="96"
-                          height="54"
-                          loading="lazy"
-                          decoding="async"
-                          alt={releaseGroup.title}
-                        />
-                      )
-                    : (
-                        <div class="rel-thumb rel-thumb-placeholder">
-                          <span class="rel-thumb-placeholder-label">{releaseGroup.type.name}</span>
-                        </div>
-                      )
-                }
+                <div class="rel-thumb rel-thumb-placeholder">
+                  <span class="rel-thumb-placeholder-label">{releaseGroup.type.name}</span>
+                </div>
                 <div class="rel-copy">
                   <div class="rel-main">{releaseGroup.title}</div>
                   <div class="label-mono rel-sub">{releaseGroup.firstReleasedOn} · {releaseGroup.type.name}</div>

--- a/src/viewer/src/features/releases/types.ts
+++ b/src/viewer/src/features/releases/types.ts
@@ -13,9 +13,9 @@ export function isLinkableTrack(track: ReleaseTrack): track is ReleaseTrack & { 
   return track.songId !== null && track.isDisplay;
 }
 
-/** 代表ジャケット: 公開リリースを発売日順に見て最初に設定されているもの。 */
-export function representativeJacketArtUrl(releaseGroup: ReleaseGroup): string | null {
-  return releaseGroup.releases.find(release => release.jacketArtUrl !== null)?.jacketArtUrl ?? null;
+/** 代表色: 公開リリースを発売日順に見て最初のもの。 */
+export function representativeColor(releaseGroup: ReleaseGroup): string {
+  return releaseGroup.releases[0].color;
 }
 
 /** グループ全体の提供形態（傘下リリースの和集合、値順）。 */

--- a/src/viewer/src/pages/index.astro
+++ b/src/viewer/src/pages/index.astro
@@ -1,10 +1,8 @@
 ---
-import JacketArt from '../components/viewer/JacketArt.astro';
 import SectionHead from '../components/viewer/SectionHead.astro';
 import SongTile from '../components/viewer/SongTile.astro';
 import TrackChip from '../components/viewer/TrackChip.astro';
 import { releaseGroupContentRepository } from '../features/releases/content';
-import { representativeJacketArtUrl } from '../features/releases/types';
 import { siteStatsRepository } from '../features/site-stats/api';
 import { songContentRepository } from '../features/songs/content';
 import Layout from '../layouts/Layout.astro';
@@ -51,7 +49,6 @@ const siteStats = await siteStatsRepository.get();
               title={latestSong.title}
               index={0}
               media={latestSong.media}
-              releaseGroups={latestSong.releaseGroups}
               aspectRatio="1 / 1"
               loading="eager"
             />
@@ -74,13 +71,6 @@ const siteStats = await siteStatsRepository.get();
       <section class="shell">
         <SectionHead title="最新リリース" />
         <div class="feature-grid-link">
-          <a href={`/releases/${latestReleaseGroup.releaseGroupId}`} class="feature-art-link">
-            <JacketArt
-              imageUrl={representativeJacketArtUrl(latestReleaseGroup)}
-              label={latestReleaseGroup.title}
-              sizes="(max-width: 1100px) calc(100vw - 40px), 320px"
-            />
-          </a>
           <div class="feature-body">
             <div class="eyebrow">{latestReleaseGroup.type.name} — {latestReleaseGroup.firstReleasedOn}</div>
             <h3 class="feature-title">

--- a/src/viewer/src/pages/releases/[releaseGroupId].astro
+++ b/src/viewer/src/pages/releases/[releaseGroupId].astro
@@ -1,7 +1,6 @@
 ---
 import ReleaseDetailContent from '../../components/viewer/details/ReleaseDetailContent.astro';
 import { releaseGroupContentRepository } from '../../features/releases/content';
-import { representativeJacketArtUrl } from '../../features/releases/types';
 import Layout from '../../layouts/Layout.astro';
 
 export async function getStaticPaths() {
@@ -14,14 +13,11 @@ export async function getStaticPaths() {
 const { releaseGroup } = Astro.props;
 
 const pageDescription = releaseGroup.description || `ヰ世界情緒が参加するリリース「${releaseGroup.title}」の情報`;
-const jacketArtUrl = representativeJacketArtUrl(releaseGroup);
-const ogImage = jacketArtUrl === null ? null : { url: jacketArtUrl, alt: `${releaseGroup.title}のジャケット` };
 ---
 
 <Layout
   pageTitle={releaseGroup.title}
   pageDescription={pageDescription}
-  ogImage={ogImage}
   breadcrumbs={[{ label: 'リリース', href: '/releases' }, { label: releaseGroup.title, href: null }]}
 >
   <section class="shell page-section detail-page">

--- a/src/viewer/src/pages/releases/index.astro
+++ b/src/viewer/src/pages/releases/index.astro
@@ -1,10 +1,9 @@
 ---
 import EntryStatus from '../../components/viewer/EntryStatus';
 import FilterBar from '../../components/viewer/FilterBar';
-import JacketArt from '../../components/viewer/JacketArt.astro';
 import SectionHead from '../../components/viewer/SectionHead.astro';
 import { releaseGroupContentRepository } from '../../features/releases/content';
-import { groupFormats, representativeJacketArtUrl } from '../../features/releases/types';
+import { groupFormats } from '../../features/releases/types';
 import Layout from '../../layouts/Layout.astro';
 
 // API は最古発売日の降順で返すのでそのまま並べる。
@@ -43,7 +42,7 @@ const releaseGroups = await releaseGroupContentRepository.all();
         <div class="entry-empty-description">検索語句や種別フィルタを変えて確認してください。</div>
       </div>
       {
-        releaseGroups.map((releaseGroup, index) => {
+        releaseGroups.map((releaseGroup) => {
           const trackTitles = releaseGroup.releases
             .flatMap(release => release.media.flatMap(medium => medium.tracks.map(track => track.title)));
           const formatNames = groupFormats(releaseGroup).map(format => format.name);
@@ -56,12 +55,6 @@ const releaseGroups = await releaseGroupContentRepository.all();
               data-release-type={String(releaseGroup.type.value)}
               data-release-search={`${releaseGroup.title} ${releaseGroup.type.name} ${trackTitles.join(' ')}`.toLowerCase()}
             >
-              <JacketArt
-                imageUrl={representativeJacketArtUrl(releaseGroup)}
-                label={releaseGroup.title}
-                sizes="(max-width: 720px) calc(100vw - 40px), (max-width: 1100px) calc((100vw - 128px) / 2), calc((min(1480px, 100vw) - 160px) / 3)"
-                loading={index === 0 ? 'eager' : 'lazy'}
-              />
               <div class="release-card-body">
                 <div class="release-card-meta">
                   <span class="release-card-badges">

--- a/src/viewer/src/pages/songs/[songId].astro
+++ b/src/viewer/src/pages/songs/[songId].astro
@@ -13,17 +13,11 @@ export async function getStaticPaths() {
 const { song } = Astro.props;
 
 const pageDescription = song.description || `ヰ世界情緒が歌う楽曲「${song.title}」の情報`;
-// 楽曲そのものに画像はないので、収録先リリースの代表ジャケットを借りる
-const jacketReleaseGroup = song.releaseGroups.find(releaseGroup => releaseGroup.jacketArtUrl !== null) ?? null;
-const ogImage = jacketReleaseGroup?.jacketArtUrl
-  ? { url: jacketReleaseGroup.jacketArtUrl, alt: `${jacketReleaseGroup.title}のジャケット` }
-  : null;
 ---
 
 <Layout
   pageTitle={song.title}
   pageDescription={pageDescription}
-  ogImage={ogImage}
   breadcrumbs={[{ label: '楽曲', href: '/songs' }, { label: song.title, href: null }]}
 >
   <section class="shell page-section detail-page">

--- a/src/viewer/src/pages/songs/index.astro
+++ b/src/viewer/src/pages/songs/index.astro
@@ -53,7 +53,6 @@ const songs = await songContentRepository.all();
                 title={song.title}
                 index={index}
                 media={song.media}
-                releaseGroups={song.releaseGroups}
                 loading={index === 0 ? 'eager' : 'lazy'}
               />
               <div class="song-grid-body">


### PR DESCRIPTION
## 概要

ジャケットアート廃止の 4 本目です
viewer からジャケットの参照をすべて外し、型が通る状態にします

**この PR で viewer から画像が消え、見た目が一時的に崩れます**
一覧・ホーム・詳細の作り直しは後続の PR で行います

## やったこと

- `representativeJacketArtUrl` を `representativeColor` に置き換え (代表色は最古の公開リリースのもの)
- リリース一覧・ホームの最新リリース枠から `JacketArt` の呼び出しを削除
- `ReleaseVersionBody` の `has-jacket` 分岐と版ごとのジャケットを削除
- `SongDetailContent` の収録リリースからジャケット画像を削除し、種別のプレースホルダに統一
- `SongTile` のジャケットフォールバックを削除 YouTube サムネイルとアイコンの 2 択に戻す
- リリース詳細と楽曲詳細の `og:image` を既定画像に変更

## やってないこと

- リリース一覧を年表の台帳に作り替える (次の PR)
- ホームの最新リリース枠を収録曲リスト主役にする
- 版ごとの色帯と、楽曲タイルへの色の敷き込み
- `JacketArt.astro` と `.jacket-art` 系スタイルの削除 (最後の PR)

## 補足

この PR の時点での既知の劣化です

- メディア未登録の 60 曲 (全 371 曲中) が無地のアイコンになります 後続の PR で収録リリースの色を敷きます
- Twitter カードが `summary_large_image` から `summary` に落ちます これは恒久的な変更です

ビルド出力を確認し、`release-jacket-art` を参照する HTML が 0 件、`og:image` が `og-default.png` になっていることを確認済みです

検証は以下が通っています

- `mise run viewer:check`
- `bun --filter viewer build` (1522 ページ)

## 関連

- [#988](https://github.com/sayuprc/isekai-observatory/pull/988)
- [#989](https://github.com/sayuprc/isekai-observatory/pull/989)
- [#990](https://github.com/sayuprc/isekai-observatory/pull/990)