### PR TITLE
discord-notifier で content / embeds を任意にしどちらか一方を必須にする

### DIFF
--- a/src/discord-notifier/README.md
+++ b/src/discord-notifier/README.md
@@ -5,7 +5,7 @@ Pub/Sub push を受け取り、Discord Webhook へ配達する Cloud Run 向け�
 ## 責務
 
 - `{env}-discord-notify` / `cloud-builds` からの Pub/Sub push を受ける
-- アプリ通知 JSON (`action` / `status` / `embeds`) を配達する
+- アプリ通知 JSON (`action` / `status` / `content?` / `embeds?`) を配達する
 - Cloud Build JSON を同じ契約に正規化して配達する
 - `action` を env の routing で channel に引き当て、`DISCORD_WEBHOOK_<CHANNEL>` へ投稿する
 
@@ -15,6 +15,7 @@ Pub/Sub push を受け取り、Discord Webhook へ配達する Cloud Run 向け�
 {
   "action": "media.youtube_import",
   "status": "failed",
+  "content": "YouTube 取り込みでエラーが発生しました",
   "embeds": [
     {
       "title": "YouTube 取り込みでエラーが発生しました",
@@ -29,7 +30,9 @@ Pub/Sub push を受け取り、Discord Webhook へ配達する Cloud Run 向け�
 
 - `action`: 処理単位の識別子。Notifier が channel を決める
 - `status`: `started` / `succeeded` / `failed` / `alert` など。embed に `color` が無いときの既定色
-- `embeds`: Discord embed 配列 (必須・空不可)。見た目はここに寄せる
+- `content`: Discord webhook の本文 (任意)。空文字や未指定なら payload に載せない
+- `embeds`: Discord embed 配列 (任意)。空配列や未指定なら payload に載せない
+- `content` と非空の `embeds` のどちらか一方は必須
 
 ## 色
 
@@ -72,7 +75,7 @@ moon run cmd/main --target native
 ```bash
 curl -sS -X POST "http://127.0.0.1:8080/" \
   -H 'Content-Type: application/json' \
-  -d '{"action":"media.youtube_import","status":"failed","embeds":[{"title":"test error","fields":[{"name":"executed_at","value":"2026-01-01T00:00:00Z","inline":true}]}]}'
+  -d '{"action":"media.youtube_import","status":"failed","content":"test error","embeds":[{"title":"test error","fields":[{"name":"executed_at","value":"2026-01-01T00:00:00Z","inline":true}]}]}'
 ```
 
 ## 環境変数

--- a/src/discord-notifier/discord.mbt
+++ b/src/discord-notifier/discord.mbt
@@ -46,9 +46,22 @@ fn apply_status_colors(embeds : Json, status : String) -> Json {
 }
 
 ///|
-/// embeds の color 未指定に status 既定色を付けて Discord payload にする
+/// content / embeds を Discord webhook payload にする
+/// embeds の color 未指定には status 既定色を付ける
 pub fn build_discord_payload(notification : Notification) -> Json {
-  { "embeds": apply_status_colors(notification.embeds, notification.status) }
+  match (notification.content, notification.embeds) {
+    (Some(content), Some(embeds)) =>
+      {
+        "content": content,
+        "embeds": apply_status_colors(embeds, notification.status),
+      }
+    (Some(content), None) => { "content": content }
+    (None, Some(embeds)) =>
+      { "embeds": apply_status_colors(embeds, notification.status) }
+    (None, None) =>
+      // parse で content / embeds のどちらかを必須にしている
+      { "content": "" }
+  }
 }
 
 ///|

--- a/src/discord-notifier/parse.mbt
+++ b/src/discord-notifier/parse.mbt
@@ -36,18 +36,50 @@ fn parse_payload_json(
   cloud_build_trigger_name~ : String,
 ) -> Notification? raise ParseError {
   match payload {
-    { "action": String(action), "status": String(status), "embeds": embeds, .. } => {
-      guard has_embeds(embeds) else {
-        raise InvalidPayload("embeds must be a non-empty array")
+    { "action": String(action), "status": String(status), .. } => {
+      let content = extract_content(payload)
+      let embeds = extract_embeds(payload)
+      guard content is Some(_) || embeds is Some(_) else {
+        raise InvalidPayload("content or non-empty embeds is required")
       }
-      Some({ action, status, embeds })
+      Some({ action, status, content, embeds })
     }
     { "id": String(_), "status": String(status), .. } =>
       parse_cloud_build(payload, status, cloud_build_trigger_name~)
     _ =>
       raise InvalidPayload(
-        "expected app notification with action/status/embeds or Cloud Build JSON",
+        "expected app notification with action/status or Cloud Build JSON",
       )
+  }
+}
+
+///|
+fn extract_content(payload : Json) -> String? {
+  match payload {
+    { "content": String(content), .. } =>
+      if content == "" {
+        None
+      } else {
+        Some(content)
+      }
+    _ => None
+  }
+}
+
+///|
+fn extract_embeds(payload : Json) -> Json? raise ParseError {
+  match payload {
+    { "embeds": embeds, .. } => {
+      guard embeds is Array(_) else {
+        raise InvalidPayload("embeds must be an array")
+      }
+      if has_embeds(embeds) {
+        Some(embeds)
+      } else {
+        None
+      }
+    }
+    _ => None
   }
 }
 
@@ -86,7 +118,12 @@ fn parse_cloud_build(
   } else {
     { "title": title, "url": log_url, "fields": fields }
   }
-  Some({ action: "cloud_build", status: notify_status, embeds: [embed] })
+  Some({
+    action: "cloud_build",
+    status: notify_status,
+    content: None,
+    embeds: Some([embed]),
+  })
 }
 
 ///|

--- a/src/discord-notifier/parse_wbtest.mbt
+++ b/src/discord-notifier/parse_wbtest.mbt
@@ -14,8 +14,58 @@ test "parse app notification raw" {
   guard notification is Some(n) else { fail("expected notification") }
   assert_eq(n.action, "media.youtube_import")
   assert_eq(n.status, "failed")
-  guard n.embeds is Array(items) else { fail("expected embeds") }
+  assert_eq(n.content, None)
+  guard n.embeds is Some(embeds) else { fail("expected embeds") }
+  guard embeds is Array(items) else { fail("expected array") }
   assert_eq(items.length(), 1)
+}
+
+///|
+test "parse app notification with content" {
+  let body = "{\"action\":\"media.youtube_import\",\"status\":\"failed\",\"content\":\"取り込み失敗\",\"embeds\":[{\"title\":\"boom\"}]}"
+  let notification = parse_request_body(
+    body,
+    cloud_build_trigger_name="dev-isekai-ci",
+  )
+  guard notification is Some(n) else { fail("expected notification") }
+  assert_eq(n.content, Some("取り込み失敗"))
+  guard n.embeds is Some(_) else { fail("expected embeds") }
+}
+
+///|
+test "parse app notification content only" {
+  let body = "{\"action\":\"media.youtube_import\",\"status\":\"failed\",\"content\":\"取り込み失敗\"}"
+  let notification = parse_request_body(
+    body,
+    cloud_build_trigger_name="dev-isekai-ci",
+  )
+  guard notification is Some(n) else { fail("expected notification") }
+  assert_eq(n.content, Some("取り込み失敗"))
+  assert_eq(n.embeds, None)
+}
+
+///|
+test "parse app notification ignores empty content when embeds present" {
+  let body = "{\"action\":\"media.youtube_import\",\"status\":\"failed\",\"content\":\"\",\"embeds\":[{\"title\":\"boom\"}]}"
+  let notification = parse_request_body(
+    body,
+    cloud_build_trigger_name="dev-isekai-ci",
+  )
+  guard notification is Some(n) else { fail("expected notification") }
+  assert_eq(n.content, None)
+  guard n.embeds is Some(_) else { fail("expected embeds") }
+}
+
+///|
+test "parse app notification ignores empty embeds when content present" {
+  let body = "{\"action\":\"media.youtube_import\",\"status\":\"failed\",\"content\":\"取り込み失敗\",\"embeds\":[]}"
+  let notification = parse_request_body(
+    body,
+    cloud_build_trigger_name="dev-isekai-ci",
+  )
+  guard notification is Some(n) else { fail("expected notification") }
+  assert_eq(n.content, Some("取り込み失敗"))
+  assert_eq(n.embeds, None)
 }
 
 ///|
@@ -44,10 +94,22 @@ test "parse app notification requires action" {
 }
 
 ///|
-test "parse app notification rejects empty embeds" {
+test "parse app notification requires content or embeds" {
   let err = @test.expect_error(() => {
     parse_request_body(
-      "{\"action\":\"admin.invite\",\"status\":\"succeeded\",\"embeds\":[]}",
+      "{\"action\":\"admin.invite\",\"status\":\"succeeded\"}",
+      cloud_build_trigger_name="dev-isekai-ci",
+    )
+    |> ignore
+  })
+  guard err is InvalidPayload(_) else { fail("expected InvalidPayload") }
+}
+
+///|
+test "parse app notification rejects empty content and empty embeds" {
+  let err = @test.expect_error(() => {
+    parse_request_body(
+      "{\"action\":\"admin.invite\",\"status\":\"succeeded\",\"content\":\"\",\"embeds\":[]}",
       cloud_build_trigger_name="dev-isekai-ci",
     )
     |> ignore
@@ -65,7 +127,9 @@ test "parse cloud build working" {
   guard notification is Some(n) else { fail("expected notification") }
   assert_eq(n.action, "cloud_build")
   assert_eq(n.status, "started")
-  guard n.embeds
+  assert_eq(n.content, None)
+  guard n.embeds is Some(embeds) else { fail("expected embeds") }
+  guard embeds
     is [
       {
         "title": String(title),
@@ -90,7 +154,8 @@ test "parse cloud build without log url" {
   )
   guard notification is Some(n) else { fail("expected notification") }
   assert_eq(n.status, "succeeded")
-  guard n.embeds is Array(items) else { fail("expected embeds") }
+  guard n.embeds is Some(embeds) else { fail("expected embeds") }
+  guard embeds is Array(items) else { fail("expected array") }
   assert_eq(items.length(), 1)
   guard items[0] is Object(map) else { fail("expected object") }
   guard map.get("title") is Some(String(title)) else { fail("expected title") }
@@ -153,21 +218,23 @@ test "dedupe started builds" {
 
 ///|
 test "discord payload fills status color when missing" {
+  let embeds : Json = [
+    {
+      "title": "取り込みでエラーが発生しました",
+      "fields": [
+        {
+          "name": "executed_at",
+          "value": "2026-01-01T00:00:00Z",
+          "inline": true,
+        },
+      ],
+    },
+  ]
   let payload = build_discord_payload({
     action: "media.youtube_import",
     status: "failed",
-    embeds: [
-      {
-        "title": "取り込みでエラーが発生しました",
-        "fields": [
-          {
-            "name": "executed_at",
-            "value": "2026-01-01T00:00:00Z",
-            "inline": true,
-          },
-        ],
-      },
-    ],
+    content: None,
+    embeds: Some(embeds),
   })
   guard payload
     is {
@@ -187,14 +254,60 @@ test "discord payload fills status color when missing" {
   assert_eq(color.to_int(), 0xED4245)
   guard fields is Array(items) else { fail("expected fields") }
   assert_eq(items.length(), 1)
+  assert_eq(
+    match payload {
+      { "content": _, .. } => true
+      _ => false
+    },
+    false,
+  )
+}
+
+///|
+test "discord payload includes content when present" {
+  let embeds : Json = [{ "title": "boom" }]
+  let payload = build_discord_payload({
+    action: "media.youtube_import",
+    status: "failed",
+    content: Some("取り込み失敗"),
+    embeds: Some(embeds),
+  })
+  guard payload is { "content": String(content), "embeds": Array(items), .. } else {
+    fail("expected content and embeds")
+  }
+  assert_eq(content, "取り込み失敗")
+  assert_eq(items.length(), 1)
+}
+
+///|
+test "discord payload content only" {
+  let payload = build_discord_payload({
+    action: "media.youtube_import",
+    status: "failed",
+    content: Some("取り込み失敗"),
+    embeds: None,
+  })
+  guard payload is { "content": String(content), .. } else {
+    fail("expected content")
+  }
+  assert_eq(content, "取り込み失敗")
+  assert_eq(
+    match payload {
+      { "embeds": _, .. } => true
+      _ => false
+    },
+    false,
+  )
 }
 
 ///|
 test "discord payload keeps explicit embed color" {
+  let embeds : Json = [{ "title": "custom", "color": 1 }]
   let payload = build_discord_payload({
     action: "media.youtube_import",
     status: "failed",
-    embeds: [{ "title": "custom", "color": 1 }],
+    content: None,
+    embeds: Some(embeds),
   })
   guard payload is { "embeds": [{ "color": Number(color, ..), .. }], .. } else {
     fail("expected embed")
@@ -204,20 +317,24 @@ test "discord payload keeps explicit embed color" {
 
 ///|
 test "discord payload colors by status" {
+  let ok_embeds : Json = [{ "title": "ok" }]
   let succeeded = build_discord_payload({
     action: "cloud_build",
     status: "succeeded",
-    embeds: [{ "title": "ok" }],
+    content: None,
+    embeds: Some(ok_embeds),
   })
   guard succeeded is { "embeds": [{ "color": Number(color, ..), .. }], .. } else {
     fail("expected embed")
   }
   assert_eq(color.to_int(), 0x57F287)
 
+  let working_embeds : Json = [{ "title": "working" }]
   let started = build_discord_payload({
     action: "cloud_build",
     status: "started",
-    embeds: [{ "title": "working" }],
+    content: None,
+    embeds: Some(working_embeds),
   })
   guard started
     is { "embeds": [{ "color": Number(started_color, ..), .. }], .. } else {

--- a/src/discord-notifier/pkg.generated.mbti
+++ b/src/discord-notifier/pkg.generated.mbti
@@ -50,7 +50,8 @@ pub fn Config::resolve_webhook_url(Self, String) -> String?
 pub struct Notification {
   action : String
   status : String
-  embeds : Json
+  content : String?
+  embeds : Json?
 } derive(Eq, @debug.Debug)
 
 pub(all) enum Outcome {

--- a/src/discord-notifier/server.mbt
+++ b/src/discord-notifier/server.mbt
@@ -27,7 +27,12 @@ pub async fn serve(app : App) -> Unit {
             err => {
               // 一時失敗として Pub/Sub に再送させる (恒久失敗の Ack と区別する)
               println("retry: failed to read body: \{err}")
-              respond(conn, 500, "Internal Server Error", body="failed to read body")
+              respond(
+                conn,
+                500,
+                "Internal Server Error",
+                body="failed to read body",
+              )
               return
             }
           }

--- a/src/discord-notifier/types.mbt
+++ b/src/discord-notifier/types.mbt
@@ -3,7 +3,11 @@
 pub struct Notification {
   action : String
   status : String
-  embeds : Json
+  /// Discord webhook の content (無い/空なら payload に載せない)
+  content : String?
+  /// Discord embed 配列 (無い/空なら payload に載せない)
+  /// content と embeds のどちらか一方は必須
+  embeds : Json?
 } derive(Eq, Debug)
 
 ///|


### PR DESCRIPTION
## 概要

アプリ通知の契約を広げ、Discord webhook の `content` と `embeds` をどちらも任意にし、どちらか一方を必須にする

## やったこと

- 通知 JSON に任意の `content` を追加し、あれば webhook payload に載せる
- `embeds` を任意化し、未指定・空配列は payload に載せない
- `content` と非空の `embeds` のどちらか一方が無い場合は `InvalidPayload` にする
- Cloud Build 正規化は従来どおり embeds のみ
- README とユニットテストを契約に追従

## やってないこと

- PHP 側の publish 基盤への `content` 追従
- Discord channel / routing の追加

## 関連

- 特になし

Made with [Cursor](https://cursor.com)