### PR TITLE
Discord 通知配達サービスを追加

### DIFF
--- a/.github/actions/setup-moonbit/action.yml
+++ b/.github/actions/setup-moonbit/action.yml
@@ -1,0 +1,24 @@
+name: Setup MoonBit
+description: Install MoonBit toolchain using vars.moonbit_version from mise.toml
+
+runs:
+  using: composite
+  steps:
+    - name: Read moonbit version
+      id: moonbit-version
+      shell: bash
+      run: echo "version=$(./tools/read-mise-value.sh moonbit_version)" >> "$GITHUB_OUTPUT"
+
+    - name: Install MoonBit
+      shell: bash
+      run: |
+        curl -fsSL https://cli.moonbitlang.com/install/unix.sh \
+          | bash -s -- "${{ steps.moonbit-version.outputs.version }}"
+        echo "${HOME}/.moon/bin" >> "$GITHUB_PATH"
+        ${HOME}/.moon/bin/moon update
+
+    - name: Install native build dependencies
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends build-essential

--- a/.github/workflows/discord-notifier-qa.yaml
+++ b/.github/workflows/discord-notifier-qa.yaml
@@ -1,0 +1,52 @@
+name: Discord Notifier QA
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  pull_request:
+    # main, stg 向け PR は release-qa 経由で必ず全実行する
+    branches-ignore:
+      - main
+      - stg
+    paths:
+      - "src/discord-notifier/**"
+      - "mise.toml"
+      - "mise.ci.toml"
+      - ".github/workflows/discord-notifier-qa.yaml"
+      - ".github/actions/setup-mise/**"
+      - ".github/actions/setup-moonbit/**"
+  push:
+    branches:
+      - dev
+    paths:
+      - "src/discord-notifier/**"
+      - "mise.toml"
+      - "mise.ci.toml"
+      - ".github/workflows/discord-notifier-qa.yaml"
+      - ".github/actions/setup-mise/**"
+      - ".github/actions/setup-moonbit/**"
+  workflow_call:
+
+env:
+  MISE_ENV: ci
+
+jobs:
+  check:
+    name: Check
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Setup mise
+        uses: ./.github/actions/setup-mise
+
+      - name: Setup MoonBit
+        uses: ./.github/actions/setup-moonbit
+
+      - name: Run check / test
+        run: mise run discord-notifier:check

--- a/.github/workflows/release-qa.yaml
+++ b/.github/workflows/release-qa.yaml
@@ -31,3 +31,7 @@ jobs:
   contracts:
     name: Contracts QA
     uses: ./.github/workflows/contracts-qa.yaml
+
+  discord-notifier:
+    name: Discord Notifier QA
+    uses: ./.github/workflows/discord-notifier-qa.yaml

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -18,6 +18,7 @@
 - `src/contracts/`: TypeSpec による API 契約
 - `src/admin/`: Astro / SolidJS / Elysia による管理画面
 - `src/viewer/`: Astro / SolidJS による閲覧サイト
+- `src/discord-notifier/`: MoonBit 製 Discord 通知配達サービス (Cloud Run)
 - `mise.toml`: 開発ツール・タスク定義、および CI / インフラ向け版ピンのカタログ(`[tools]` / `[vars]`)
 - `compose.yaml`: ローカルで使う proxy / php / mysql / redis の定義
 
@@ -43,6 +44,7 @@
 | サーバーの業務ロジック | `src/server` | 必要なら `src/contracts` | `mise run ecs`, `phpstan`, `arkitect`, `test` |
 | 管理画面の UI / BFF | `src/admin` | 必要なら `src/contracts` | `cd src && bun --filter admin lint:check`, `style:check`, `build` |
 | 閲覧サイトの UI | `src/viewer` | 必要なら `src/contracts` | `cd src && bun --filter viewer lint:check`, `style:check`, `build` |
+| Discord 通知配達 | `src/discord-notifier` | 各 env の `docker/discord-notifier`、Cloud Build | `mise run discord-notifier:check` |
 | 開発環境 | `mise.toml`, `compose.yaml`, `infra/local/docker/` | 関連 docs | 起動確認と影響範囲の明記 |
 | 環境別インフラ | `infra/development/`, `infra/staging/`, `infra/production/` | 関連 docs | Cloud Build 設定、Dockerfile、build context の確認 |
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -15,7 +15,7 @@
 
 ## Key Design Docs
 
-- `design-docs/subproject-boundaries.md`: `contracts` / `server` / `admin` / `viewer` の責務境界
+- `design-docs/subproject-boundaries.md`: `contracts` / `server` / `admin` / `viewer` / `discord-notifier` の責務境界
 - `design-docs/local-runtime-topology.md`: ローカル開発時のサービス構成、worktree 分離、並列実装の運用
 
 ## Working Records

--- a/docs/agent-map.md
+++ b/docs/agent-map.md
@@ -14,6 +14,7 @@
 - サーバー側の業務ロジック: `src/server`
 - 管理画面 UI / BFF: `src/admin`
 - 閲覧サイト UI: `src/viewer`
+- Discord 通知配達: `src/discord-notifier`
 - それ以外の変更ルート: `ARCHITECTURE.md`
 
 ## 文書の置き場所

--- a/docs/design-docs/INDEX.md
+++ b/docs/design-docs/INDEX.md
@@ -4,4 +4,4 @@
 
 - `core-beliefs.md`: このリポジトリで優先する開発原則
 - `local-runtime-topology.md`: ローカル開発時のサービス構成、worktree 分離、並列実装の運用
-- `subproject-boundaries.md`: `contracts` / `server` / `admin` / `viewer` の責務境界
+- `subproject-boundaries.md`: `contracts` / `server` / `admin` / `viewer` / `discord-notifier` の責務境界

--- a/docs/design-docs/subproject-boundaries.md
+++ b/docs/design-docs/subproject-boundaries.md
@@ -44,3 +44,10 @@ UI 実装方針の詳細は `FRONTEND.md` を参照します
 - `src/viewer/src/styles/`: スタイル
 
 UI 実装方針の詳細は `FRONTEND.md` を参照します
+
+## Discord Notifier
+
+- `src/discord-notifier/`: MoonBit 製の Discord 通知配達サービス
+- Pub/Sub push を受け、`action` を環境変数の routing で channel に引き当てて Discord Webhook へ投稿する
+- 業務処理は持たない。振り分けは環境変数で行う
+- 発信元は Discord を直接呼ばず、Pub/Sub に正規化済み JSON を publish する

--- a/infra/development/README.md
+++ b/infra/development/README.md
@@ -4,7 +4,7 @@
 
 ## Cloud Build
 
-- `cloudbuild/ci.yaml`: API / CLI / DB migrate / Admin / Viewer のコンテナを build / push し、Cloud Run service / job と Cloudflare Worker を deploy する
+- `cloudbuild/ci.yaml`: API / CLI / DB migrate / Admin / Viewer / Discord Notifier のコンテナを build / push し、Cloud Run service / job と Cloudflare Worker を deploy する
 - Cloud Build から実行する build command は YAML に直接定義する
 
 ## Dockerfiles
@@ -14,6 +14,7 @@
 - `docker/db-migrate/Dockerfile`: migration job 用で Atlas と schema 定義のみを含める
 - `docker/admin/Dockerfile`: Admin 用で build stage では `bun --filter admin build`、runtime stage では Bun slim image を使う
 - `docker/viewer/Dockerfile`: Viewer deploy job 用で `viewer-deploy` を entrypoint にする
+- `docker/discord-notifier/Dockerfile`: MoonBit 製 Discord Notifier を native ビルドして載せる
 
 ## 初回構築前提
 
