### PR TITLE
PHP から Discord 通知を Pub/Sub 経由で送る基盤と YouTube 取り込み通知を追加する

### DIFF
--- a/src/server/.env.example
+++ b/src/server/.env.example
@@ -86,3 +86,5 @@ AUTH_PASSKEY_RP_ID=local.admin.isekaijoucho.fan
 AUTH_PASSKEY_ORIGIN=https://local.admin.isekaijoucho.fan
 
 YOUTUBE_API_KEY=
+
+NOTIFICATION_TOPIC=

--- a/src/server/app/Providers/Domain/SupportServiceProvider.php
+++ b/src/server/app/Providers/Domain/SupportServiceProvider.php
@@ -8,6 +8,7 @@ use CuyZ\Valinor\MapperBuilder;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
 use Override;
+use Support\App\Environment;
 use Support\Contracts\ClockInterface;
 use Support\Contracts\MapperInterface;
 use Support\Contracts\TransactionInterface;
@@ -21,6 +22,10 @@ use Support\Infrastructures\Query\AuditLog\AuditLogQueryService;
 use Support\Infrastructures\Uuid\UuidConverter;
 use Support\Infrastructures\Uuid\UuidGenerator;
 use Support\Infrastructures\Valinor\MapperBuilderFactory;
+use Support\Notification\Contracts\NotificationDriverInterface;
+use Support\Notification\DebugInfrastructures\NopNotificationPubSubDriver;
+use Support\Notification\Infrastructures\NotificationConfig;
+use Support\Notification\Infrastructures\NotificationPubSubDriver;
 use Support\UseCase\AuditLog\AuditLogRecorderInterface;
 use Support\UseCase\AuditLog\Query\AuditLogQueryServiceInterface;
 
@@ -40,5 +45,19 @@ class SupportServiceProvider extends ServiceProvider
         $this->app->bind(ClockInterface::class, Clock::class);
         $this->app->bind(AuditLogRecorderInterface::class, AuditLogRecorder::class);
         $this->app->bind(AuditLogQueryServiceInterface::class, AuditLogQueryService::class);
+
+        $this->app->singleton(
+            NotificationConfig::class,
+            static fn () => new NotificationConfig(
+                config()->string('gc.google_cloud_project'),
+                config()->string('gc.pubsub.notification.topic'),
+            ),
+        );
+        $this->app->singleton(
+            NotificationDriverInterface::class,
+            static fn (Application $app) => in_array(Environment::getEnv(), [Environment::Local, Environment::Testing], true)
+                ? $app->make(NopNotificationPubSubDriver::class)
+                : $app->make(NotificationPubSubDriver::class),
+        );
     }
 }

--- a/src/server/composer.json
+++ b/src/server/composer.json
@@ -13,6 +13,7 @@
     "emonkak/orm": "^5.0",
     "firebase/php-jwt": "^7.0",
     "google/apiclient": "^2.19",
+    "google/cloud-pubsub": "^2.20",
     "guzzlehttp/guzzle": "^7.13",
     "laravel/framework": "^12.0",
     "laravel/sanctum": "^4.0",

