### PR TITLE
リリース一覧を年ごとの台帳に作り替える

### DIFF
--- a/docs/exec-plans/active/20260809-release-list-ledger.md
+++ b/docs/exec-plans/active/20260809-release-list-ledger.md
@@ -41,12 +41,14 @@ planned
 
 ## Steps
 
-- [ ] `src/viewer/src/features/releases/types.ts` に `representativeColor()` を追加する。`representativeJacketArtUrl` と同じく、公開リリースを発売日順に見て最初のものを採る
-- [ ] `index.astro` を年グルーピングに書き換える。`firstReleasedOn` の年で束ね、年内は API の返却順（新しい順）を維持する
-- [ ] 行のマークアップを 色の縦棒 / 色見本 / タイトル / 種別 / 日付 に置き換え、`data-release-entry` などフィルタ用の属性は現行のまま残す
-- [ ] `FilterBar` と `EntryStatus` の配線を維持したうえで、`EntryStatus` が年セクションの畳み込みも行えるようにする
-- [ ] `viewer.css` の `.release-grid` / `.release-card` 系を削除し、台帳のスタイルを追加する。タイトルは 2 行までの折り返しにする
+- [x] `src/viewer/src/features/releases/types.ts` に `representativeColor()` を追加する（`20260809-release-color-column.md` の viewer 剥がしで実施済み）
+- [x] `index.astro` を年グルーピングに書き換える。`firstReleasedOn` の年で束ね、年内は API の返却順（新しい順）を維持する
+- [x] 行のマークアップを 色の縦棒 / 色見本 / タイトル / 種別 / 日付 に置き換え、`data-release-entry` などフィルタ用の属性は現行のまま残す
+- [x] `FilterBar` と `EntryStatus` の配線を維持する。年セクションの畳み込みは CSS の `:has()`、
+      年ごとの件数は新設した `EntryGroupStatus` が担う
+- [x] `viewer.css` の `.release-grid` / `.release-card` 系を削除し、台帳のスタイルを追加する。タイトルは 2 行までの折り返しにする
 - [ ] 6 パレットすべてで色見本のコントラストを目視確認し、必要なら表示時に明度を丸める処理を入れる
+      （現状は全 84 件が固定値 `#989899` なので確認できない。実データ投入後に持ち越す）
 
 ## Decision Log
 
@@ -57,6 +59,10 @@ planned
 - 2026-08-09: タイトルは PC でも 2 行まで折り返す。切れる行が全体の 2 割あり例外ではないため
 - 2026-08-09: 同名・同日のリリースグループ（`再会` のシングルと EP など）への追加対応はしない。種別列で区別できる
 - 2026-08-09: 検索中も年グルーピングを維持し、0 件の年は畳む。検索の有無でレイアウトの軸が変わると結果の並び順が読めなくなるため
+- 2026-08-09: 年セクションの畳み込みは CSS の `:has()` で持つ。`FilterBar` が非表示の entry に付ける
+  `data-viewer-filter-match="false"` を否定形で見るので、属性が付いていない初期状態でも表示が維持され、JS なしで成立する
+- 2026-08-09: 年ごとの件数だけは CSS で出せないため `EntryGroupStatus` を新設する。
+  `EntryStatus` と同じく `viewer:filter-change` を購読し、件数の書き換えだけを担う
 
 ## Validation
 

--- a/src/viewer/src/components/viewer/EntryGroupStatus.tsx
+++ b/src/viewer/src/components/viewer/EntryGroupStatus.tsx
@@ -1,0 +1,46 @@
+import { onCleanup, onMount } from 'solid-js';
+
+type Props = {
+  // 絞り込み対象の entry を指す CSS セレクタ FilterBar に渡すものと揃える
+  entrySelector: string;
+  // entry を束ねるグループ（年など）を指す CSS セレクタ
+  groupSelector: string;
+  // グループ内で件数を表示する要素を指す CSS セレクタ
+  countSelector: string;
+  unit: string;
+};
+
+/**
+ * グループごとの件数表示を絞り込みに追従させる
+ * グループ自体の表示・非表示は CSS の :has() が持つので、ここでは件数だけを書き換える
+ */
+export default function EntryGroupStatus(props: Props) {
+  const updateCounts = () => {
+    for (const group of document.querySelectorAll(props.groupSelector)) {
+      const countElement = group.querySelector(props.countSelector);
+
+      if (!(countElement instanceof HTMLElement)) {
+        continue;
+      }
+
+      const matched = Array.from(group.querySelectorAll(props.entrySelector))
+        .filter((entry): entry is HTMLElement => entry instanceof HTMLElement)
+        .filter(entry => entry.dataset.viewerFilterMatch !== 'false').length;
+
+      countElement.textContent = `${matched}${props.unit}`;
+    }
+  };
+
+  onMount(() => {
+    const onFilterChange = (event: Event) => {
+      if (!(event instanceof CustomEvent)) return;
+      if (event.detail?.entrySelector !== props.entrySelector) return;
+      updateCounts();
+    };
+
+    document.addEventListener('viewer:filter-change', onFilterChange);
+    onCleanup(() => document.removeEventListener('viewer:filter-change', onFilterChange));
+  });
+
+  return null;
+}