@@ -28,9 +29,10 @@
 
 ## Notes
 
-- `ci.yaml` は Artifact Registry の repository を `_ARTIFACT_REPOSITORY`、image 名を `_API_IMAGE` / `_CLI_IMAGE` / `_DB_MIGRATE_IMAGE` / `_ADMIN_IMAGE` / `_VIEWER_IMAGE` で受け取る
+- `ci.yaml` は Artifact Registry の repository を `_ARTIFACT_REPOSITORY`、image 名を `_API_IMAGE` / `_CLI_IMAGE` / `_DB_MIGRATE_IMAGE` / `_ADMIN_IMAGE` / `_VIEWER_IMAGE` / `_DISCORD_NOTIFIER_IMAGE` で受け取る
 - Cloud Run の service / job 名は `dev-*` の値を YAML に直接定義する
 - Cloud Run jobs の service account は `_JOB_SERVICE_ACCOUNT` で受け取る
+- Discord Notifier の runtime service account は `_NOTIFY_SERVICE_ACCOUNT` で受け取る
 - Admin の `PUBLIC_APP_URL` は Cloud Build substitution の `_PUBLIC_APP_URL` を build arg として渡す
 - Viewer deploy job は `API_URL` / `SITE_URL` / Cloudflare Worker 名 / account ID / API token secret を受け取り、Cloudflare Workers へ deploy する
 - dev はクロール不要のため `SITE_NOINDEX=true` を渡し、robots.txt と meta robots を noindex にする

--- a/infra/development/cloudbuild/ci.yaml
+++ b/infra/development/cloudbuild/ci.yaml
@@ -39,6 +39,14 @@ steps:
       - -c
       - docker pull ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_VIEWER_IMAGE}:latest || exit 0
 
+  - id: pull-discord-notifier-image
+    name: gcr.io/cloud-builders/docker
+    entrypoint: bash
+    waitFor: ["-"]
+    args:
+      - -c
+      - docker pull ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_DISCORD_NOTIFIER_IMAGE}:latest || exit 0
+
   - id: build-api-image
     name: gcr.io/cloud-builders/docker
     waitFor:
@@ -89,6 +97,26 @@ steps:
           -t ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_DB_MIGRATE_IMAGE}:latest \
           --cache-from ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_DB_MIGRATE_IMAGE}:latest \
           --build-arg "MISE_VERSION=$${MISE_VERSION}" \
+          .
+
+  - id: build-discord-notifier-image
+    name: gcr.io/cloud-builders/docker
+    entrypoint: bash
+    waitFor:
+      - pull-discord-notifier-image
+    args:
+      - -c
+      - |
+        set -euo pipefail
+
+        MOONBIT_VERSION=$$(./tools/read-mise-value.sh moonbit_version)
+
+        docker build \
+          -f infra/development/docker/discord-notifier/Dockerfile \
+          -t ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_DISCORD_NOTIFIER_IMAGE}:$COMMIT_SHA \
+          -t ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_DISCORD_NOTIFIER_IMAGE}:latest \
+          --cache-from ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_DISCORD_NOTIFIER_IMAGE}:latest \
+          --build-arg "MOONBIT_VERSION=$${MOONBIT_VERSION}" \
           .
 
   - id: build-admin-image
@@ -177,6 +205,15 @@ steps:
       - --all-tags
       - ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_VIEWER_IMAGE}
 
+  - id: push-discord-notifier-image
+    name: gcr.io/cloud-builders/docker
+    waitFor:
+      - build-discord-notifier-image
+    args:
+      - push
+      - --all-tags
+      - ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_DISCORD_NOTIFIER_IMAGE}
+
   # TODO マイグレーションを別で行う
   - id: deploy-db-migrate-job
     name: gcr.io/google.com/cloudsdktool/cloud-sdk
@@ -252,6 +289,23 @@ steps:
       - ${_API_SERVICE_ACCOUNT}
       - --ingress
       - ${_API_INGRESS}
+      - --quiet
+
+  - id: deploy-discord-notifier
+    name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    entrypoint: gcloud
+    waitFor:
+      - push-discord-notifier-image
+    args:
+      - run
+      - deploy
+      - dev-isekai-discord-notifier
+      - --image
+      - ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_DISCORD_NOTIFIER_IMAGE}:$COMMIT_SHA
+      - --region
+      - ${_REGION}
+      - --service-account
+      - ${_NOTIFY_SERVICE_ACCOUNT}
       - --quiet
 
   - id: deploy-admin

