### PR TITLE
リリース詳細と楽曲タイルのジャケット利用を色に置き換える

### DIFF
--- a/docs/exec-plans/active/20260809-jacket-color-fallback.md
+++ b/docs/exec-plans/active/20260809-jacket-color-fallback.md
@@ -4,7 +4,7 @@
 
 ## Status
 
-planned
+in-progress
 
 ## Background
 
@@ -41,12 +41,12 @@ planned
 
 ## Steps
 
-- [ ] `ReleaseVersionBody.astro` に版ごとの色帯を入れ、`has-jacket` の分岐とスタイルを削除する
-- [ ] `SongTile.astro` のアイコンフォールバックに収録リリースの色を敷く。
+- [x] `ReleaseVersionBody.astro` に版ごとの色帯を入れ、`has-jacket` の分岐とスタイルを削除する
+- [x] `SongTile.astro` のアイコンフォールバックに収録リリースの色を敷く。
       色の採り方は従来のジャケットと同じく `releaseGroups` の先頭から最初に見つかったものを使う
-- [ ] `SongDetailContent.astro` の収録リリースに色見本を入れる
-- [ ] `viewer.css` の `.jacket-art` 依存スタイルのうち、この 2 箇所に紐づくものを整理する
-- [ ] メディア未登録の 60 曲が一覧でどう見えるか確認する
+- [x] `SongDetailContent.astro` の収録リリースに色見本を入れる
+- [x] `viewer.css` の `.jacket-art` 依存スタイルのうち、この 2 箇所に紐づくものを整理する
+- [x] メディア未登録の楽曲が一覧でどう見えるか確認する
 
 ## Decision Log
 
@@ -55,7 +55,10 @@ planned
 - 2026-08-09: メディア未登録の楽曲は収録リリースの色を地に敷く。無地のアイコンを 60 枚出すのは避けたく、YouTube サムネイル 311 枚を捨てるのは廃止の理由と釣り合わないため
 - 2026-08-09: 楽曲タイルの色は `releaseGroups` の先頭から最初に見つかったものを採る。既存の導出規則をそのまま流用でき、新しい並べ替えを足さずに済む
 - 2026-08-09: リリース詳細の版セクションには版ごとの色帯を出す。効くのは版が複数ある 4 グループだけだが、色を版に持つ判断と整合する
+- 2026-08-09: 収録リリースが無いカバー曲などは色を敷けないので、従来のアイコンフォールバックのまま残す
 
 ## Validation
 
--
+- `mise run viewer:check` 通過
+- `bun --filter viewer build` 通過。楽曲一覧 371 曲のうち YouTube サムネ 309・色フォールバック 23・収録リリース無しのアイコン 39。
+  `has-jacket` / `release-version-art` は出力から消えている

--- a/src/viewer/src/components/viewer/SongTile.astro
+++ b/src/viewer/src/components/viewer/SongTile.astro
@@ -1,18 +1,19 @@
 ---
 import { youtubeThumbnailFromUrl, youtubeThumbnailSrcset } from '../../features/media/labels';
-import type { SongMedia } from '../../features/songs/types';
+import type { SongMedia, SongReleaseGroup } from '../../features/songs/types';
 
 interface Props {
   songId: string;
   title: string;
   index: number;
   media?: SongMedia[];
+  releaseGroups?: SongReleaseGroup[];
   aspectRatio?: string;
   /** ファーストビューに入る画像だけ eager にする。遅延したままだと LCP が伸びる */
   loading?: 'lazy' | 'eager';
 }
 
-const { index, media = [], aspectRatio = '16 / 9', loading = 'lazy' } = Astro.props;
+const { index, media = [], releaseGroups = [], aspectRatio = '16 / 9', loading = 'lazy' } = Astro.props;
 
 // プラットフォームとサムネイルは状態として保持せず url から導出する。
 // メディアがあれば最初にサムネイルを導出できたものを採用する。
