### PR TITLE
not nullable な color を setter でレスポンスに載せる

### DIFF
--- a/src/server/app/Http/Presenters/Api/Admin/V1/Release/Converter.php
+++ b/src/server/app/Http/Presenters/Api/Admin/V1/Release/Converter.php
@@ -19,14 +19,13 @@ class Converter
 {
     public function toOpenApiRelease(Release $release): OpenApiRelease
     {
-        return new OpenApiRelease([
-            'color' => $release->color->value,
-        ])
+        return new OpenApiRelease()
             ->setReleaseId($release->releaseId->value)
             ->setReleaseGroupId($release->releaseGroupId->value)
             ->setName($release->name->value)
             ->setReleasedOn($release->releasedOn->value->toMutable())
             ->setDescription($release->description->value)
+            ->setColor($release->color->value)
             ->setIsDisplay($release->isDisplay)
             ->setOrderNo($release->orderNo->value)
             ->setFormatValues($release->formats->toGeneric()->map(

--- a/src/server/app/Http/Presenters/Api/Admin/V1/ReleaseGroup/Converter.php
+++ b/src/server/app/Http/Presenters/Api/Admin/V1/ReleaseGroup/Converter.php
@@ -42,12 +42,11 @@ class Converter
 
     public function toOpenApiReferencedRelease(ReleaseGroupReferencedRelease $release): OpenApiReleaseGroupReferencedRelease
     {
-        return new OpenApiReleaseGroupReferencedRelease([
-            'color' => $release->color,
-        ])
+        return new OpenApiReleaseGroupReferencedRelease()
             ->setReleaseId($release->releaseId)
             ->setName($release->name)
             ->setReleasedOn(new DateTime($release->releasedOn))
+            ->setColor($release->color)
             ->setIsDisplay($release->isDisplay)
             ->setOrderNo($release->orderNo)
             ->setFormatValues(array_map(

--- a/src/server/app/Http/Presenters/Api/Viewer/V1/Release/ListPresenter.php
+++ b/src/server/app/Http/Presenters/Api/Viewer/V1/Release/ListPresenter.php
@@ -50,13 +50,12 @@ class ListPresenter
 
     private function toOpenApiReleaseListItem(ReleaseListItem $release): OpenApiReleaseListItem
     {
-        return new OpenApiReleaseListItem([
-            'color' => $release->color,
-        ])
+        return new OpenApiReleaseListItem()
             ->setReleaseId($release->releaseId)
             ->setName($release->name)
             ->setReleasedOn(new DateTime($release->releasedOn))
             ->setDescription($release->description)
+            ->setColor($release->color)
             ->setOrderNo($release->orderNo)
             ->setFormats(array_map($this->toOpenApiReleaseFormat(...), $release->formats))
             ->setMedia(array_map($this->toOpenApiReleaseMediumItem(...), $release->media));

--- a/src/server/app/Http/Presenters/Api/Viewer/V1/Song/ListPresenter.php
+++ b/src/server/app/Http/Presenters/Api/Viewer/V1/Song/ListPresenter.php
@@ -60,13 +60,12 @@ class ListPresenter
     {
         $type = ReleaseGroupType::from($releaseGroup->typeValue);
 
-        return new OpenApiSongReleaseGroupSummary([
-            'color' => $releaseGroup->color,
-        ])
+        return new OpenApiSongReleaseGroupSummary()
             ->setReleaseGroupId($releaseGroup->releaseGroupId)
             ->setTitle($releaseGroup->title)
             ->setType(new OpenApiReleaseGroupType()->setName($type->getName())->setValue(ReleaseGroupTypeValue::from($type->value)))
-            ->setFirstReleasedOn(new DateTime($releaseGroup->firstReleasedOn));
+            ->setFirstReleasedOn(new DateTime($releaseGroup->firstReleasedOn))
+            ->setColor($releaseGroup->color);
     }
 
     private function toOpenApiSongMediaSummary(SongMediaSummary $media): OpenApiSongMediaSummary


### PR DESCRIPTION
## 概要

`color` は not nullable になったので、Presenter / Converter で配列ではなく `setColor()` でレスポンスを組み立てます。

## やったこと

- Admin `Release` / `ReleaseGroup` Converter の `color` を `setColor()` に置き換えた
- Viewer `Release` / `Song` ListPresenter の `color` を `setColor()` に置き換えた

## やってないこと

- nullable フィールド（`name` / `song_id` / `lyrics_link` など）の配列渡しはそのまま

## 関連

- #989（jacket → color）
- `feature/remove-jacket-art`


Made with [Cursor](https://cursor.com)