### PR TITLE
viewer で YouTube サムネイル origin へ preconnect する

### DIFF
--- a/src/viewer/src/features/media/labels.ts
+++ b/src/viewer/src/features/media/labels.ts
@@ -96,11 +96,14 @@ export function youtubeVideoId(url: string): string | null {
   return null;
 }
 
+/** YouTube サムネイル画像の origin。preconnect 用 */
+export const YOUTUBE_THUMBNAIL_ORIGIN = 'https://i.ytimg.com';
+
 // YouTube 動画 url ならサムネイル URL(sddefault.jpg)を導出する。動画でなければ null
 export function youtubeThumbnailFromUrl(url: string): string | null {
   const id = youtubeVideoId(url);
 
-  return id === null ? null : `https://i.ytimg.com/vi/${id}/sddefault.jpg`;
+  return id === null ? null : `${YOUTUBE_THUMBNAIL_ORIGIN}/vi/${id}/sddefault.jpg`;
 }
 
 // 保存済みサムネイル URL(末尾 sddefault.jpg)のファイル名のみを差し替えて

--- a/src/viewer/src/layouts/Layout.astro
+++ b/src/viewer/src/layouts/Layout.astro
@@ -19,6 +19,8 @@ interface Props {
   breadcrumbs?: readonly BreadcrumbItem[];
   /** エラーページのように、実体のある URL として索引させたくないページで立てる */
   noindex?: boolean;
+  /** LCP 寄与があるサードパーティ origin だけ渡す。img 用なので crossorigin は付けない */
+  preconnect?: readonly string[];
 }
 
 const {
@@ -27,6 +29,7 @@ const {
   ogImage = null,
   breadcrumbs = [],
   noindex: pageNoindex = false,
+  preconnect = [],
 } = Astro.props;
 
 const generateTitle = (title: string) => {
@@ -50,6 +53,7 @@ const trail: readonly BreadcrumbItem[] = breadcrumbs.length > 0 ? [{ label: 'ホ
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    {preconnect.map(origin => <link rel="preconnect" href={origin} />)}
     <link rel="canonical" href={canonicalUrl} />
     {noindex && <meta name="robots" content="noindex, nofollow" />}
     <meta name="description" content={pageDescription} />

--- a/src/viewer/src/pages/index.astro
+++ b/src/viewer/src/pages/index.astro
@@ -2,6 +2,7 @@
 import SectionHead from '../components/viewer/SectionHead.astro';
 import SongTile from '../components/viewer/SongTile.astro';
 import TrackChip from '../components/viewer/TrackChip.astro';
+import { YOUTUBE_THUMBNAIL_ORIGIN, youtubeThumbnailFromUrl } from '../features/media/labels';
 import { releaseGroupContentRepository } from '../features/releases/content';
 import { representativeColor } from '../features/releases/types';
 import { siteStatsRepository } from '../features/site-stats/api';
@@ -13,9 +14,12 @@ const latestSong = await songContentRepository.latest();
 const latestReleaseTracks = latestReleaseGroup?.releases[0]?.media.flatMap(medium => medium.tracks) ?? [];
 
 const siteStats = await siteStatsRepository.get();
+const preconnect = latestSong?.media.some(entry => youtubeThumbnailFromUrl(entry.url) !== null)
+  ? [YOUTUBE_THUMBNAIL_ORIGIN]
+  : [];
 ---
 
-<Layout pageTitle="">
+<Layout pageTitle="" preconnect={preconnect}>
   <section class="hero-data">
     <div class="shell">
       <h1 class="hero-mark hero-mark-data">ヰ世界観測所</h1>

--- a/src/viewer/src/pages/media/[mediaId].astro
+++ b/src/viewer/src/pages/media/[mediaId].astro
@@ -1,7 +1,7 @@
 ---
 import MediaDetailContent from '../../components/viewer/details/MediaDetailContent.astro';
 import { mediaContentRepository } from '../../features/media/content';
-import { youtubeThumbnailFromUrl } from '../../features/media/labels';
+import { YOUTUBE_THUMBNAIL_ORIGIN, youtubeThumbnailFromUrl } from '../../features/media/labels';
 import Layout from '../../layouts/Layout.astro';
 
 export async function getStaticPaths() {
@@ -16,9 +16,10 @@ const { media } = Astro.props;
 const pageDescription = `ヰ世界情緒が出演するメディア「${media.title}」の情報`;
 const thumbnailUrl = youtubeThumbnailFromUrl(media.url);
 const ogImage = thumbnailUrl === null ? null : { url: thumbnailUrl, alt: `${media.title}のサムネイル` };
+const preconnect = thumbnailUrl === null ? [] : [YOUTUBE_THUMBNAIL_ORIGIN];
 ---
 
-<Layout pageTitle={media.title} pageDescription={pageDescription} ogImage={ogImage}>
+<Layout pageTitle={media.title} pageDescription={pageDescription} ogImage={ogImage} preconnect={preconnect}>
   <section class="shell page-section detail-page">
     <MediaDetailContent media={media} />
   </section>

--- a/src/viewer/src/pages/songs/[songId].astro
+++ b/src/viewer/src/pages/songs/[songId].astro
@@ -1,5 +1,6 @@
 ---
 import SongDetailContent from '../../components/viewer/details/SongDetailContent.astro';
+import { YOUTUBE_THUMBNAIL_ORIGIN, youtubeThumbnailFromUrl } from '../../features/media/labels';
 import { songContentRepository } from '../../features/songs/content';
 import Layout from '../../layouts/Layout.astro';
 
@@ -13,12 +14,16 @@ export async function getStaticPaths() {
 const { song } = Astro.props;
 
 const pageDescription = song.description || `ヰ世界情緒が歌う楽曲「${song.title}」の情報`;
+const preconnect = song.media.some(entry => youtubeThumbnailFromUrl(entry.url) !== null)
+  ? [YOUTUBE_THUMBNAIL_ORIGIN]
+  : [];
 ---
 
 <Layout
   pageTitle={song.title}
   pageDescription={pageDescription}
   breadcrumbs={[{ label: '楽曲', href: '/songs' }, { label: song.title, href: null }]}
+  preconnect={preconnect}
 >
   <section class="shell page-section detail-page">
     <SongDetailContent song={song} />

--- a/src/viewer/src/pages/songs/index.astro
+++ b/src/viewer/src/pages/songs/index.astro
@@ -3,13 +3,14 @@ import EntryStatus from '../../components/viewer/EntryStatus';
 import FilterBar from '../../components/viewer/FilterBar';
 import SectionHead from '../../components/viewer/SectionHead.astro';
 import SongTile from '../../components/viewer/SongTile.astro';
+import { YOUTUBE_THUMBNAIL_ORIGIN } from '../../features/media/labels';
 import { songContentRepository } from '../../features/songs/content';
 import Layout from '../../layouts/Layout.astro';
 
 const songs = await songContentRepository.all();
 ---
 
-<Layout pageTitle="楽曲" pageDescription="ヰ世界情緒の楽曲一覧">
+<Layout pageTitle="楽曲" pageDescription="ヰ世界情緒の楽曲一覧" preconnect={[YOUTUBE_THUMBNAIL_ORIGIN]}>
   <section class="shell page-section">
     <SectionHead title="楽曲" level={1} />
 


### PR DESCRIPTION
## 概要

YouTube サムネイル (`i.ytimg.com`) を表示するページで preconnect し、接続セットアップ待ちによる LCP 遅延を減らす

## やったこと

- `YOUTUBE_THUMBNAIL_ORIGIN` を定義し、サムネイル URL 生成と共有する
- `Layout` に任意の `preconnect` prop を追加する
- ホーム / 楽曲一覧 / 楽曲詳細 / メディア詳細で、サムネを出すときだけ `i.ytimg.com` を preconnect する

## やってないこと

- サムネを出さないページへの一律 preconnect
- `dns-prefetch` や preload の追加
- 実測による LCP 改善の検証

## 関連

- 特になし

Made with [Cursor](https://cursor.com)