--- a/src/viewer/src/pages/releases/index.astro
+++ b/src/viewer/src/pages/releases/index.astro
@@ -1,13 +1,16 @@
 ---
+import EntryGroupStatus from '../../components/viewer/EntryGroupStatus';
 import EntryStatus from '../../components/viewer/EntryStatus';
 import FilterBar from '../../components/viewer/FilterBar';
 import SectionHead from '../../components/viewer/SectionHead.astro';
 import { releaseGroupContentRepository } from '../../features/releases/content';
-import { groupFormats } from '../../features/releases/types';
+import { representativeColor } from '../../features/releases/types';
 import Layout from '../../layouts/Layout.astro';
 
-// API は最古発売日の降順で返すのでそのまま並べる。
+// API は最古発売日の降順で返すので、年の区切りを入れるだけで並べ替えは不要
 const releaseGroups = await releaseGroupContentRepository.all();
+
+const years = [...new Set(releaseGroups.map(releaseGroup => releaseGroup.firstReleasedOn.slice(0, 4)))];
 ---
 
 <Layout pageTitle="リリース" pageDescription="ヰ世界情緒のリリース一覧">
@@ -36,39 +39,59 @@ const releaseGroups = await releaseGroupContentRepository.all();
       initialCount={releaseGroups.length}
     />
 
-    <div class="release-grid">
-      <div class="entry-empty entry-empty-panel" data-release-empty hidden>
-        <div class="entry-empty-title">該当するリリースがありません</div>
-        <div class="entry-empty-description">検索語句や種別フィルタを変えて確認してください。</div>
-      </div>
-      {
-        releaseGroups.map((releaseGroup) => {
-          const trackTitles = releaseGroup.releases
-            .flatMap(release => release.media.flatMap(medium => medium.tracks.map(track => track.title)));
-          const formatNames = groupFormats(releaseGroup).map(format => format.name);
+    <EntryGroupStatus
+      client:idle
+      entrySelector="[data-release-entry]"
+      groupSelector="[data-release-year]"
+      countSelector="[data-release-year-count]"
+      unit="作品"
+    />
 
-          return (
-            <a
-              href={`/releases/${releaseGroup.releaseGroupId}`}
-              class="release-card"
-              data-release-entry
-              data-release-type={String(releaseGroup.type.value)}
-              data-release-search={`${releaseGroup.title} ${releaseGroup.type.name} ${trackTitles.join(' ')}`.toLowerCase()}
-            >
-              <div class="release-card-body">
-                <div class="release-card-meta">
-                  <span class="release-card-badges">
-                    <span class="pill" data-release-type={String(releaseGroup.type.value)}>{releaseGroup.type.name}</span>
-                    {formatNames.map(name => <span class="format-chip">{name}</span>)}
-                  </span>
-                  <span class="label-mono">{releaseGroup.firstReleasedOn}</span>
-                </div>
-                <div class="song-grid-title">{releaseGroup.title}</div>
-              </div>
-            </a>
-          );
-        })
-      }
+    <div class="entry-empty entry-empty-panel" data-release-empty hidden>
+      <div class="entry-empty-title">該当するリリースがありません</div>
+      <div class="entry-empty-description">検索語句や種別フィルタを変えて確認してください。</div>
     </div>
