### PR TITLE
リリース一覧の年見出しを Spectral に揃える

### DIFF
--- a/src/viewer/src/styles/viewer.css
+++ b/src/viewer/src/styles/viewer.css
@@ -1593,8 +1593,9 @@ body.drawer-lock {
 }
 
 .release-year-num {
-  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-family: Spectral, serif;
   font-size: clamp(34px, 6vw, 52px);
+  font-weight: 500;
   line-height: 1;
   letter-spacing: 0.02em;
 }


### PR DESCRIPTION
## 概要

リリース一覧の年見出しフォントを、サイトの数値表記で使っている Spectral に揃えます。

## やったこと

- `.release-year-num` の `font-family` を `JetBrains Mono` から `Spectral` に変更した

## やってないこと

- 年以外の台帳スタイルの変更

## 関連

- #993（リリース一覧の台帳化）


Made with [Cursor](https://cursor.com)