@@ -20,10 +21,23 @@ const thumbnailUrl = media.reduce<string | null>((found, entry) => found ?? yout
 
 const thumbnailSrcset = thumbnailUrl === null ? undefined : youtubeThumbnailSrcset(thumbnailUrl);
 
+// メディアから導出できなければ収録リリースの最初の代表色で代替する
+const fallbackColor = thumbnailUrl === null
+  ? releaseGroups.reduce<string | null>((found, entry) => found ?? entry.color, null)
+  : null;
+
 const sequence = String(index + 1).padStart(2, '0');
+const tileStyle = [
+  `--song-tile-aspect:${aspectRatio}`,
+  fallbackColor === null ? null : `--song-tile-color:${fallbackColor}`,
+].filter(Boolean).join(';');
 ---
 
-<div class="song-tile" style={`--song-tile-aspect:${aspectRatio};`} aria-hidden="true">
+<div
+  class:list={['song-tile', { 'has-color-fallback': fallbackColor !== null }]}
+  style={tileStyle}
+  aria-hidden="true"
+>
   {
     thumbnailUrl
       ? (

--- a/src/viewer/src/components/viewer/details/ReleaseDetailContent.astro
+++ b/src/viewer/src/components/viewer/details/ReleaseDetailContent.astro
@@ -25,7 +25,6 @@ const isSingleReleaseGroup = releaseGroup.releases.length === 1;
                 <span class="label-mono">{release.formats.map(format => format.name).join('・')}</span>
               </div>
               <div class="release-version-body">
-                {/* 単一リリースのジャケットは常に開いた状態でファーストビューに入るため eager にする */}
                 <ReleaseVersionBody release={release} />
               </div>
             </section>

--- a/src/viewer/src/components/viewer/details/ReleaseVersionBody.astro
+++ b/src/viewer/src/components/viewer/details/ReleaseVersionBody.astro
@@ -9,7 +9,7 @@ interface Props {
 const { release } = Astro.props;
 ---
 
-<div class="release-version-content">
+<div class="release-version-content" style={`--c:${release.color};`}>
   <div class="release-version-track-list">
     {release.description && <p class="detail-description release-version-description">{release.description}</p>}
     {

--- a/src/viewer/src/components/viewer/details/SongDetailContent.astro
+++ b/src/viewer/src/components/viewer/details/SongDetailContent.astro
@@ -44,10 +44,12 @@ const formatPublishedAt = (value: string): string =>
         <div class="rel-list">
           {
             releaseGroups.map(releaseGroup => (
-              <a class="rel-chip" href={`/releases/${releaseGroup.releaseGroupId}`}>
-                <div class="rel-thumb rel-thumb-placeholder">
-                  <span class="rel-thumb-placeholder-label">{releaseGroup.type.name}</span>
-                </div>
+              <a
+                class="rel-chip"
+                href={`/releases/${releaseGroup.releaseGroupId}`}
+                style={`--c:${releaseGroup.color};`}
+              >
+                <span class="rel-swatch" aria-hidden="true" />
                 <div class="rel-copy">
                   <div class="rel-main">{releaseGroup.title}</div>
                   <div class="label-mono rel-sub">{releaseGroup.firstReleasedOn} · {releaseGroup.type.name}</div>

--- a/src/viewer/src/pages/index.astro
+++ b/src/viewer/src/pages/index.astro
@@ -51,6 +51,7 @@ const siteStats = await siteStatsRepository.get();
               title={latestSong.title}
               index={0}
               media={latestSong.media}
+              releaseGroups={latestSong.releaseGroups}
               aspectRatio="1 / 1"
               loading="eager"
             />

--- a/src/viewer/src/pages/songs/index.astro
+++ b/src/viewer/src/pages/songs/index.astro
@@ -53,6 +53,7 @@ const songs = await songContentRepository.all();
                 title={song.title}
                 index={index}
                 media={song.media}
+                releaseGroups={song.releaseGroups}
                 loading={index === 0 ? 'eager' : 'lazy'}
               />
               <div class="song-grid-body">

--- a/src/viewer/src/styles/viewer.css
+++ b/src/viewer/src/styles/viewer.css
@@ -1202,16 +1202,8 @@ body.drawer-lock {
 .release-version-content {
   display: grid;
   gap: 18px;
-}
-
-.release-version-content.has-jacket {
-  grid-template-columns: minmax(96px, 140px) minmax(0, 1fr);
-  align-items: start;
-}
-
-.release-version-art {
-  width: 100%;
-  max-width: 140px;
+  padding-left: 16px;
+  border-left: 3px solid var(--c);
 }
 
 .release-version-track-list {
@@ -2185,6 +2177,17 @@ body.drawer-lock {
   letter-spacing: 0.08em;
 }
 
+/* 楽曲詳細の収録リリース一覧。画像の代わりに色見本を置く */
+
+.rel-swatch {
+  flex: none;
+  width: 26px;
+  height: 26px;
+  background: var(--c);
+  border-radius: 2px;
+  box-shadow: inset 0 0 0 1px rgb(255 255 255 / 7%);
+}
+
 .jacket-art {
   aspect-ratio: var(--tile-aspect, 1 / 1);
   background:
@@ -2226,8 +2229,7 @@ body.drawer-lock {
   transform: translate(-50%, -50%);
 }
 
-/* サムネイルが無い楽曲のプレースホルダー。実写サムネと並んでも浮かないよう、
-   テーマ連動の中間色にアイコンを主役として据える。 */
+/* サムネイルが無い楽曲は収録リリースの代表色を地に敷く */
 
 .song-tile {
   position: relative;
@@ -2240,6 +2242,13 @@ body.drawer-lock {
   overflow: hidden;
   background: var(--bg-elev-2);
   border: 1px solid var(--line);
+}
+
+.song-tile.has-color-fallback {
+  background:
+    radial-gradient(ellipse at 30% 20%, color-mix(in oklab, var(--song-tile-color) 66%, transparent), transparent 50%),
+    radial-gradient(ellipse at 70% 80%, color-mix(in oklab, var(--song-tile-color) 40%, transparent), transparent 60%),
+    linear-gradient(135deg, var(--song-tile-color), color-mix(in oklab, var(--song-tile-color) 55%, var(--bg-elev-2)));
 }
 
 .song-tile-image {
@@ -2325,10 +2334,6 @@ body.drawer-lock {
   width: 18px;
   height: 18px;
   fill: white;
-}
-
-.detail-panel .song-detail-content .jacket-art {
-  max-width: 280px;
 }
 
 .detail-panel .song-detail-content .detail-title {
@@ -2542,14 +2547,6 @@ body.drawer-lock {
   .media-list-row > :last-child,
   .media-list-row .label-mono {
     display: none;
-  }
-
-  .release-version-content.has-jacket {
-    grid-template-columns: 1fr;
-  }
-
-  .release-version-art {
-    width: min(160px, 100%);
   }
 
   .detail-panel {


### PR DESCRIPTION
## 概要

ジャケットアート廃止の後続です。リリース詳細の版セクションと楽曲タイルに代表色を入れ、1 本目で失われた識別子を戻します。

## やったこと

- リリース詳細の版セクションに版ごとの色帯を入れ、`has-jacket` レイアウトの残骸を削除した
- メディア未登録の楽曲タイルに、収録リリース先頭の代表色を地として敷くようにした
- 楽曲詳細の収録リリース一覧を画像プレースホルダから色見本に差し替えた

## やってないこと

- `JacketArt.astro` 本体とストレージ掃除（次の掃除 PR）
- YouTube サムネイルがある楽曲の表示変更
- 収録リリースが無いカバー曲などへの色の付与（色の元が無いためアイコンのまま）

## 関連

- #994（ホームの最新リリース枠）
- `docs/exec-plans/active/20260809-jacket-color-fallback.md`


Made with [Cursor](https://cursor.com)