+
+    {
+      years.map((year) => {
+        const items = releaseGroups.filter(releaseGroup => releaseGroup.firstReleasedOn.startsWith(year));
+
+        return (
+          <section class="release-year" data-release-year>
+            <div class="release-year-head">
+              <div class="release-year-num">{year}</div>
+              <div class="release-year-count" data-release-year-count>{items.length}作品</div>
+            </div>
+            <ol class="release-year-list">
+              {
+                items.map((releaseGroup) => {
+                  const trackTitles = releaseGroup.releases
+                    .flatMap(release => release.media.flatMap(medium => medium.tracks.map(track => track.title)));
+
+                  return (
+                    <li
+                      data-release-entry
+                      data-release-type={String(releaseGroup.type.value)}
+                      data-release-search={`${releaseGroup.title} ${releaseGroup.type.name} ${trackTitles.join(' ')}`.toLowerCase()}
+                    >
+                      <a
+                        href={`/releases/${releaseGroup.releaseGroupId}`}
+                        class="release-row"
+                        style={`--release-color:${representativeColor(releaseGroup)};`}
+                      >
+                        <span class="release-row-chip" aria-hidden="true" />
+                        <span class="release-row-title">{releaseGroup.title}</span>
+                        <span class="release-row-type">{releaseGroup.type.name}</span>
+                        <span class="label-mono release-row-date">{releaseGroup.firstReleasedOn.slice(5).replace('-', '.')}</span>
+                      </a>
+                    </li>
+                  );
+                })
+              }
+            </ol>
+          </section>
+        );
+      })
+    }
   </section>
 </Layout>

--- a/src/viewer/src/styles/viewer.css
+++ b/src/viewer/src/styles/viewer.css
@@ -1560,9 +1560,115 @@ body.drawer-lock {
   color: var(--fg-muted);
 }
 