--- a/infra/development/docker/discord-notifier/Dockerfile
+++ b/infra/development/docker/discord-notifier/Dockerfile
@@ -1,0 +1,48 @@
+FROM debian:bookworm-slim AS builder
+
+ARG MOONBIT_VERSION
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    bash \
+    build-essential \
+    ca-certificates \
+    curl \
+    git \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV PATH="/root/.moon/bin:${PATH}"
+
+RUN curl -fsSL https://cli.moonbitlang.com/install/unix.sh \
+  | bash -s -- "${MOONBIT_VERSION}"
+
+WORKDIR /src
+
+COPY src/discord-notifier/moon.mod src/discord-notifier/moon.pkg ./
+COPY src/discord-notifier/*.mbt ./
+COPY src/discord-notifier/cmd ./cmd
+
+RUN moon update \
+  && moon build --target native --release
+
+FROM debian:bookworm-slim
+
+ENV TZ=Asia/Tokyo \
+  PORT=8080
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    tzdata \
+  && rm -rf /var/lib/apt/lists/* \
+  && groupadd --system app \
+  && useradd --system --gid app --home-dir /home/app --create-home \
+    --shell /usr/sbin/nologin app
+
+COPY --from=builder /src/_build/native/release/build/cmd/main/main.exe /usr/local/bin/discord-notifier
+
+USER app
+
+EXPOSE 8080
+
+CMD ["discord-notifier"]

--- a/infra/production/README.md
+++ b/infra/production/README.md
@@ -4,7 +4,7 @@
 
 ## Cloud Build
 
-- `cloudbuild/ci.yaml`: API / CLI / DB migrate / Admin / Viewer のコンテナを build / push し、Cloud Run service / job と Cloudflare Worker を deploy する
+- `cloudbuild/ci.yaml`: API / CLI / DB migrate / Admin / Viewer / Discord Notifier のコンテナを build / push し、Cloud Run service / job と Cloudflare Worker を deploy する
 - Cloud Build から実行する build command は YAML に直接定義する
 
 ## Dockerfiles
@@ -14,6 +14,7 @@
 - `docker/db-migrate/Dockerfile`: migration job 用で Atlas と schema 定義のみを含める
 - `docker/admin/Dockerfile`: Admin 用で build stage では `bun --filter admin build`、runtime stage では Bun slim image を使う
 - `docker/viewer/Dockerfile`: Viewer deploy job 用で `viewer-deploy` を entrypoint にする
+- `docker/discord-notifier/Dockerfile`: MoonBit 製 Discord Notifier を native ビルドして載せる
 
 ## 初回構築前提
 
@@ -28,9 +29,10 @@
 
 ## Notes
 
-- `ci.yaml` は Artifact Registry の repository を `_ARTIFACT_REPOSITORY`、image 名を `_API_IMAGE` / `_CLI_IMAGE` / `_DB_MIGRATE_IMAGE` / `_ADMIN_IMAGE` / `_VIEWER_IMAGE` で受け取る
+- `ci.yaml` は Artifact Registry の repository を `_ARTIFACT_REPOSITORY`、image 名を `_API_IMAGE` / `_CLI_IMAGE` / `_DB_MIGRATE_IMAGE` / `_ADMIN_IMAGE` / `_VIEWER_IMAGE` / `_DISCORD_NOTIFIER_IMAGE` で受け取る
 - Cloud Run の service / job 名は `prod-*` の値を YAML に直接定義する
 - Cloud Run jobs の service account は `_JOB_SERVICE_ACCOUNT` で受け取る
+- Discord Notifier の runtime service account は `_NOTIFY_SERVICE_ACCOUNT` で受け取る
 - Admin の `PUBLIC_APP_URL` は Cloud Build substitution の `_PUBLIC_APP_URL` を build arg として渡す
 - Viewer deploy job は `API_URL` / `SITE_URL` / Cloudflare Worker 名 / account ID / API token secret を受け取り、Cloudflare Workers へ deploy する
 - `APP_ENV=production` を Admin は Dockerfile の `ENV`、Viewer deploy job は runtime env で渡す。production では環境バッジを表示しない

--- a/infra/production/cloudbuild/ci.yaml
+++ b/infra/production/cloudbuild/ci.yaml
@@ -39,6 +39,14 @@ steps:
       - -c
       - docker pull ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_VIEWER_IMAGE}:latest || exit 0
 
+  - id: pull-discord-notifier-image
+    name: gcr.io/cloud-builders/docker
+    entrypoint: bash
+    waitFor: ["-"]
+    args:
+      - -c
+      - docker pull ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_DISCORD_NOTIFIER_IMAGE}:latest || exit 0
+
   - id: build-api-image
     name: gcr.io/cloud-builders/docker
     waitFor:
@@ -89,6 +97,26 @@ steps:
           -t ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_DB_MIGRATE_IMAGE}:latest \
           --cache-from ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_DB_MIGRATE_IMAGE}:latest \
           --build-arg "MISE_VERSION=$${MISE_VERSION}" \
+          .
+
+  - id: build-discord-notifier-image
+    name: gcr.io/cloud-builders/docker
+    entrypoint: bash
+    waitFor:
+      - pull-discord-notifier-image
+    args:
+      - -c
+      - |
+        set -euo pipefail
+
+        MOONBIT_VERSION=$$(./tools/read-mise-value.sh moonbit_version)
+
+        docker build \
+          -f infra/production/docker/discord-notifier/Dockerfile \
+          -t ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_DISCORD_NOTIFIER_IMAGE}:$COMMIT_SHA \
+          -t ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_DISCORD_NOTIFIER_IMAGE}:latest \
+          --cache-from ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_DISCORD_NOTIFIER_IMAGE}:latest \
+          --build-arg "MOONBIT_VERSION=$${MOONBIT_VERSION}" \
           .
 
   - id: build-admin-image
@@ -177,6 +205,15 @@ steps:
       - --all-tags
       - ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_VIEWER_IMAGE}
 
+  - id: push-discord-notifier-image
+    name: gcr.io/cloud-builders/docker
+    waitFor:
+      - build-discord-notifier-image
+    args:
+      - push
+      - --all-tags
+      - ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_DISCORD_NOTIFIER_IMAGE}
+
   # TODO マイグレーションを別で行う
   - id: deploy-db-migrate-job
     name: gcr.io/google.com/cloudsdktool/cloud-sdk
@@ -252,6 +289,23 @@ steps:
       - ${_API_SERVICE_ACCOUNT}
       - --ingress
       - ${_API_INGRESS}
+      - --quiet
+
+  - id: deploy-discord-notifier
+    name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    entrypoint: gcloud
+    waitFor:
+      - push-discord-notifier-image
+    args:
+      - run
+      - deploy
+      - prod-isekai-discord-notifier
+      - --image
+      - ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_DISCORD_NOTIFIER_IMAGE}:$COMMIT_SHA
+      - --region
+      - ${_REGION}
+      - --service-account
+      - ${_NOTIFY_SERVICE_ACCOUNT}
       - --quiet
 
   - id: deploy-admin

--- a/infra/production/docker/discord-notifier/Dockerfile
+++ b/infra/production/docker/discord-notifier/Dockerfile
@@ -1,0 +1,48 @@
+FROM debian:bookworm-slim AS builder
+
+ARG MOONBIT_VERSION
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    bash \
+    build-essential \
+    ca-certificates \
+    curl \
+    git \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV PATH="/root/.moon/bin:${PATH}"
+
+RUN curl -fsSL https://cli.moonbitlang.com/install/unix.sh \
+  | bash -s -- "${MOONBIT_VERSION}"
+
+WORKDIR /src
+
+COPY src/discord-notifier/moon.mod src/discord-notifier/moon.pkg ./
+COPY src/discord-notifier/*.mbt ./
+COPY src/discord-notifier/cmd ./cmd
+
+RUN moon update \
+  && moon build --target native --release
+
+FROM debian:bookworm-slim
+
+ENV TZ=Asia/Tokyo \
+  PORT=8080
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    tzdata \
+  && rm -rf /var/lib/apt/lists/* \
+  && groupadd --system app \
+  && useradd --system --gid app --home-dir /home/app --create-home \
+    --shell /usr/sbin/nologin app
+
+COPY --from=builder /src/_build/native/release/build/cmd/main/main.exe /usr/local/bin/discord-notifier
+
+USER app
+
+EXPOSE 8080
+
+CMD ["discord-notifier"]

--- a/infra/staging/README.md
+++ b/infra/staging/README.md
@@ -4,7 +4,7 @@
 
 ## Cloud Build
 
-- `cloudbuild/ci.yaml`: API / CLI / DB migrate / Admin / Viewer のコンテナを build / push し、Cloud Run service / job と Cloudflare Worker を deploy する
+- `cloudbuild/ci.yaml`: API / CLI / DB migrate / Admin / Viewer / Discord Notifier のコンテナを build / push し、Cloud Run service / job と Cloudflare Worker を deploy する
 - Cloud Build から実行する build command は YAML に直接定義する
 
 ## Dockerfiles
@@ -14,6 +14,7 @@
 - `docker/db-migrate/Dockerfile`: migration job 用で Atlas と schema 定義のみを含める
 - `docker/admin/Dockerfile`: Admin 用で build stage では `bun --filter admin build`、runtime stage では Bun slim image を使う
 - `docker/viewer/Dockerfile`: Viewer deploy job 用で `viewer-deploy` を entrypoint にする
+- `docker/discord-notifier/Dockerfile`: MoonBit 製 Discord Notifier を native ビルドして載せる
 
 ## 初回構築前提
 
@@ -28,9 +29,10 @@
 
 ## Notes
 
-- `ci.yaml` は Artifact Registry の repository を `_ARTIFACT_REPOSITORY`、image 名を `_API_IMAGE` / `_CLI_IMAGE` / `_DB_MIGRATE_IMAGE` / `_ADMIN_IMAGE` / `_VIEWER_IMAGE` で受け取る
+- `ci.yaml` は Artifact Registry の repository を `_ARTIFACT_REPOSITORY`、image 名を `_API_IMAGE` / `_CLI_IMAGE` / `_DB_MIGRATE_IMAGE` / `_ADMIN_IMAGE` / `_VIEWER_IMAGE` / `_DISCORD_NOTIFIER_IMAGE` で受け取る
 - Cloud Run の service / job 名は `stg-*` の値を YAML に直接定義する
 - Cloud Run jobs の service account は `_JOB_SERVICE_ACCOUNT` で受け取る
+- Discord Notifier の runtime service account は `_NOTIFY_SERVICE_ACCOUNT` で受け取る
 - Admin の `PUBLIC_APP_URL` は Cloud Build substitution の `_PUBLIC_APP_URL` を build arg として渡す
 - Viewer deploy job は `API_URL` / `SITE_URL` / Cloudflare Worker 名 / account ID / API token secret を受け取り、Cloudflare Workers へ deploy する
 - staging はクロール不要のため `SITE_NOINDEX=true` を渡し、robots.txt と meta robots を noindex にする

--- a/infra/staging/cloudbuild/ci.yaml
+++ b/infra/staging/cloudbuild/ci.yaml
@@ -39,6 +39,14 @@ steps:
       - -c
       - docker pull ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_VIEWER_IMAGE}:latest || exit 0
 
+  - id: pull-discord-notifier-image
+    name: gcr.io/cloud-builders/docker
+    entrypoint: bash
+    waitFor: ["-"]
+    args:
+      - -c
+      - docker pull ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_DISCORD_NOTIFIER_IMAGE}:latest || exit 0
+
   - id: build-api-image
     name: gcr.io/cloud-builders/docker
     waitFor:
@@ -89,6 +97,26 @@ steps:
           -t ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_DB_MIGRATE_IMAGE}:latest \
           --cache-from ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_DB_MIGRATE_IMAGE}:latest \
           --build-arg "MISE_VERSION=$${MISE_VERSION}" \
+          .
+
+  - id: build-discord-notifier-image
+    name: gcr.io/cloud-builders/docker
+    entrypoint: bash
+    waitFor:
+      - pull-discord-notifier-image
+    args:
+      - -c
+      - |
+        set -euo pipefail
+
+        MOONBIT_VERSION=$$(./tools/read-mise-value.sh moonbit_version)
+
+        docker build \
+          -f infra/staging/docker/discord-notifier/Dockerfile \
+          -t ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_DISCORD_NOTIFIER_IMAGE}:$COMMIT_SHA \
+          -t ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_DISCORD_NOTIFIER_IMAGE}:latest \
+          --cache-from ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_DISCORD_NOTIFIER_IMAGE}:latest \
+          --build-arg "MOONBIT_VERSION=$${MOONBIT_VERSION}" \
           .
 
   - id: build-admin-image
@@ -177,6 +205,15 @@ steps:
       - --all-tags
       - ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_VIEWER_IMAGE}
 
+  - id: push-discord-notifier-image
+    name: gcr.io/cloud-builders/docker
+    waitFor:
+      - build-discord-notifier-image
+    args:
+      - push
+      - --all-tags
+      - ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_DISCORD_NOTIFIER_IMAGE}
+
   # TODO マイグレーションを別で行う
   - id: deploy-db-migrate-job
     name: gcr.io/google.com/cloudsdktool/cloud-sdk
@@ -252,6 +289,23 @@ steps:
       - ${_API_SERVICE_ACCOUNT}
       - --ingress
       - ${_API_INGRESS}
+      - --quiet
+
+  - id: deploy-discord-notifier
+    name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    entrypoint: gcloud
+    waitFor:
+      - push-discord-notifier-image
+    args:
+      - run
+      - deploy
+      - stg-isekai-discord-notifier
+      - --image
+      - ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_DISCORD_NOTIFIER_IMAGE}:$COMMIT_SHA
+      - --region
+      - ${_REGION}
+      - --service-account
+      - ${_NOTIFY_SERVICE_ACCOUNT}
       - --quiet
 
   - id: deploy-admin

--- a/infra/staging/docker/discord-notifier/Dockerfile
+++ b/infra/staging/docker/discord-notifier/Dockerfile
@@ -1,0 +1,48 @@
+FROM debian:bookworm-slim AS builder
+
+ARG MOONBIT_VERSION
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    bash \
+    build-essential \
+    ca-certificates \
+    curl \
+    git \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV PATH="/root/.moon/bin:${PATH}"
+
+RUN curl -fsSL https://cli.moonbitlang.com/install/unix.sh \
+  | bash -s -- "${MOONBIT_VERSION}"
+
+WORKDIR /src
+
+COPY src/discord-notifier/moon.mod src/discord-notifier/moon.pkg ./
+COPY src/discord-notifier/*.mbt ./
+COPY src/discord-notifier/cmd ./cmd
+
+RUN moon update \
+  && moon build --target native --release
+
+FROM debian:bookworm-slim
+
+ENV TZ=Asia/Tokyo \
+  PORT=8080
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    tzdata \
+  && rm -rf /var/lib/apt/lists/* \
+  && groupadd --system app \
+  && useradd --system --gid app --home-dir /home/app --create-home \
+    --shell /usr/sbin/nologin app
+
+COPY --from=builder /src/_build/native/release/build/cmd/main/main.exe /usr/local/bin/discord-notifier
+
+USER app
+
+EXPOSE 8080
+
+CMD ["discord-notifier"]

--- a/mise.toml
+++ b/mise.toml
@@ -10,6 +10,8 @@ pnpm = "11.20.0"
 
 [vars]
 mise_version = "2026.7.13"
+# moonc の version 文字列 (moon version --all の moonc 行)。install script / Docker build-arg で共有する
+moonbit_version = "0.10.6+80dc50f24"
 server_tag = "8.5.7"
 proxy_tag = "1.27"
 openapi_tag = "7.21.0"
@@ -458,4 +460,24 @@ run = [
   "bun run biome:format:check",
   "bun run eslint:check",
   "bun run stylelint:check",
+]
+
+# -- Discord Notifier --
+
+[tasks."discord-notifier:test"]
+description = "discord-notifier の moon test を実行する"
+dir = "src/discord-notifier"
+run = "moon test"
+
+[tasks."discord-notifier:build"]
+description = "discord-notifier を native release ビルドする"
+dir = "src/discord-notifier"
+run = "moon build --target native --release"
+
+[tasks."discord-notifier:check"]
+description = "discord-notifier の check / test を実行する"
+dir = "src/discord-notifier"
+run = [
+  "moon check",
+  "moon test",
 ]

--- a/src/discord-notifier/.gitignore
+++ b/src/discord-notifier/.gitignore
@@ -1,0 +1,6 @@
+.DS_Store
+_build/
+target/
+target
+.mooncakes/
+.moonagent/

--- a/src/discord-notifier/AGENTS.md
+++ b/src/discord-notifier/AGENTS.md
@@ -1,0 +1,23 @@
+# discord-notifier
+
+MoonBit 製の Discord 通知配達サービス
+
+## 構成
+
+- `parse.mbt`: Pub/Sub envelope / アプリ通知 / Cloud Build 正規化
+- `config.mbt`: env からの action -> channel 振り分け
+- `dedup.mbt`: cloud_build started のプロセスローカル重複抑止
+- `discord.mbt`: embeds に status 既定色を付けて Webhook POST
+- `handle.mbt` / `server.mbt`: HTTP 配線
+
+## コマンド
+
+```bash
+moon check
+moon test
+moon fmt
+moon info
+moon build --target native --release
+```
+
+最後に `moon info && moon fmt` を回す

--- a/src/discord-notifier/README.md
+++ b/src/discord-notifier/README.md
@@ -1,0 +1,97 @@
+# discord-notifier
+
+Pub/Sub push を受け取り、Discord Webhook へ配達する Cloud Run 向けサービス (MoonBit)
+
+## 責務
+
+- `{env}-discord-notify` / `cloud-builds` からの Pub/Sub push を受ける
+- アプリ通知 JSON (`action` / `status` / `embeds`) を配達する
+- Cloud Build JSON を同じ契約に正規化して配達する
+- `action` を env の routing で channel に引き当て、`DISCORD_WEBHOOK_<CHANNEL>` へ投稿する
+
+## 契約
+
+```json
+{
+  "action": "media.youtube_import",
+  "status": "failed",
+  "embeds": [
+    {
+      "title": "YouTube 取り込みでエラーが発生しました",
+      "fields": [
+        { "name": "executed_at", "value": "2026-08-11T22:00:00+09:00", "inline": true },
+        { "name": "channel_id", "value": "UCxxxx", "inline": true }
+      ]
+    }
+  ]
+}
+```
+
+- `action`: 処理単位の識別子。Notifier が channel を決める
+- `status`: `started` / `succeeded` / `failed` / `alert` など。embed に `color` が無いときの既定色
+- `embeds`: Discord embed 配列 (必須・空不可)。見た目はここに寄せる
+
+## 色
+
+1. embed に `color` があればそれを使う
+2. 無ければ `status` から既定色を付ける
+
+## 振り分け
+
+1. `DISCORD_ACTION_ROUTING` で `action` → channel を引く
+2. マップに無い action は `DISCORD_DEFAULT_CHANNEL`(既定 `app`)
+3. `DISCORD_WEBHOOK_<CHANNEL>` へ POST
+
+新しい action を既存 channel へ送るだけなら routing の更新で足り、Notifier コードは触らない  
+新しい channel を作るときは Webhook 用 env / secret が追加で必要
+
+## ローカル
+
+前提: MoonBit toolchain (`moon`)
+
+```bash
+cd src/discord-notifier
+moon test
+moon build --target native --release
+```
+
+起動例:
+
+```bash
+export PORT=8080
+export DISCORD_DEFAULT_CHANNEL=app
+export DISCORD_ACTION_ROUTING='{"cloud_build":"build"}'
+export CLOUD_BUILD_TRIGGER_NAME=dev-isekai-ci
+export DISCORD_WEBHOOK_APP='https://example.com/webhooks/...'
+export DISCORD_WEBHOOK_BUILD='https://example.com/webhooks/...'
+moon run cmd/main --target native
+```
+
+生 JSON の動作確認:
+
+```bash
+curl -sS -X POST "http://127.0.0.1:8080/" \
+  -H 'Content-Type: application/json' \
+  -d '{"action":"media.youtube_import","status":"failed","embeds":[{"title":"test error","fields":[{"name":"executed_at","value":"2026-01-01T00:00:00Z","inline":true}]}]}'
+```
+
+## 環境変数
+
+| 名前 | 用途 |
+|---|---|
+| `PORT` | listen port (Cloud Run 既定) |
+| `DISCORD_DEFAULT_CHANNEL` | マップに無い action の channel (既定 `app`) |
+| `DISCORD_ACTION_ROUTING` | action -> channel のマップ (JSON) |
+| `DISCORD_WEBHOOK_<CHANNEL>` | channel ごとの Webhook URL |
+| `CLOUD_BUILD_TRIGGER_NAME` | 処理対象の Cloud Build trigger 名 |
+
+## コンテナ
+
+各環境の Dockerfile:
+
+- `infra/development/docker/discord-notifier/Dockerfile`
+- `infra/staging/docker/discord-notifier/Dockerfile`
+- `infra/production/docker/discord-notifier/Dockerfile`
+
+`mise.toml` の `moonbit_version` を build-arg `MOONBIT_VERSION` に渡す  
+バージョンは `moonc` の文字列 (`0.10.6+80dc50f24` 形式) で固定する

--- a/src/discord-notifier/cmd/main/main.mbt
+++ b/src/discord-notifier/cmd/main/main.mbt
@@ -1,0 +1,13 @@
+///|
+async fn main {
+  let config = @lib.Config::from_env() catch {
+    err => {
+      println("invalid config: \{err}")
+      return
+    }
+  }
+  let app = @lib.App::new(config)
+  @lib.serve(app) catch {
+    err => println("server stopped: \{err}")
+  }
+}

--- a/src/discord-notifier/cmd/main/moon.pkg
+++ b/src/discord-notifier/cmd/main/moon.pkg
@@ -1,0 +1,6 @@
+import {
+  "isekai-observatory/discord-notifier" @lib,
+  "moonbitlang/async",
+}
+
+pkgtype(kind: "executable")

--- a/src/discord-notifier/cmd/main/pkg.generated.mbti
+++ b/src/discord-notifier/cmd/main/pkg.generated.mbti
@@ -1,0 +1,12 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "isekai-observatory/discord-notifier/cmd/main"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits

--- a/src/discord-notifier/config.mbt
+++ b/src/discord-notifier/config.mbt
@@ -1,0 +1,65 @@
+///|
+pub(all) struct Config {
+  default_channel : String
+  action_routing : Map[String, String]
+  cloud_build_trigger_name : String
+  port : Int
+} derive(Eq, Debug)
+
+///|
+pub fn Config::from_env() -> Config raise {
+  let default_channel = match @env.get_env_var("DISCORD_DEFAULT_CHANNEL") {
+    Some(value) => if value == "" { "app" } else { value }
+    None => "app"
+  }
+  let action_routing = match @env.get_env_var("DISCORD_ACTION_ROUTING") {
+    None | Some("") => Map([])
+    Some(raw) => {
+      let json = @json.parse(raw) catch {
+        err => raise Failure("DISCORD_ACTION_ROUTING: \{err}")
+      }
+      @json.from_json(json) catch {
+        err => raise Failure("DISCORD_ACTION_ROUTING: \{err}")
+      }
+    }
+  }
+  let cloud_build_trigger_name = match
+    @env.get_env_var("CLOUD_BUILD_TRIGGER_NAME") {
+    Some(value) => value
+    None => ""
+  }
+  let port = match @env.get_env_var("PORT") {
+    None | Some("") => 8080
+    Some(raw) =>
+      @string.parse_int(raw) catch {
+        _ => raise Failure("PORT must be an integer: \{raw}")
+      }
+  }
+  { default_channel, action_routing, cloud_build_trigger_name, port }
+}
+
+///|
+/// channel `build` -> env `DISCORD_WEBHOOK_BUILD`
+pub fn webhook_env_name(channel : String) -> String {
+  "DISCORD_WEBHOOK_\{channel.to_upper()}"
+}
+
+///|
+/// action を channel に解決する
+/// ROUTING に無い action は default_channel へ送る
+pub fn Config::resolve_channel(self : Config, action : String) -> String {
+  match self.action_routing.get(action) {
+    Some(channel) => channel
+    None => self.default_channel
+  }
+}
+
+///|
+pub fn Config::resolve_webhook_url(self : Config, action : String) -> String? {
+  let channel = self.resolve_channel(action)
+  let env_name = webhook_env_name(channel)
+  match @env.get_env_var(env_name) {
+    Some(url) => if url == "" { None } else { Some(url) }
+    None => None
+  }
+}

--- a/src/discord-notifier/dedup.mbt
+++ b/src/discord-notifier/dedup.mbt
@@ -1,0 +1,24 @@
+///|
+/// プロセスローカルな build started 重複抑止
+/// コールドスタート後は消えるので、稀な重複は許容する
+pub struct StartedBuildDeduper {
+  seen : @hashset.HashSet[String]
+}
+
+///|
+pub fn StartedBuildDeduper::new() -> StartedBuildDeduper {
+  { seen: @hashset.HashSet([]) }
+}
+
+///|
+/// まだ見ていないなら true (通知すべき)
+/// すでに見たなら false (スキップ)
+pub fn StartedBuildDeduper::should_notify_started(
+  self : StartedBuildDeduper,
+  build_id : String,
+) -> Bool {
+  if build_id == "" {
+    return true
+  }
+  self.seen.add_and_check(build_id)
+}

--- a/src/discord-notifier/discord.mbt
+++ b/src/discord-notifier/discord.mbt
@@ -1,0 +1,70 @@
+///|
+/// Discord embed の色 (RGB を Int で表す)
+fn embed_color_for_status(status : String) -> Int {
+  match status {
+    "succeeded" => 0x57F287
+    "failed" | "alert" => 0xED4245
+    "started" => 0x3498DB
+    _ => 0x95A5A6
+  }
+}
+
+///|
+pub fn has_embeds(embeds : Json) -> Bool {
+  match embeds {
+    Array(items) => items.length() > 0
+    _ => false
+  }
+}
+
+///|
+/// embed に color が無ければ status 由来の色を付ける
+fn ensure_embed_color(embed : Json, color : Int) -> Json {
+  guard embed is Object(map) else { return embed }
+  match map.get("color") {
+    Some(_) => embed
+    None => {
+      let out : Map[String, Json] = Map([], capacity=map.length() + 1)
+      for k, v in map {
+        out[k] = v
+      }
+      out["color"] = color.to_json()
+      out.to_json()
+    }
+  }
+}
+
+///|
+fn apply_status_colors(embeds : Json, status : String) -> Json {
+  let color = embed_color_for_status(status)
+  guard embeds is Array(items) else { return embeds }
+  let out : Array[Json] = []
+  for embed in items {
+    out.push(ensure_embed_color(embed, color))
+  }
+  out.to_json()
+}
+
+///|
+/// embeds の color 未指定に status 既定色を付けて Discord payload にする
+pub fn build_discord_payload(notification : Notification) -> Json {
+  { "embeds": apply_status_colors(notification.embeds, notification.status) }
+}
+
+///|
+pub async fn post_discord_webhook(
+  webhook_url : String,
+  notification : Notification,
+) -> Unit {
+  let payload = build_discord_payload(notification)
+  let (response, body) = @http.post(webhook_url, payload, headers={
+    "Content-Type": "application/json",
+  })
+  defer ignore(body)
+  guard response.code is (200..<300) else {
+    let body_text = body.text() catch { _ => "" }
+    raise Failure(
+      "discord webhook failed: \{response.code} \{response.reason} \{body_text}",
+    )
+  }
+}

--- a/src/discord-notifier/handle.mbt
+++ b/src/discord-notifier/handle.mbt
@@ -1,0 +1,54 @@
+///|
+pub struct App {
+  config : Config
+  deduper : StartedBuildDeduper
+}
+
+///|
+pub fn App::new(config : Config) -> App {
+  { config, deduper: StartedBuildDeduper::new() }
+}
+
+///|
+pub async fn App::handle_body(self : App, body : String) -> Outcome {
+  let notification = parse_request_body(
+    body,
+    cloud_build_trigger_name=self.config.cloud_build_trigger_name,
+  ) catch {
+    err => {
+      println("ack permanent parse error: \{err.to_string()}")
+      return Ack
+    }
+  }
+  guard notification is Some(notification) else { return Ack }
+
+  if notification.action == "cloud_build" && notification.status == "started" {
+    let build_id = match cloud_build_id(body) {
+      Some(id) => id
+      None => ""
+    }
+    guard self.deduper.should_notify_started(build_id) else {
+      println("skip duplicate cloud_build started: \{build_id}")
+      return Ack
+    }
+  }
+
+  let channel = self.config.resolve_channel(notification.action)
+  let webhook_url = match self.config.resolve_webhook_url(notification.action) {
+    Some(url) => url
+    None => {
+      println(
+        "ack missing webhook for channel=\{channel} action=\{notification.action} status=\{notification.status}",
+      )
+      return Ack
+    }
+  }
+
+  post_discord_webhook(webhook_url, notification) catch {
+    err => return Retry(err.to_string())
+  }
+  println(
+    "delivered action=\{notification.action} status=\{notification.status} channel=\{channel}",
+  )
+  Ack
+}

--- a/src/discord-notifier/moon.mod
+++ b/src/discord-notifier/moon.mod
@@ -1,0 +1,17 @@
+name = "isekai-observatory/discord-notifier"
+
+version = "0.1.0"
+
+readme = "README.md"
+
+repository = ""
+
+keywords = [ ]
+
+preferred_target = "native"
+
+description = "Pub/Sub push を受けて Discord Webhook へ配達する Cloud Run Notifier"
+
+import {
+  "moonbitlang/async@0.20.4",
+}

--- a/src/discord-notifier/moon.pkg
+++ b/src/discord-notifier/moon.pkg
@@ -1,0 +1,15 @@
+import {
+  "moonbitlang/async/http",
+  "moonbitlang/async/io",
+  "moonbitlang/async/socket",
+  "moonbitlang/core/encoding/base64",
+  "moonbitlang/core/encoding/utf8",
+  "moonbitlang/core/env",
+  "moonbitlang/core/hashset",
+  "moonbitlang/core/json",
+  "moonbitlang/core/string",
+}
+
+import {
+  "moonbitlang/core/test",
+} for "wbtest"

--- a/src/discord-notifier/parse.mbt
+++ b/src/discord-notifier/parse.mbt
@@ -1,0 +1,109 @@
+///|
+/// HTTP body (Pub/Sub push envelope または生 JSON) から Notification を取り出す
+/// Cloud Build で対象外 / 未対応 status のときは None
+pub fn parse_request_body(
+  body : String,
+  cloud_build_trigger_name~ : String,
+) -> Notification? raise ParseError {
+  let root = @json.parse(body) catch {
+    _ => raise InvalidJson("failed to parse request body")
+  }
+  let payload = extract_payload_json(root)
+  parse_payload_json(payload, cloud_build_trigger_name~)
+}
+
+///|
+fn extract_payload_json(root : Json) -> Json raise ParseError {
+  match root {
+    { "message": { "data": String(data), .. }, .. } => {
+      let bytes = @base64.decode(data, ignore_whitespace=true) catch {
+        _ => raise InvalidBase64("failed to decode message.data")
+      }
+      let text = @utf8.decode(bytes) catch {
+        _ => raise InvalidPayload("message.data is not valid utf8")
+      }
+      @json.parse(text) catch {
+        _ => raise InvalidJson("failed to parse decoded message.data")
+      }
+    }
+    _ => root
+  }
+}
+
+///|
+fn parse_payload_json(
+  payload : Json,
+  cloud_build_trigger_name~ : String,
+) -> Notification? raise ParseError {
+  match payload {
+    { "action": String(action), "status": String(status), "embeds": embeds, .. } => {
+      guard has_embeds(embeds) else {
+        raise InvalidPayload("embeds must be a non-empty array")
+      }
+      Some({ action, status, embeds })
+    }
+    { "id": String(_), "status": String(status), .. } =>
+      parse_cloud_build(payload, status, cloud_build_trigger_name~)
+    _ =>
+      raise InvalidPayload(
+        "expected app notification with action/status/embeds or Cloud Build JSON",
+      )
+  }
+}
+
+///|
+fn parse_cloud_build(
+  payload : Json,
+  status : String,
+  cloud_build_trigger_name~ : String,
+) -> Notification? {
+  let trigger_name = extract_trigger_name(payload)
+  guard cloud_build_trigger_name != "" &&
+    trigger_name == cloud_build_trigger_name else {
+    return None
+  }
+  let (notify_status, title) = match status {
+    "WORKING" => ("started", "Cloud Build が開始しました")
+    "SUCCESS" => ("succeeded", "Cloud Build が成功しました")
+    "FAILURE" | "INTERNAL_ERROR" | "TIMEOUT" | "CANCELLED" =>
+      ("failed", "Cloud Build が失敗しました")
+    _ => return None
+  }
+  let build_id = match payload {
+    { "id": String(id), .. } => id
+    _ => "unknown"
+  }
+  let log_url = match payload {
+    { "logUrl": String(url), .. } => url
+    _ => ""
+  }
+  let fields : Json = [
+    { "name": "build_id", "value": build_id, "inline": true },
+    { "name": "trigger", "value": trigger_name, "inline": true },
+  ]
+  let embed : Json = if log_url == "" {
+    { "title": title, "fields": fields }
+  } else {
+    { "title": title, "url": log_url, "fields": fields }
+  }
+  Some({ action: "cloud_build", status: notify_status, embeds: [embed] })
+}
+
+///|
+fn extract_trigger_name(payload : Json) -> String {
+  match payload {
+    { "substitutions": { "TRIGGER_NAME": String(name), .. }, .. } => name
+    _ => ""
+  }
+}
+
+///|
+/// build started の重複抑止用に build id を取り出す
+pub fn cloud_build_id(payload_json_text : String) -> String? {
+  let root = @json.parse(payload_json_text) catch { _ => return None }
+  let payload = extract_payload_json(root) catch { _ => return None }
+  match payload {
+    { "id": String(id), "status": String(_), .. } => Some(id)
+    _ => None
+  }
+}

--- a/src/discord-notifier/parse_wbtest.mbt
+++ b/src/discord-notifier/parse_wbtest.mbt
@@ -1,0 +1,227 @@
+///|
+fn encode_pubsub(inner : String) -> String {
+  let data = @base64.encode(@utf8.encode(inner))
+  "{\"message\":{\"data\":\"\{data}\"}}"
+}
+
+///|
+test "parse app notification raw" {
+  let body = "{\"action\":\"media.youtube_import\",\"status\":\"failed\",\"embeds\":[{\"title\":\"boom\",\"fields\":[{\"name\":\"executed_at\",\"value\":\"2026-01-01T00:00:00Z\"}]}]}"
+  let notification = parse_request_body(
+    body,
+    cloud_build_trigger_name="dev-isekai-ci",
+  )
+  guard notification is Some(n) else { fail("expected notification") }
+  assert_eq(n.action, "media.youtube_import")
+  assert_eq(n.status, "failed")
+  guard n.embeds is Array(items) else { fail("expected embeds") }
+  assert_eq(items.length(), 1)
+}
+
+///|
+test "parse app notification via pubsub envelope" {
+  let inner = "{\"action\":\"admin.invite\",\"status\":\"succeeded\",\"embeds\":[{\"title\":\"ok\"}]}"
+  let body = encode_pubsub(inner)
+  let notification = parse_request_body(
+    body,
+    cloud_build_trigger_name="dev-isekai-ci",
+  )
+  guard notification is Some(n) else { fail("expected notification") }
+  assert_eq(n.action, "admin.invite")
+  assert_eq(n.status, "succeeded")
+}
+
+///|
+test "parse app notification requires action" {
+  let err = @test.expect_error(() => {
+    parse_request_body(
+      "{\"status\":\"failed\",\"embeds\":[{\"title\":\"boom\"}]}",
+      cloud_build_trigger_name="dev-isekai-ci",
+    )
+    |> ignore
+  })
+  guard err is InvalidPayload(_) else { fail("expected InvalidPayload") }
+}
+
+///|
+test "parse app notification rejects empty embeds" {
+  let err = @test.expect_error(() => {
+    parse_request_body(
+      "{\"action\":\"admin.invite\",\"status\":\"succeeded\",\"embeds\":[]}",
+      cloud_build_trigger_name="dev-isekai-ci",
+    )
+    |> ignore
+  })
+  guard err is InvalidPayload(_) else { fail("expected InvalidPayload") }
+}
+
+///|
+test "parse cloud build working" {
+  let inner = "{\"id\":\"build-1\",\"status\":\"WORKING\",\"logUrl\":\"https://example.com/log\",\"substitutions\":{\"TRIGGER_NAME\":\"dev-isekai-ci\"}}"
+  let notification = parse_request_body(
+    encode_pubsub(inner),
+    cloud_build_trigger_name="dev-isekai-ci",
+  )
+  guard notification is Some(n) else { fail("expected notification") }
+  assert_eq(n.action, "cloud_build")
+  assert_eq(n.status, "started")
+  guard n.embeds
+    is [
+      {
+        "title": String(title),
+        "url": String(url),
+        "fields": Array(fields),
+        ..
+      },
+    ] else {
+    fail("expected embed")
+  }
+  assert_eq(title, "Cloud Build が開始しました")
+  assert_eq(url, "https://example.com/log")
+  assert_eq(fields.length(), 2)
+}
+
+///|
+test "parse cloud build without log url" {
+  let inner = "{\"id\":\"build-2\",\"status\":\"SUCCESS\",\"substitutions\":{\"TRIGGER_NAME\":\"dev-isekai-ci\"}}"
+  let notification = parse_request_body(
+    encode_pubsub(inner),
+    cloud_build_trigger_name="dev-isekai-ci",
+  )
+  guard notification is Some(n) else { fail("expected notification") }
+  assert_eq(n.status, "succeeded")
+  guard n.embeds is Array(items) else { fail("expected embeds") }
+  assert_eq(items.length(), 1)
+  guard items[0] is Object(map) else { fail("expected object") }
+  guard map.get("title") is Some(String(title)) else { fail("expected title") }
+  assert_eq(title, "Cloud Build が成功しました")
+  assert_eq(map.get("url"), None)
+  guard map.get("fields") is Some(Array(fields)) else {
+    fail("expected fields")
+  }
+  assert_eq(fields.length(), 2)
+}
+
+///|
+test "parse cloud build ignores other trigger" {
+  let inner = "{\"id\":\"build-1\",\"status\":\"SUCCESS\",\"substitutions\":{\"TRIGGER_NAME\":\"other\"}}"
+  let notification = parse_request_body(
+    encode_pubsub(inner),
+    cloud_build_trigger_name="dev-isekai-ci",
+  )
+  assert_eq(notification, None)
+}
+
+///|
+test "parse cloud build failed statuses" {
+  let statuses = ["FAILURE", "INTERNAL_ERROR", "TIMEOUT", "CANCELLED"]
+  for status in statuses {
+    let inner = "{\"id\":\"b\",\"status\":\"\{status}\",\"substitutions\":{\"TRIGGER_NAME\":\"dev-isekai-ci\"}}"
+    let notification = parse_request_body(
+      encode_pubsub(inner),
+      cloud_build_trigger_name="dev-isekai-ci",
+    )
+    guard notification is Some(n) else { fail("expected \{status}") }
+    assert_eq(n.action, "cloud_build")
+    assert_eq(n.status, "failed")
+  }
+}
+
+///|
+test "resolve channel from action routing" {
+  let config : Config = {
+    default_channel: "app",
+    action_routing: { "cloud_build": "build", "ops.alert": "ops" },
+    cloud_build_trigger_name: "dev-isekai-ci",
+    port: 8080,
+  }
+  assert_eq(config.resolve_channel("cloud_build"), "build")
+  assert_eq(config.resolve_channel("ops.alert"), "ops")
+  assert_eq(config.resolve_channel("media.youtube_import"), "app")
+  assert_eq(config.resolve_channel(""), "app")
+  assert_eq(webhook_env_name("build"), "DISCORD_WEBHOOK_BUILD")
+  assert_eq(webhook_env_name("app"), "DISCORD_WEBHOOK_APP")
+}
+
+///|
+test "dedupe started builds" {
+  let deduper = StartedBuildDeduper::new()
+  assert_true(deduper.should_notify_started("build-1"))
+  assert_false(deduper.should_notify_started("build-1"))
+  assert_true(deduper.should_notify_started("build-2"))
+}
+
+///|
+test "discord payload fills status color when missing" {
+  let payload = build_discord_payload({
+    action: "media.youtube_import",
+    status: "failed",
+    embeds: [
+      {
+        "title": "取り込みでエラーが発生しました",
+        "fields": [
+          {
+            "name": "executed_at",
+            "value": "2026-01-01T00:00:00Z",
+            "inline": true,
+          },
+        ],
+      },
+    ],
+  })
+  guard payload
+    is {
+      "embeds": [
+        {
+          "title": String(title),
+          "color": Number(color, ..),
+          "fields": fields,
+          ..
+        },
+      ],
+      ..
+    } else {
+    fail("expected colored embed")
+  }
+  assert_eq(title, "取り込みでエラーが発生しました")
+  assert_eq(color.to_int(), 0xED4245)
+  guard fields is Array(items) else { fail("expected fields") }
+  assert_eq(items.length(), 1)
+}
+
+///|
+test "discord payload keeps explicit embed color" {
+  let payload = build_discord_payload({
+    action: "media.youtube_import",
+    status: "failed",
+    embeds: [{ "title": "custom", "color": 1 }],
+  })
+  guard payload is { "embeds": [{ "color": Number(color, ..), .. }], .. } else {
+    fail("expected embed")
+  }
+  assert_eq(color.to_int(), 1)
+}
+
+///|
+test "discord payload colors by status" {
+  let succeeded = build_discord_payload({
+    action: "cloud_build",
+    status: "succeeded",
+    embeds: [{ "title": "ok" }],
+  })
+  guard succeeded is { "embeds": [{ "color": Number(color, ..), .. }], .. } else {
+    fail("expected embed")
+  }
+  assert_eq(color.to_int(), 0x57F287)
+
+  let started = build_discord_payload({
+    action: "cloud_build",
+    status: "started",
+    embeds: [{ "title": "working" }],
+  })
+  guard started
+    is { "embeds": [{ "color": Number(started_color, ..), .. }], .. } else {
+    fail("expected embed")
+  }
+  assert_eq(started_color.to_int(), 0x3498DB)
+}

--- a/src/discord-notifier/pkg.generated.mbti
+++ b/src/discord-notifier/pkg.generated.mbti
@@ -1,0 +1,69 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "isekai-observatory/discord-notifier"
+
+import {
+  "moonbitlang/core/debug",
+  "moonbitlang/core/hashset",
+}
+
+// Values
+pub fn build_discord_payload(Notification) -> Json
+
+pub fn cloud_build_id(String) -> String?
+
+pub fn has_embeds(Json) -> Bool
+
+pub fn parse_request_body(String, cloud_build_trigger_name~ : String) -> Notification? raise ParseError
+
+pub async fn post_discord_webhook(String, Notification) -> Unit
+
+pub async fn serve(App) -> Unit
+
+pub fn webhook_env_name(String) -> String
+
+// Errors
+pub suberror ParseError {
+  InvalidJson(String)
+  InvalidBase64(String)
+  InvalidPayload(String)
+} derive(Eq, @debug.Debug)
+pub fn ParseError::to_string(Self) -> String
+
+// Types and methods
+pub struct App {
+  config : Config
+  deduper : StartedBuildDeduper
+}
+pub async fn App::handle_body(Self, String) -> Outcome
+pub fn App::new(Config) -> Self
+
+pub(all) struct Config {
+  default_channel : String
+  action_routing : Map[String, String]
+  cloud_build_trigger_name : String
+  port : Int
+} derive(Eq, @debug.Debug)
+pub fn Config::from_env() -> Self raise
+pub fn Config::resolve_channel(Self, String) -> String
+pub fn Config::resolve_webhook_url(Self, String) -> String?
+
+pub struct Notification {
+  action : String
+  status : String
+  embeds : Json
+} derive(Eq, @debug.Debug)
+
+pub(all) enum Outcome {
+  Ack
+  Retry(String)
+} derive(Eq, @debug.Debug)
+
+pub struct StartedBuildDeduper {
+  seen : @hashset.HashSet[String]
+}
+pub fn StartedBuildDeduper::new() -> Self
+pub fn StartedBuildDeduper::should_notify_started(Self, String) -> Bool
+
+// Type aliases
+
+// Traits

--- a/src/discord-notifier/server.mbt
+++ b/src/discord-notifier/server.mbt
@@ -1,0 +1,45 @@
+///|
+async fn respond(
+  conn : @http.ServerConnection,
+  code : Int,
+  reason : String,
+  body? : String = "",
+) -> Unit {
+  conn.send_response(code, reason, extra_headers={
+    "Content-Type": "text/plain; charset=utf-8",
+  })
+  if body != "" {
+    conn.write_string(body)
+  }
+  conn.end_response()
+}
+
+///|
+pub async fn serve(app : App) -> Unit {
+  let addr = @socket.Addr::parse("[::]:\{app.config.port}")
+  let server = @http.Server(addr)
+  println("discord-notifier listening on \{server.addr}")
+  server.run_forever() <| ((request, body, conn) => {
+    match request.meth {
+      Get => respond(conn, 200, "OK", body="ok")
+      Post => {
+        let text = body.read_all().text() catch {
+            err => {
+              // 一時失敗として Pub/Sub に再送させる (恒久失敗の Ack と区別する)
+              println("retry: failed to read body: \{err}")
+              respond(conn, 500, "Internal Server Error", body="failed to read body")
+              return
+            }
+          }
+        match app.handle_body(text) {
+          Ack => respond(conn, 204, "No Content")
+          Retry(msg) => {
+            println("retry: \{msg}")
+            respond(conn, 500, "Internal Server Error", body=msg)
+          }
+        }
+      }
+      _ => respond(conn, 405, "Method Not Allowed")
+    }
+  })
+}

--- a/src/discord-notifier/types.mbt
+++ b/src/discord-notifier/types.mbt
@@ -1,0 +1,32 @@
+///|
+/// Discord へ送る正規化済み通知
+pub struct Notification {
+  action : String
+  status : String
+  embeds : Json
+} derive(Eq, Debug)
+
+///|
+/// 1 メッセージ処理の結果
+pub(all) enum Outcome {
+  /// Pub/Sub に ack してよい (配達成功 / 意図的スキップ / 恒久失敗)
+  Ack
+  /// 一時失敗。Pub/Sub に再送させる
+  Retry(String)
+} derive(Eq, Debug)
+
+///|
+pub suberror ParseError {
+  InvalidJson(String)
+  InvalidBase64(String)
+  InvalidPayload(String)
+} derive(Eq, Debug)
+
+///|
+pub fn ParseError::to_string(self : ParseError) -> String {
+  match self {
+    InvalidJson(msg) => "invalid json: \{msg}"
+    InvalidBase64(msg) => "invalid base64: \{msg}"
+    InvalidPayload(msg) => "invalid payload: \{msg}"
+  }
+}


### PR DESCRIPTION
## 概要

Pub/Sub push を受けて Discord Webhook へ配達する Cloud Run 向け Notifier (`src/discord-notifier`) を追加する。発信元は `action` を送り、チャンネル振り分けは Notifier 側の env で行う。

## やったこと

- MoonBit 製 `discord-notifier` を追加し、アプリ通知と Cloud Build を共通契約へ正規化して配達する
- 契約を `action` / `status` / `embeds` にする（embeds 必須・空不可。`color` が無ければ `status` の既定色を付ける）
- `DISCORD_ACTION_ROUTING` で `action` → channel → `DISCORD_WEBHOOK_<CHANNEL>` を解決する
- 各環境の Dockerfile / Cloud Build CI / mise タスクと design-docs を追加する

## やってないこと

- PHP 側からの Pub/Sub publish
- infra repo の Terraform apply / secret value 投入
- 実 Discord Webhook への結合確認

## 関連

- 特になし