--- a/src/server/composer.lock
+++ b/src/server/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "15a9226e185b6dfed3b76b35d76af92c",
+    "content-hash": "13661ecaeca6896363dc2c50e75c6174",
     "packages": [
         {
             "name": "brick/math",
@@ -1167,6 +1167,386 @@
             "time": "2026-07-22T22:36:10+00:00"
         },
         {
+            "name": "google/cloud-core",
+            "version": "v1.73.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/googleapis/google-cloud-php-core.git",
+                "reference": "23f6a68674f07bc23d02a683405cd9d2d283688a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/googleapis/google-cloud-php-core/zipball/23f6a68674f07bc23d02a683405cd9d2d283688a",
+                "reference": "23f6a68674f07bc23d02a683405cd9d2d283688a",
+                "shasum": ""
+            },
+            "require": {
+                "google/auth": "^1.53",
+                "google/gax": "^1.38.0",
+                "guzzlehttp/guzzle": "^7.8.2||^8.0",
+                "guzzlehttp/promises": "^2.0.3||^3.0",
+                "guzzlehttp/psr7": "^2.6.3||^3.0",
+                "monolog/monolog": "^2.9||^3.0",
+                "php": "^8.1",
+                "psr/http-message": "^1.0||^2.0",
+                "rize/uri-template": "~0.3||~0.4"
+            },
+            "require-dev": {
+                "erusev/parsedown": "^1.6",
+                "google/cloud-common-protos": "~0.5||^1.0",
+                "nikic/php-parser": "^5.6",
+                "opis/closure": "^3.7|^4.0",
+                "phpdocumentor/reflection": "^6.0",
+                "phpdocumentor/reflection-docblock": "^5.3.3||^6.0",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.0",
+                "squizlabs/php_codesniffer": "3.*"
+            },
+            "suggest": {
+                "opis/closure": "May be used to serialize closures to process jobs in the batch daemon. Please require version ^3.",
+                "symfony/lock": "Required for the Spanner cached based session pool. Please require the following commit: 3.3.x-dev#1ba6ac9"
+            },
+            "bin": [
+                "bin/google-cloud-batch"
+            ],
+            "type": "library",
+            "extra": {
+                "component": {
+                    "id": "cloud-core",
+                    "path": "Core",
+                    "entry": "src/ServiceBuilder.php",
+                    "target": "googleapis/google-cloud-php-core.git"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Google\\Cloud\\Core\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "description": "Google Cloud PHP shared dependency, providing functionality useful to all components.",
+            "support": {
+                "source": "https://github.com/googleapis/google-cloud-php-core/tree/v1.73.1"
+            },
+            "time": "2026-08-07T09:39:23+00:00"
+        },
+        {
+            "name": "google/cloud-pubsub",
+            "version": "v2.20.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/googleapis/google-cloud-php-pubsub.git",
+                "reference": "2af5d13205acb5316f185511efc6d7565f939dbb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/googleapis/google-cloud-php-pubsub/zipball/2af5d13205acb5316f185511efc6d7565f939dbb",
+                "reference": "2af5d13205acb5316f185511efc6d7565f939dbb",
+                "shasum": ""
+            },
+            "require": {
+                "google/cloud-core": "^1.57",
+                "google/gax": "^1.38.0",
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "erusev/parsedown": "^1.6",
+                "flix-tech/avro-php": "^5.0.0",
+                "phpdocumentor/reflection": "^5.3.3||^6.0",
+                "phpdocumentor/reflection-docblock": "^5.3.3||^6.0",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.0",
+                "squizlabs/php_codesniffer": "3.*"
+            },
+            "suggest": {
+                "ext-grpc": "The gRPC extension enables use of the performant gRPC transport",
+                "ext-protobuf": "Provides a significant increase in throughput over the pure PHP protobuf implementation. See https://cloud.google.com/php/grpc for installation instructions."
+            },
+            "type": "library",
+            "extra": {
+                "component": {
+                    "id": "cloud-pubsub",
+                    "path": "PubSub",
+                    "entry": "src/PubSubClient.php",
+                    "target": "googleapis/google-cloud-php-pubsub.git"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Google\\Cloud\\PubSub\\": "src",
+                    "GPBMetadata\\Google\\Pubsub\\": "metadata"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "description": "Cloud PubSub Client for PHP",
+            "support": {
+                "source": "https://github.com/googleapis/google-cloud-php-pubsub/tree/v2.20.0"
+            },
+            "time": "2026-08-10T16:39:50+00:00"
+        },
+        {
+            "name": "google/common-protos",
+            "version": "4.14.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/googleapis/common-protos-php.git",
+                "reference": "4eb6813b8068653e055fc8a63dbda3446f3e8869"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/googleapis/common-protos-php/zipball/4eb6813b8068653e055fc8a63dbda3446f3e8869",
+                "reference": "4eb6813b8068653e055fc8a63dbda3446f3e8869",
+                "shasum": ""
+            },
+            "require": {
+                "google/protobuf": "^4.31||^5.0",
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6"
+            },
+            "type": "library",
+            "extra": {
+                "component": {
+                    "id": "common-protos",
+                    "path": "CommonProtos",
+                    "entry": "README.md",
+                    "target": "googleapis/common-protos-php.git"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Google\\Api\\": "src/Api",
+                    "Google\\Iam\\": "src/Iam",
+                    "Google\\Rpc\\": "src/Rpc",
+                    "Google\\Type\\": "src/Type",
+                    "Google\\Cloud\\": "src/Cloud",
+                    "GPBMetadata\\Google\\Api\\": "metadata/Api",
+                    "GPBMetadata\\Google\\Iam\\": "metadata/Iam",
+                    "GPBMetadata\\Google\\Rpc\\": "metadata/Rpc",
+                    "GPBMetadata\\Google\\Type\\": "metadata/Type",
+                    "GPBMetadata\\Google\\Cloud\\": "metadata/Cloud",
+                    "GPBMetadata\\Google\\Logging\\": "metadata/Logging"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "description": "Google API Common Protos for PHP",
+            "homepage": "https://github.com/googleapis/common-protos-php",
+            "keywords": [
+                "google"
+            ],
+            "support": {
+                "source": "https://github.com/googleapis/common-protos-php/tree/v4.14.1"
+            },
+            "time": "2026-06-17T23:07:32+00:00"
+        },
+        {
+            "name": "google/gax",
+            "version": "v1.47.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/googleapis/gax-php.git",
+                "reference": "0c25a2499a7204bee09e3cb28437a391d85976e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/googleapis/gax-php/zipball/0c25a2499a7204bee09e3cb28437a391d85976e5",
+                "reference": "0c25a2499a7204bee09e3cb28437a391d85976e5",
+                "shasum": ""
+            },
+            "require": {
+                "google/auth": "^1.53",
+                "google/common-protos": "^4.9",
+                "google/grpc-gcp": "^0.4",
+                "google/longrunning": "~0.4",
+                "google/protobuf": "^4.31||^5.34",
+                "grpc/grpc": "^1.13",
+                "guzzlehttp/promises": "^2.0.3||^3.0",
+                "guzzlehttp/psr7": "^2.6.3||^3.0",
+                "php": "^8.1",
+                "ramsey/uuid": "^4.0"
+            },
+            "conflict": {
+                "ext-protobuf": "<4.31.0"
+            },
+            "require-dev": {
+                "google/cloud-tools": "^0.16.1",
+                "phpspec/prophecy-phpunit": "^2.1",
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^9.6"
+            },
+            "type": "library",
+            "extra": {
+                "component": {
+                    "id": "gax",
+                    "path": "Gax",
+                    "entry": "README.md",
+                    "target": "googleapis/gax-php.git"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Google\\ApiCore\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Google API Core for PHP",
+            "homepage": "https://github.com/googleapis/gax-php",
+            "keywords": [
+                "google"
+            ],
+            "support": {
+                "issues": "https://github.com/googleapis/gax-php/issues",
+                "source": "https://github.com/googleapis/gax-php/tree/v1.47.1"
+            },
+            "time": "2026-08-10T16:39:50+00:00"
+        },
+        {
+            "name": "google/grpc-gcp",
+            "version": "0.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/GoogleCloudPlatform/grpc-gcp-php.git",
+                "reference": "1049c0c15b6a1789fdeb52af688a94d540932469"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/GoogleCloudPlatform/grpc-gcp-php/zipball/1049c0c15b6a1789fdeb52af688a94d540932469",
+                "reference": "1049c0c15b6a1789fdeb52af688a94d540932469",
+                "shasum": ""
+            },
+            "require": {
+                "google/auth": "^1.3",
+                "google/protobuf": "^v3.25.3||^4.26.1||^5.0",
+                "grpc/grpc": "^v1.13.0",
+                "php": "^8.0",
+                "psr/cache": "^1.0.1||^2.0.0||^3.0.0"
+            },
+            "require-dev": {
+                "google/cloud-spanner": "^1.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Grpc\\Gcp\\": "src/"
+                },
+                "classmap": [
+                    "src/generated/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "description": "gRPC GCP library for channel management",
+            "support": {
+                "issues": "https://github.com/GoogleCloudPlatform/grpc-gcp-php/issues",
+                "source": "https://github.com/GoogleCloudPlatform/grpc-gcp-php/tree/v0.4.2"
+            },
+            "time": "2026-03-12T22:56:09+00:00"
+        },
+        {
+            "name": "google/longrunning",
+            "version": "0.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/googleapis/php-longrunning.git",
+                "reference": "2c22ca5184cba320f5e7e012261b82bdc969a4f6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/googleapis/php-longrunning/zipball/2c22ca5184cba320f5e7e012261b82bdc969a4f6",
+                "reference": "2c22ca5184cba320f5e7e012261b82bdc969a4f6",
+                "shasum": ""
+            },
+            "require-dev": {
+                "google/gax": "^1.38.0",
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "component": {
+                    "id": "longrunning",
+                    "path": "LongRunning",
+                    "entry": null,
+                    "target": "googleapis/php-longrunning"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Google\\LongRunning\\": "src/LongRunning",
+                    "Google\\ApiCore\\LongRunning\\": "src/ApiCore/LongRunning",
+                    "GPBMetadata\\Google\\Longrunning\\": "metadata/Longrunning"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "description": "Google LongRunning Client for PHP",
+            "support": {
+                "source": "https://github.com/googleapis/php-longrunning/tree/v0.8.0"
+            },
+            "time": "2026-08-10T16:39:50+00:00"
+        },
+        {
+            "name": "google/protobuf",
+            "version": "v5.35.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/protocolbuffers/protobuf-php.git",
+                "reference": "55bb4a7d6739b5af0927b96213c1371a3afb7cfb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/protocolbuffers/protobuf-php/zipball/55bb4a7d6739b5af0927b96213c1371a3afb7cfb",
+                "reference": "55bb4a7d6739b5af0927b96213c1371a3afb7cfb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">=11.5.0 <12.0.0"
+            },
+            "suggest": {
+                "ext-bcmath": "Need to support JSON deserialization"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Google\\Protobuf\\": "src/Google/Protobuf",
+                    "GPBMetadata\\Google\\Protobuf\\": "src/GPBMetadata/Google/Protobuf"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "proto library for PHP",
+            "homepage": "https://developers.google.com/protocol-buffers/",
+            "keywords": [
+                "proto"
+            ],
+            "support": {
+                "source": "https://github.com/protocolbuffers/protobuf-php/tree/v5.35.1"
+            },
+            "time": "2026-06-11T21:19:23+00:00"
+        },
+        {
             "name": "graham-campbell/result-type",
             "version": "v1.1.4",
             "source": {
@@ -1227,6 +1607,50 @@
                 }
             ],
             "time": "2025-12-27T19:43:20+00:00"
+        },
+        {
+            "name": "grpc/grpc",
+            "version": "1.82.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/grpc/grpc-php.git",
+                "reference": "be984cb608f21e96453b3cfe54c748cc7b192250"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/grpc/grpc-php/zipball/be984cb608f21e96453b3cfe54c748cc7b192250",
+                "reference": "be984cb608f21e96453b3cfe54c748cc7b192250",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.0"
+            },
+            "require-dev": {
+                "google/auth": "^v1.3.0"
+            },
+            "suggest": {
+                "ext-protobuf": "For better performance, install the protobuf C extension.",
+                "google/protobuf": "To get started using grpc quickly, install the native protobuf library."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Grpc\\": "src/lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "description": "gRPC library for PHP",
+            "homepage": "https://grpc.io",
+            "keywords": [
+                "rpc"
+            ],
+            "support": {
+                "source": "https://github.com/grpc/grpc-php/tree/v1.82.0"
+            },
+            "time": "2026-07-03T09:39:53+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -5064,6 +5488,70 @@
                 "source": "https://github.com/Riverline/multipart-parser/tree/2.2.2"
             },
             "time": "2026-01-15T11:08:16+00:00"
+        },
+        {
+            "name": "rize/uri-template",
+            "version": "0.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/rize/UriTemplate.git",
+                "reference": "7ad22944daede547b4542e1c977ec4a81aa20832"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rize/UriTemplate/zipball/7ad22944daede547b4542e1c977ec4a81aa20832",
+                "reference": "7ad22944daede547b4542e1c977ec4a81aa20832",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.63",
+                "phpstan/phpstan": "^1.12",
+                "phpunit/phpunit": "~10.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Rize\\": "src/Rize"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marut K",
+                    "homepage": "http://twitter.com/rezigned"
+                }
+            ],
+            "description": "PHP URI Template (RFC 6570) supports both expansion & extraction",
+            "keywords": [
+                "RFC 6570",
+                "template",
+                "uri"
+            ],
+            "support": {
+                "issues": "https://github.com/rize/UriTemplate/issues",
+                "source": "https://github.com/rize/UriTemplate/tree/0.4.2"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.me/rezigned",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/rezigned",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/rize-uri-template",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2026-05-07T15:30:40+00:00"
         },
         {
             "name": "sayuprc/date-type",

--- a/src/server/config/gc.php
+++ b/src/server/config/gc.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'google_cloud_project' => env('GOOGLE_CLOUD_PROJECT'),
+
+    'pubsub' => [
+        'notification' => [
+            'topic' => env('NOTIFICATION_TOPIC'),
+        ],
+    ],
+];

--- a/src/server/packages/Media/Application/Cli/UseCase/ImportYouTube/ImportYouTubeNotifier.php
+++ b/src/server/packages/Media/Application/Cli/UseCase/ImportYouTube/ImportYouTubeNotifier.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Media\Application\Cli\UseCase\ImportYouTube;
+
+use Support\Notification\Contracts\Action;
+use Support\Notification\Contracts\Color;
+use Support\Notification\Contracts\Embed\NotificationEmbed;
+use Support\Notification\Contracts\Status;
+use Support\Notification\NotificationService;
+use Throwable;
+
+readonly class ImportYouTubeNotifier
+{
+    public function __construct(private NotificationService $notifier)
+    {
+    }
+
+    /**
+     * @param list<ChannelImportResult> $results
+     */
+    public function succeeded(array $results): void
+    {
+        $this->notifier->notice(
+            Action::MediaYoutubeImport,
+            Status::Succeeded,
+            content: 'YouTube からの取り込みを実行しました',
+            embeds: array_map(
+                fn (ChannelImportResult $result): NotificationEmbed => $this->buildEmbed($result),
+                $results,
+            ),
+        );
+    }
+
+    public function failed(Throwable $e): void
+    {
+        $this->notifier->notice(
+            Action::MediaYoutubeImport,
+            Status::Failed,
+            content: 'YouTube からの取り込みで例外が発生しました',
+            embeds: [
+                new NotificationEmbed(
+                    title: $e->getMessage(),
+                    color: Color::Error,
+                ),
+            ],
+        );
+    }
+
+    private function buildEmbed(ChannelImportResult $result): NotificationEmbed
+    {
+        if ($result->channelFound) {
+            return new NotificationEmbed(
+                title: sprintf('%s の取り込みが完了', $result->channel->name->value),
+                description: sprintf('取り込み件数: %d', $result->importedCount),
+                color: $result->importedCount === 0 ? Color::Warning : Color::Success,
+                url: $this->buildChannelUrl($result->channel->channelId->value),
+            );
+        }
+
+        return new NotificationEmbed(
+            title: sprintf('%s に失敗', $result->channel->name->value),
+            description: 'チャンネルが見つかりませんでした',
+            color: Color::Error,
+            url: $this->buildChannelUrl($result->channel->channelId->value),
+        );
+    }
+
+    private function buildChannelUrl(string $channelId): string
+    {
+        return sprintf('https://www.youtube.com/channel/%s', $channelId);
+    }
+}

--- a/src/server/packages/Media/Application/Cli/UseCase/ImportYouTube/ImportYouTubeUseCase.php
+++ b/src/server/packages/Media/Application/Cli/UseCase/ImportYouTube/ImportYouTubeUseCase.php
@@ -17,6 +17,7 @@ use Media\Domain\Models\YouTubeChannel\YouTubeChannel;
 use Media\Domain\Models\YouTubeChannel\YouTubeChannelRepositoryInterface;
 use Support\Contracts\TransactionInterface;
 use Support\Contracts\Uuid\UuidGeneratorInterface;
+use Throwable;
 
 readonly class ImportYouTubeUseCase
 {
@@ -27,6 +28,7 @@ readonly class ImportYouTubeUseCase
         private YouTubeVideoQueryServiceInterface $videoQueryService,
         private YouTubeShortVideoQueryServiceInterface $shortVideoQueryService,
         private MediaRepositoryInterface $mediaRepository,
+        private ImportYouTubeNotifier $notifier,
     ) {
     }
 
@@ -34,8 +36,16 @@ readonly class ImportYouTubeUseCase
     {
         $results = [];
 
-        foreach ($this->channelRepository->findAll() as $channel) {
-            $results[] = $this->importChannel($channel);
+        try {
+            foreach ($this->channelRepository->findAll() as $channel) {
+                $results[] = $this->importChannel($channel);
+            }
+
+            $this->notifier->succeeded($results);
+        } catch (Throwable $e) {
+            $this->notifier->failed($e);
+
+            throw $e;
         }
 
         return new ImportYouTubeOutputData($results);

--- a/src/server/packages/Support/Notification/Contracts/Action.php
+++ b/src/server/packages/Support/Notification/Contracts/Action.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Support\Notification\Contracts;
+
+enum Action: string
+{
+    case MediaYoutubeImport = 'media.youtube_import';
+}

--- a/src/server/packages/Support/Notification/Contracts/Color.php
+++ b/src/server/packages/Support/Notification/Contracts/Color.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Support\Notification\Contracts;
+
+/**
+ * Discord embed の color
+ * Info / Success / Error / Default は notifier の status 既定色と揃える
+ */
+enum Color: int
+{
+    case Info = 0x34_98DB;
+
+    case Success = 0x57_F287;
+
+    case Warning = 0xFE_E75C;
+
+    case Error = 0xED_4245;
+
+    case Default = 0x95_A5A6;
+}

--- a/src/server/packages/Support/Notification/Contracts/Embed/Field.php
+++ b/src/server/packages/Support/Notification/Contracts/Embed/Field.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Support\Notification\Contracts\Embed;
+
+/**
+ * @phpstan-type _field array{name?: string, value?: string, inline: bool}
+ */
+final readonly class Field
+{
+    private ?string $name;
+
+    private ?string $value;
+
+    public function __construct(
+        ?string $name = null,
+        ?string $value = null,
+        private bool $inline = false,
+    ) {
+        $this->name = is_null($name) ? null : mb_trim($name);
+        $this->value = is_null($value) ? null : mb_trim($value);
+    }
+
+    /**
+     * @return _field
+     */
+    public function toArray(): array
+    {
+        $array = [
+            'inline' => $this->inline,
+        ];
+
+        if (! is_null($this->name) && $this->name !== '') {
+            $array['name'] = $this->name;
+        }
+
+        if (! is_null($this->value) && $this->value !== '') {
+            $array['value'] = $this->value;
+        }
+
+        return $array;
+    }
+}

--- a/src/server/packages/Support/Notification/Contracts/Embed/NotificationEmbed.php
+++ b/src/server/packages/Support/Notification/Contracts/Embed/NotificationEmbed.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Support\Notification\Contracts\Embed;
+
+use DateTimeInterface;
+use Support\Notification\Contracts\Color;
+
+/**
+ * @phpstan-import-type _field from Field
+ */
+readonly class NotificationEmbed
+{
+    private ?string $title;
+
+    private ?string $description;
+
+    private ?string $url;
+
+    /**
+     * @param array<Field> $fields
+     */
+    public function __construct(
+        ?string $title = null,
+        ?string $description = null,
+        ?string $url = null,
+        private ?Color $color = null,
+        private ?DateTimeInterface $timestamp = null,
+        private array $fields = [],
+    ) {
+        $this->title = is_null($title) ? null : mb_trim($title);
+        $this->description = is_null($description) ? null : mb_trim($description);
+        $this->url = is_null($url) ? null : mb_trim($url);
+    }
+
+    /**
+     * @return array{title?: string, description?: string, url?: string, color?: int, timestamp?: string, fields?: array<_field>}
+     */
+    public function toArray(): array
+    {
+        $array = [];
+
+        if (! is_null($this->title) && $this->title !== '') {
+            $array['title'] = $this->title;
+        }
+
+        if (! is_null($this->description) && $this->description !== '') {
+            $array['description'] = $this->description;
+        }
+
+        if (! is_null($this->url) && $this->url !== '') {
+            $array['url'] = $this->url;
+        }
+
+        if (! is_null($this->color)) {
+            $array['color'] = $this->color->value;
+        }
+
+        if (! is_null($this->timestamp)) {
+            $array['timestamp'] = $this->timestamp->format('c');
+        }
+
+        if (0 < count($this->fields)) {
+            $array['fields'] = array_map(static fn (Field $field) => $field->toArray(), $this->fields);
+        }
+
+        return $array;
+    }
+}

--- a/src/server/packages/Support/Notification/Contracts/NotificationDriverInterface.php
+++ b/src/server/packages/Support/Notification/Contracts/NotificationDriverInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Support\Notification\Contracts;
+
+interface NotificationDriverInterface
+{
+    public function notice(NotificationMessage $message): void;
+}

--- a/src/server/packages/Support/Notification/Contracts/NotificationMessage.php
+++ b/src/server/packages/Support/Notification/Contracts/NotificationMessage.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Support\Notification\Contracts;
+
+use LogicException;
+use Support\Notification\Contracts\Embed\NotificationEmbed;
+
+final readonly class NotificationMessage
+{
+    private ?string $content;
+
+    /**
+     * @param array<NotificationEmbed> $embeds
+     */
+    public function __construct(
+        private Action $action,
+        private Status $status,
+        ?string $content = null,
+        private array $embeds = [],
+    ) {
+        $this->content = is_null($content) ? null : mb_trim($content);
+
+        if ((is_null($this->content) || $this->content === '') && count($this->embeds) === 0) {
+            throw new LogicException('$content か $embeds のどちらか一方は必須です');
+        }
+    }
+
+    public function toJson(): string
+    {
+        $array = [
+            'action' => $this->action->value,
+            'status' => $this->status->value,
+        ];
+
+        if (! is_null($this->content) && $this->content !== '') {
+            $array['content'] = $this->content;
+        }
+
+        if (0 < count($this->embeds)) {
+            $array['embeds'] = array_map(static fn (NotificationEmbed $embed) => $embed->toArray(), $this->embeds);
+        }
+
+        return json_encode($array, JSON_THROW_ON_ERROR);
+    }
+}

--- a/src/server/packages/Support/Notification/Contracts/Status.php
+++ b/src/server/packages/Support/Notification/Contracts/Status.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Support\Notification\Contracts;
+
+enum Status: string
+{
+    case Started = 'started';
+
+    case Succeeded = 'succeeded';
+
+    case Failed = 'failed';
+}

--- a/src/server/packages/Support/Notification/DebugInfrastructures/NopNotificationPubSubDriver.php
+++ b/src/server/packages/Support/Notification/DebugInfrastructures/NopNotificationPubSubDriver.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Support\Notification\DebugInfrastructures;
+
+use Override;
+use Support\Notification\Contracts\NotificationDriverInterface;
+use Support\Notification\Contracts\NotificationMessage;
+
+final readonly class NopNotificationPubSubDriver implements NotificationDriverInterface
+{
+    #[Override]
+    public function notice(NotificationMessage $message): void
+    {
+        // ローカル用なので何もしない
+    }
+}

--- a/src/server/packages/Support/Notification/Infrastructures/NotificationConfig.php
+++ b/src/server/packages/Support/Notification/Infrastructures/NotificationConfig.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Support\Notification\Infrastructures;
+
+final readonly class NotificationConfig
+{
+    public function __construct(
+        public string $project,
+        public string $topic,
+    ) {
+    }
+}

--- a/src/server/packages/Support/Notification/Infrastructures/NotificationPubSubDriver.php
+++ b/src/server/packages/Support/Notification/Infrastructures/NotificationPubSubDriver.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Support\Notification\Infrastructures;
+
+use Google\Cloud\PubSub\V1\Client\PublisherClient;
+use Google\Cloud\PubSub\V1\PublishRequest;
+use Google\Cloud\PubSub\V1\PubsubMessage;
+use Override;
+use Support\Notification\Contracts\NotificationDriverInterface;
+use Support\Notification\Contracts\NotificationMessage;
+
+final readonly class NotificationPubSubDriver implements NotificationDriverInterface
+{
+    public function __construct(
+        private NotificationConfig $config,
+        private PublisherClient $publisher,
+    ) {
+    }
+
+    #[Override]
+    public function notice(NotificationMessage $message): void
+    {
+        $this->publisher->publish(
+            new PublishRequest()
+                ->setTopic(PublisherClient::topicName($this->config->project, $this->config->topic))
+                ->setMessages([new PubsubMessage()->setData($message->toJson())]),
+        );
+    }
+}

--- a/src/server/packages/Support/Notification/NotificationService.php
+++ b/src/server/packages/Support/Notification/NotificationService.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Support\Notification;
+
+use Support\Notification\Contracts\Action;
+use Support\Notification\Contracts\Embed\NotificationEmbed;
+use Support\Notification\Contracts\NotificationDriverInterface;
+use Support\Notification\Contracts\NotificationMessage;
+use Support\Notification\Contracts\Status;
+
+readonly class NotificationService
+{
+    public function __construct(private NotificationDriverInterface $driver)
+    {
+    }
+
+    /**
+     * @param array<NotificationEmbed> $embeds
+     */
+    public function notice(Action $action, Status $status, ?string $content = null, array $embeds = []): void
+    {
+        $this->driver->notice(new NotificationMessage($action, $status, $content, $embeds));
+    }
+}

--- a/src/server/tests/Unit/Media/Application/Cli/UseCase/ImportYouTube/ImportYouTubeNotifierTest.php
+++ b/src/server/tests/Unit/Media/Application/Cli/UseCase/ImportYouTube/ImportYouTubeNotifierTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Media\Application\Cli\UseCase\ImportYouTube;
+
+use Media\Application\Cli\UseCase\ImportYouTube\ChannelImportResult;
+use Media\Application\Cli\UseCase\ImportYouTube\ImportYouTubeNotifier;
+use Mockery;
+use Mockery\MockInterface;
+use PHPUnit\Framework\Attributes\Test;
+use RuntimeException;
+use Support\Notification\Contracts\Action;
+use Support\Notification\Contracts\Color;
+use Support\Notification\Contracts\Embed\NotificationEmbed;
+use Support\Notification\Contracts\NotificationDriverInterface;
+use Support\Notification\Contracts\NotificationMessage;
+use Support\Notification\Contracts\Status;
+use Support\Notification\NotificationService;
+use Tests\Support\Domain\EntityFactory;
+use Tests\TestCase;
+
+class ImportYouTubeNotifierTest extends TestCase
+{
+    use EntityFactory;
+
+    private MockInterface&NotificationDriverInterface $driver;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->driver = Mockery::mock(NotificationDriverInterface::class);
+    }
+
+    #[Test]
+    public function succeededNotifiesWithResultEmbeds(): void
+    {
+        $expected = new NotificationMessage(
+            Action::MediaYoutubeImport,
+            Status::Succeeded,
+            content: 'YouTube からの取り込みを実行しました',
+            embeds: [
+                new NotificationEmbed(
+                    title: '成功ch の取り込みが完了',
+                    description: '取り込み件数: 2',
+                    color: Color::Success,
+                    url: 'https://www.youtube.com/channel/UCabcdefghijklmnopqrstuv',
+                ),
+                new NotificationEmbed(
+                    title: '失敗ch に失敗',
+                    description: 'チャンネルが見つかりませんでした',
+                    color: Color::Error,
+                    url: 'https://www.youtube.com/channel/UCabcdefghijklmnopqrstuw',
+                ),
+                new NotificationEmbed(
+                    title: '0件ch の取り込みが完了',
+                    description: '取り込み件数: 0',
+                    color: Color::Warning,
+                    url: 'https://www.youtube.com/channel/UCabcdefghijklmnopqrstux',
+                ),
+            ],
+        );
+
+        $this->driver->shouldReceive('notice')
+            ->once()
+            ->with(Mockery::on(
+                static fn (NotificationMessage $message): bool => $message->toJson() === $expected->toJson(),
+            ));
+
+        $this->getInstance()->succeeded([
+            ChannelImportResult::imported(
+                $this->createYouTubeChannel('UCabcdefghijklmnopqrstuv', '成功ch'),
+                2,
+            ),
+            ChannelImportResult::channelNotFound(
+                $this->createYouTubeChannel('UCabcdefghijklmnopqrstuw', '失敗ch'),
+            ),
+            ChannelImportResult::imported(
+                $this->createYouTubeChannel('UCabcdefghijklmnopqrstux', '0件ch'),
+                0,
+            ),
+        ]);
+    }
+
+    #[Test]
+    public function failedNotifiesWithExceptionMessage(): void
+    {
+        $expected = new NotificationMessage(
+            Action::MediaYoutubeImport,
+            Status::Failed,
+            content: 'YouTube からの取り込みで例外が発生しました',
+            embeds: [
+                new NotificationEmbed(
+                    title: 'boom',
+                    color: Color::Error,
+                ),
+            ],
+        );
+
+        $this->driver->shouldReceive('notice')
+            ->once()
+            ->with(Mockery::on(
+                static fn (NotificationMessage $message): bool => $message->toJson() === $expected->toJson(),
+            ));
+
+        $this->getInstance()->failed(new RuntimeException('boom'));
+    }
+
+    private function getInstance(): ImportYouTubeNotifier
+    {
+        return new ImportYouTubeNotifier(new NotificationService($this->driver));
+    }
+}

--- a/src/server/tests/Unit/Support/Notification/Contracts/ColorTest.php
+++ b/src/server/tests/Unit/Support/Notification/Contracts/ColorTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Support\Notification\Contracts;
+
+use PHPUnit\Framework\Attributes\Test;
+use Support\Notification\Contracts\Color;
+use Tests\TestCase;
+
+class ColorTest extends TestCase
+{
+    #[Test]
+    public function valuesMatchExpectedPalette(): void
+    {
+        $this->assertSame(0x34_98DB, Color::Info->value);
+        $this->assertSame(0x57_F287, Color::Success->value);
+        $this->assertSame(0xFE_E75C, Color::Warning->value);
+        $this->assertSame(0xED_4245, Color::Error->value);
+        $this->assertSame(0x95_A5A6, Color::Default->value);
+    }
+}

--- a/src/server/tests/Unit/Support/Notification/Contracts/Embed/FieldTest.php
+++ b/src/server/tests/Unit/Support/Notification/Contracts/Embed/FieldTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Support\Notification\Contracts\Embed;
+
+use PHPUnit\Framework\Attributes\Test;
+use Support\Notification\Contracts\Embed\Field;
+use Tests\TestCase;
+
+class FieldTest extends TestCase
+{
+    #[Test]
+    public function toArrayIncludesInlineByDefault(): void
+    {
+        $field = new Field();
+
+        $this->assertSame(
+            [
+                'inline' => false,
+            ],
+            $field->toArray(),
+        );
+    }
+
+    #[Test]
+    public function toArrayIncludesPresentNameAndValue(): void
+    {
+        $field = new Field(name: 'channel_id', value: 'UCxxxx', inline: true);
+
+        $this->assertSame(
+            [
+                'inline' => true,
+                'name' => 'channel_id',
+                'value' => 'UCxxxx',
+            ],
+            $field->toArray(),
+        );
+    }
+
+    #[Test]
+    public function toArrayOmitsBlankStringsAfterTrim(): void
+    {
+        $field = new Field(name: '  ', value: '  value  ');
+
+        $this->assertSame(
+            [
+                'inline' => false,
+                'value' => 'value',
+            ],
+            $field->toArray(),
+        );
+    }
+}

--- a/src/server/tests/Unit/Support/Notification/Contracts/Embed/NotificationEmbedTest.php
+++ b/src/server/tests/Unit/Support/Notification/Contracts/Embed/NotificationEmbedTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Support\Notification\Contracts\Embed;
+
+use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\Test;
+use Support\Notification\Contracts\Color;
+use Support\Notification\Contracts\Embed\Field;
+use Support\Notification\Contracts\Embed\NotificationEmbed;
+use Tests\TestCase;
+
+class NotificationEmbedTest extends TestCase
+{
+    #[Test]
+    public function toArrayIncludesOnlyPresentOptionalFields(): void
+    {
+        $embed = new NotificationEmbed(
+            title: 'title',
+            url: 'https://example.com',
+            fields: [
+                new Field(name: 'name', value: 'value'),
+            ],
+        );
+
+        $this->assertSame(
+            [
+                'title' => 'title',
+                'url' => 'https://example.com',
+                'fields' => [
+                    [
+                        'inline' => false,
+                        'name' => 'name',
+                        'value' => 'value',
+                    ],
+                ],
+            ],
+            $embed->toArray(),
+        );
+    }
+
+    #[Test]
+    public function toArrayFormatsTimestampAsIso8601(): void
+    {
+        $timestamp = new DateTimeImmutable('2026-01-01T12:34:56+00:00');
+        $embed = new NotificationEmbed(
+            description: 'description',
+            timestamp: $timestamp,
+        );
+
+        $this->assertSame(
+            [
+                'description' => 'description',
+                'timestamp' => '2026-01-01T12:34:56+00:00',
+            ],
+            $embed->toArray(),
+        );
+    }
+
+    #[Test]
+    public function toArrayIncludesColorValue(): void
+    {
+        $embed = new NotificationEmbed(
+            title: 'failed',
+            color: Color::Error,
+        );
+
+        $this->assertSame(
+            [
+                'title' => 'failed',
+                'color' => 0xED_4245,
+            ],
+            $embed->toArray(),
+        );
+    }
+}

--- a/src/server/tests/Unit/Support/Notification/Contracts/NotificationMessageTest.php
+++ b/src/server/tests/Unit/Support/Notification/Contracts/NotificationMessageTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Support\Notification\Contracts;
+
+use DateTimeImmutable;
+use LogicException;
+use PHPUnit\Framework\Attributes\Test;
+use Support\Notification\Contracts\Action;
+use Support\Notification\Contracts\Embed\Field;
+use Support\Notification\Contracts\Embed\NotificationEmbed;
+use Support\Notification\Contracts\NotificationMessage;
+use Support\Notification\Contracts\Status;
+use Tests\TestCase;
+
+class NotificationMessageTest extends TestCase
+{
+    #[Test]
+    public function toJsonMatchesDiscordNotifierContract(): void
+    {
+        $timestamp = new DateTimeImmutable('2026-08-11T22:00:00+09:00');
+        $message = new NotificationMessage(
+            Action::MediaYoutubeImport,
+            Status::Failed,
+            content: 'YouTube 取り込みでエラーが発生しました',
+            embeds: [
+                new NotificationEmbed(
+                    title: 'YouTube 取り込みでエラーが発生しました',
+                    timestamp: $timestamp,
+                    fields: [
+                        new Field(name: 'executed_at', value: '2026-08-11T22:00:00+09:00', inline: true),
+                        new Field(name: 'channel_id', value: 'UCxxxx', inline: true),
+                    ],
+                ),
+            ],
+        );
+
+        $this->assertSame(
+            [
+                'action' => 'media.youtube_import',
+                'status' => 'failed',
+                'content' => 'YouTube 取り込みでエラーが発生しました',
+                'embeds' => [
+                    [
+                        'title' => 'YouTube 取り込みでエラーが発生しました',
+                        'timestamp' => '2026-08-11T22:00:00+09:00',
+                        'fields' => [
+                            [
+                                'inline' => true,
+                                'name' => 'executed_at',
+                                'value' => '2026-08-11T22:00:00+09:00',
+                            ],
+                            [
+                                'inline' => true,
+                                'name' => 'channel_id',
+                                'value' => 'UCxxxx',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            json_decode($message->toJson(), associative: true, flags: JSON_THROW_ON_ERROR),
+        );
+    }
+
+    #[Test]
+    public function toJsonAllowsContentOnly(): void
+    {
+        $message = new NotificationMessage(
+            Action::MediaYoutubeImport,
+            Status::Started,
+            content: '取り込みを開始しました',
+        );
+
+        $this->assertSame(
+            [
+                'action' => 'media.youtube_import',
+                'status' => 'started',
+                'content' => '取り込みを開始しました',
+            ],
+            json_decode($message->toJson(), associative: true, flags: JSON_THROW_ON_ERROR),
+        );
+    }
+
+    #[Test]
+    public function toJsonAllowsEmbedsOnly(): void
+    {
+        $message = new NotificationMessage(
+            Action::MediaYoutubeImport,
+            Status::Succeeded,
+            embeds: [
+                new NotificationEmbed(title: 'first'),
+                new NotificationEmbed(title: 'second'),
+            ],
+        );
+
+        $decoded = json_decode($message->toJson(), associative: true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame('media.youtube_import', $decoded['action']);
+        $this->assertSame('succeeded', $decoded['status']);
+        $this->assertArrayNotHasKey('content', $decoded);
+        $this->assertCount(2, $decoded['embeds']);
+        $this->assertSame('first', $decoded['embeds'][0]['title']);
+        $this->assertSame('second', $decoded['embeds'][1]['title']);
+    }
+
+    #[Test]
+    public function toJsonTrimsContentAndOmitsBlankContent(): void
+    {
+        $message = new NotificationMessage(
+            Action::MediaYoutubeImport,
+            Status::Failed,
+            content: '  取り込み失敗  ',
+            embeds: [
+                new NotificationEmbed(title: 'boom'),
+            ],
+        );
+        $decoded = json_decode($message->toJson(), associative: true, flags: JSON_THROW_ON_ERROR);
+        $this->assertSame('取り込み失敗', $decoded['content']);
+
+        $blankContent = new NotificationMessage(
+            Action::MediaYoutubeImport,
+            Status::Failed,
+            content: '   ',
+            embeds: [
+                new NotificationEmbed(title: 'boom'),
+            ],
+        );
+        $blankDecoded = json_decode($blankContent->toJson(), associative: true, flags: JSON_THROW_ON_ERROR);
+        $this->assertArrayNotHasKey('content', $blankDecoded);
+    }
+
+    #[Test]
+    public function constructorRequiresContentOrEmbeds(): void
+    {
+        $this->expectException(LogicException::class);
+
+        new NotificationMessage(Action::MediaYoutubeImport, Status::Started);
+    }
+
+    #[Test]
+    public function constructorRejectsBlankContentWithoutEmbeds(): void
+    {
+        $this->expectException(LogicException::class);
+
+        new NotificationMessage(Action::MediaYoutubeImport, Status::Started, content: '   ');
+    }
+}

--- a/src/server/tests/Unit/Support/Notification/NotificationServiceTest.php
+++ b/src/server/tests/Unit/Support/Notification/NotificationServiceTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Support\Notification;
+
+use Mockery;
+use Mockery\MockInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Support\Notification\Contracts\Action;
+use Support\Notification\Contracts\Embed\NotificationEmbed;
+use Support\Notification\Contracts\NotificationDriverInterface;
+use Support\Notification\Contracts\NotificationMessage;
+use Support\Notification\Contracts\Status;
+use Support\Notification\NotificationService;
+use Tests\TestCase;
+
+class NotificationServiceTest extends TestCase
+{
+    private MockInterface&NotificationDriverInterface $driver;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->driver = Mockery::mock(NotificationDriverInterface::class);
+    }
+
+    #[Test]
+    public function noticeDelegatesMessageToDriver(): void
+    {
+        $embeds = [
+            new NotificationEmbed(title: 'ok'),
+        ];
+        $expected = new NotificationMessage(
+            Action::MediaYoutubeImport,
+            Status::Succeeded,
+            embeds: $embeds,
+        );
+
+        $this->driver->shouldReceive('notice')
+            ->once()
+            ->with(Mockery::on(
+                static fn (NotificationMessage $message): bool => $message->toJson() === $expected->toJson(),
+            ));
+
+        $this->getInstance()->notice(Action::MediaYoutubeImport, Status::Succeeded, embeds: $embeds);
+    }
+
+    #[Test]
+    public function noticeDelegatesContentOnly(): void
+    {
+        $expected = new NotificationMessage(
+            Action::MediaYoutubeImport,
+            Status::Started,
+            content: '取り込みを開始しました',
+        );
+
+        $this->driver->shouldReceive('notice')
+            ->once()
+            ->with(Mockery::on(
+                static fn (NotificationMessage $message): bool => $message->toJson() === $expected->toJson(),
+            ));
+
+        $this->getInstance()->notice(
+            Action::MediaYoutubeImport,
+            Status::Started,
+            content: '取り込みを開始しました',
+        );
+    }
+
+    private function getInstance(): NotificationService
+    {
+        return new NotificationService($this->driver);
+    }
+}


### PR DESCRIPTION
## 概要

PHP 側から Discord 通知契約の JSON を Pub/Sub へ publish する基盤を追加し、YouTube 取り込み結果の通知を UseCase から切り離して送れるようにする

## やったこと

- Discord 通知契約に沿ったメッセージ型と `NotificationService` / Pub/Sub driver を追加する
- ローカル・テストでは Nop driver に切り替える DI を入れる
- YouTube 取り込み結果の Discord 通知処理を `ImportYouTubeNotifier` に切り出し、UseCase から呼ぶようにする
- 上記のユニットテストを追加する

## やってないこと

- YouTube 取り込み以外の通知ユースケースへの展開

## 関連

- 特になし

Made with [Cursor](https://cursor.com)