### PR TITLE
リリース一覧の色チップを削除する

### DIFF
--- a/src/viewer/src/pages/releases/index.astro
+++ b/src/viewer/src/pages/releases/index.astro
@@ -79,7 +79,6 @@ const years = [...new Set(releaseGroups.map(releaseGroup => releaseGroup.firstRe
                         class="release-row"
                         style={`--release-color:${representativeColor(releaseGroup)};`}
                       >
-                        <span class="release-row-chip" aria-hidden="true" />
                         <span class="release-row-title">{releaseGroup.title}</span>
                         <span class="release-row-type">{releaseGroup.type.name}</span>
                         <span class="label-mono release-row-date">{releaseGroup.firstReleasedOn.slice(5).replace('-', '.')}</span>

--- a/src/viewer/src/styles/viewer.css
+++ b/src/viewer/src/styles/viewer.css
@@ -1666,7 +1666,7 @@ body.drawer-lock {
   transition: background 0.2s ease;
 }
 
-/* ジャケットの代わりに置く色 縦棒と見本の 2 箇所で出す */
+/* ジャケットの代わりに左ボーダーで代表色を示す */
 
 .release-row::before {
   position: absolute;
@@ -1683,15 +1683,6 @@ body.drawer-lock {
 
 .release-row:hover {
   background: color-mix(in srgb, var(--release-color) 12%, transparent);
-}
-
-.release-row-chip {
-  flex: none;
-  width: 26px;
-  height: 26px;
-  background: var(--release-color);
-  border-radius: 2px;
-  box-shadow: inset 0 0 0 1px rgb(255 255 255 / 7%);
 }
 
 .release-row-title {
@@ -2477,11 +2468,6 @@ body.drawer-lock {
 
   .release-row {
     padding-left: 16px;
-  }
-
-  .release-row-chip {
-    width: 22px;
-    height: 22px;
   }
 
   /* リンクはボトムナビへ移動するためヘッダーからは消す */


### PR DESCRIPTION
## 概要

リリース一覧で代表色を示していた行内の色チップを削除し、左ボーダーのみで色を伝える形に揃えます。

## やったこと

- リリース行から `release-row-chip` を削除
- 関連するスタイルとモバイル向けサイズ指定を削除

## やってないこと

- 年見出し横のカラーバー追加（試したが採用しない）
- モック HTML（`discography-mock.html`）の取り込み

## 関連

- 特になし

Made with [Cursor](https://cursor.com)