+/* ---------- リリース一覧 (年ごとの台帳) ---------- */
+
+.release-year {
+  margin-top: 56px;
+}
+
+/* 絞り込みで 1 件も残らなかった年は畳む
+   FilterBar は非表示の entry に data-viewer-filter-match="false" を付けるので、
+   1 件も付いていない初期状態でも表示が維持される */
+
+.release-year:not(:has([data-release-entry]:not([data-viewer-filter-match="false"]))) {
+  display: none;
+}
+
+.release-year-head {
+  display: flex;
+  gap: 18px;
+  align-items: baseline;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--line);
+}
+
+.release-year-num {
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: clamp(34px, 6vw, 52px);
+  line-height: 1;
+  letter-spacing: 0.02em;
+}
+
+.release-year-count {
+  font-size: 13px;
+  color: var(--fg-muted);
+}
+
+.release-year-list {
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.release-row {
+  position: relative;
+  display: flex;
+  gap: 18px;
+  align-items: center;
+  padding: 14px 12px 14px 20px;
+  color: inherit;
+  text-decoration: none;
+  border-bottom: 1px solid var(--line-soft);
+  transition: background 0.2s ease;
+}
+
+/* ジャケットの代わりに置く色 縦棒と見本の 2 箇所で出す */
+
+.release-row::before {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 3px;
+  content: "";
+  background: var(--release-color);
+  transition: width 0.25s cubic-bezier(0.2, 0.8, 0.25, 1);
+}
+
+.release-row:hover::before {
+  width: 7px;
+}
+
+.release-row:hover {
+  background: color-mix(in srgb, var(--release-color) 12%, transparent);
+}
+
+.release-row-chip {
+  flex: none;
+  width: 26px;
+  height: 26px;
+  background: var(--release-color);
+  border-radius: 2px;
+  box-shadow: inset 0 0 0 1px rgb(255 255 255 / 7%);
+}
+
+.release-row-title {
+  /* ライブ映像作品はタイトルが長い 1 行省略だと読めないので 2 行まで折り返す */
+  display: -webkit-box;
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  -webkit-line-clamp: 2;
+  font-family: "Noto Serif JP", "Shippori Mincho", serif;
+  font-size: 16px;
+  line-height: 1.6;
+  letter-spacing: 0.03em;
+  -webkit-box-orient: vertical;
+}
+
+.release-row-type {
+  flex: none;
+  width: 5.5em;
+  font-size: 12px;
+  color: var(--fg-muted);
+}
+
+.release-row-date {
+  flex: none;
+  width: 4.5em;
+  text-align: right;
+}
+
 .media-card-grid,
-.song-grid,
-.release-grid {
+.song-grid {
   display: grid;
   gap: 28px;
 }
@@ -1576,31 +1682,24 @@ body.drawer-lock {
   grid-template-columns: repeat(4, minmax(0, 1fr));
 }
 
-.release-grid {
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 32px;
-}
-
 .media-card,
-.song-grid-card,
-.release-card {
+.song-grid-card {
   display: block;
 }
 
 /* 一覧は 300 件超を一度に描くので、画面外のカードはレイアウトと描画を省く
    高さは auto で実測値を再利用させ、初回だけ概算値を使う */
 
-.song-grid-card,
-.release-card {
+.song-grid-card {
   /* auto 付きを解釈しないブラウザ向けに固定値を先に置く。未指定だと画面外カードが高さ 0 に潰れる */
   contain-intrinsic-size: 260px;
   contain-intrinsic-size: auto 260px;
   content-visibility: auto;
+  transition: transform 0.18s ease;
 }
 
 .media-card-body,
-.song-grid-body,
-.release-card-body {
+.song-grid-body {
   padding: 16px 4px 0;
 }
 
@@ -1618,28 +1717,16 @@ body.drawer-lock {
   font-size: 17px;
 }
 
-.song-grid-card {
-  transition: transform 0.18s ease;
-}
-
 .song-grid-card:hover {
   transform: translateY(-2px);
 }
 
-.song-grid-meta,
-.release-card-meta {
+.song-grid-meta {
   display: flex;
   gap: 12px;
   align-items: center;
   justify-content: space-between;
   margin-bottom: 8px;
-}
-
-.release-card-badges {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-  align-items: center;
 }
 
 .media-card-tags {
@@ -2274,7 +2361,6 @@ body.drawer-lock {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 
-  .release-grid,
   .media-card-grid,
   .recent-posts-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -2319,7 +2405,6 @@ body.drawer-lock {
   }
 
   .song-grid,
-  .release-grid,
   .media-card-grid,
   .recent-posts-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -2369,6 +2454,23 @@ body.drawer-lock {
 }
 
 @media (width <= 720px) {
+  /* 台帳の行は狭い幅だと種別と日付が入らないので落とす
+     種別は絞り込みで代替でき、年は見出しに出ている */
+
+  .release-row-type,
+  .release-row-date {
+    display: none;
+  }
+
+  .release-row {
+    padding-left: 16px;
+  }
+
+  .release-row-chip {
+    width: 22px;
+    height: 22px;
+  }
+
   /* リンクはボトムナビへ移動するためヘッダーからは消す */
 
   .nav-links {
@@ -2409,7 +2511,6 @@ body.drawer-lock {
   }
 
   .song-grid,
-  .release-grid,
   .media-card-grid,
   .recent-posts-grid,
   .song-credit-grid {


### PR DESCRIPTION
## 概要

ジャケットアート廃止の 5 本目です
画像を失ったリリース一覧を、カードグリッドから年ごとの台帳へ作り替えます

`discography-mock.html` で構造を確認したうえで実装しています

## やったこと

- `/releases` を `firstReleasedOn` の年でグルーピングし、年の降順・年内は API の返却順 (新しい順) で並べる
- 行を 色の縦棒 / 色見本 / タイトル / 種別 / 日付 の 5 要素にする
- タイトルは 2 行まで折り返す (ライブ映像作品はタイトルが長く、1 行省略だと読めないため)
- `.release-grid` / `.release-card` 系のスタイルを削除し、台帳のスタイルを追加
- 720px 以下では種別と日付を落とす (種別は絞り込みで代替でき、年は見出しに出ている)

## やってないこと

- 色見本のコントラスト確認 現状は全 84 件が固定値 `#989899` なので確認できません 実データ投入後に持ち越します
- ホーム・詳細・楽曲タイル (後続の PR)

## 補足

**年セクションの畳み込みは CSS の `:has()` で持たせました**

```css
.release-year:not(:has([data-release-entry]:not([data-viewer-filter-match="false"]))) {
  display: none;
}
```

`FilterBar` は非表示の entry に `data-viewer-filter-match="false"` を付けるので、否定形で見れば
属性が付いていない初期状態でも表示が維持され、JS なしで成立します

年ごとの件数だけは CSS で出せないため `EntryGroupStatus` を新設しました
`EntryStatus` と同じく `viewer:filter-change` を購読し、件数の書き換えだけを担います

検索・種別フィルタは現行のまま維持しています

ビルド出力で 7 年 / 84 件が生成されていることを確認済みです

検証は以下が通っています

- `mise run viewer:check`
- `bun --filter viewer build` (1522 ページ)

## 関連

- [#988](https://github.com/sayuprc/isekai-observatory/pull/988)
- [#989](https://github.com/sayuprc/isekai-observatory/pull/989)
- [#990](https://github.com/sayuprc/isekai-observatory/pull/990)
- [#992](https://github.com/sayuprc/isekai-observatory/pull/992)