### PR TITLE
discord-notifier で Cloud Run Job 失敗を通知する

### DIFF
--- a/src/discord-notifier/AGENTS.md
+++ b/src/discord-notifier/AGENTS.md
@@ -4,7 +4,7 @@ MoonBit 製の Discord 通知配達サービス
 
 ## 構成
 
-- `parse.mbt`: Pub/Sub envelope / アプリ通知 / Cloud Build 正規化
+- `parse.mbt`: Pub/Sub envelope / アプリ通知 / Cloud Build / Cloud Run Job 失敗 LogEntry の正規化
 - `config.mbt`: env からの action -> channel 振り分け
 - `dedup.mbt`: cloud_build started のプロセスローカル重複抑止
 - `discord.mbt`: embeds に status 既定色を付けて Webhook POST

--- a/src/discord-notifier/README.md
+++ b/src/discord-notifier/README.md
@@ -4,9 +4,10 @@ Pub/Sub push を受け取り、Discord Webhook へ配達する Cloud Run 向け�
 
 ## 責務
 
-- `{env}-discord-notify` / `cloud-builds` からの Pub/Sub push を受ける
+- `{env}-discord-notify` / `cloud-builds` / `{env}-cloud-run-job-failures` からの Pub/Sub push を受ける
 - アプリ通知 JSON (`action` / `status` / `content?` / `embeds?`) を配達する
 - Cloud Build JSON を同じ契約に正規化して配達する
+- Cloud Run Job 失敗の LogEntry を `action=cloud_run_job` / `status=failed` に正規化して配達する
 - `action` を env の routing で channel に引き当て、`DISCORD_WEBHOOK_<CHANNEL>` へ投稿する
 
 ## 契約
@@ -63,10 +64,11 @@ moon build --target native --release
 ```bash
 export PORT=8080
 export DISCORD_DEFAULT_CHANNEL=app
-export DISCORD_ACTION_ROUTING='{"cloud_build":"build"}'
+export DISCORD_ACTION_ROUTING='{"cloud_build":"build","cloud_run_job":"job_fail"}'
 export CLOUD_BUILD_TRIGGER_NAME=dev-isekai-ci
 export DISCORD_WEBHOOK_APP='https://example.com/webhooks/...'
 export DISCORD_WEBHOOK_BUILD='https://example.com/webhooks/...'
+export DISCORD_WEBHOOK_JOB_FAIL='https://example.com/webhooks/...'
 moon run cmd/main --target native
 ```
 

--- a/src/discord-notifier/parse.mbt
+++ b/src/discord-notifier/parse.mbt
@@ -46,9 +46,15 @@ fn parse_payload_json(
     }
     { "id": String(_), "status": String(status), .. } =>
       parse_cloud_build(payload, status, cloud_build_trigger_name~)
+    { "resource": { "type": String(resource_type), .. }, .. } =>
+      if resource_type == "cloud_run_job" {
+        Some(parse_cloud_run_job(payload))
+      } else {
+        None
+      }
     _ =>
       raise InvalidPayload(
-        "expected app notification with action/status or Cloud Build JSON",
+        "expected app notification with action/status, Cloud Build JSON, or cloud_run_job LogEntry",
       )
   }
 }
@@ -131,6 +137,75 @@ fn extract_trigger_name(payload : Json) -> String {
   match payload {
     { "substitutions": { "TRIGGER_NAME": String(name), .. }, .. } => name
     _ => ""
+  }
+}
+
+///|
+/// Cloud Logging LogEntry (resource.type=cloud_run_job) を正規化する
+/// Sink 側で失敗のみ流す前提なので status は常に failed
+fn parse_cloud_run_job(payload : Json) -> Notification {
+  let job = match payload {
+    { "resource": { "labels": labels, .. }, .. } =>
+      json_string_field(labels, "job_name")
+    _ => "unknown"
+  }
+  let location = match payload {
+    { "resource": { "labels": labels, .. }, .. } =>
+      json_string_field(labels, "location")
+    _ => "unknown"
+  }
+  let execution = match payload {
+    { "labels": labels, .. } =>
+      json_string_field(labels, "run.googleapis.com/execution_name")
+    _ => "unknown"
+  }
+  let message = truncate_text(extract_log_message(payload), 1000)
+  let job_label = if job == "" { "unknown" } else { job }
+  let execution_label = if execution == "" { "unknown" } else { execution }
+  let location_label = if location == "" { "unknown" } else { location }
+  let message_label = if message == "" { "(no message)" } else { message }
+  let embed : Json = {
+    "title": "Cloud Run Job failed: \{job_label}",
+    "fields": [
+      { "name": "job", "value": job_label, "inline": true },
+      { "name": "execution", "value": execution_label, "inline": true },
+      { "name": "location", "value": location_label, "inline": true },
+      { "name": "message", "value": message_label, "inline": false },
+    ],
+  }
+  {
+    action: "cloud_run_job",
+    status: "failed",
+    content: None,
+    embeds: Some([embed]),
+  }
+}
+
+///|
+fn extract_log_message(payload : Json) -> String {
+  match payload {
+    { "protoPayload": { "status": { "message": String(message), .. }, .. }, .. } =>
+      message
+    { "textPayload": String(message), .. } => message
+    _ => ""
+  }
+}
+
+///|
+fn json_string_field(obj : Json, key : String) -> String {
+  guard obj is Object(map) else { return "" }
+  match map.get(key) {
+    Some(String(value)) => value
+    _ => ""
+  }
+}
+
+///|
+fn truncate_text(text : String, max_len : Int) -> String {
+  if text.length() <= max_len {
+    text
+  } else {
+    "\{text[:max_len]}..."
   }
 }
 

--- a/src/discord-notifier/parse_wbtest.mbt
+++ b/src/discord-notifier/parse_wbtest.mbt
@@ -193,19 +193,110 @@ test "parse cloud build failed statuses" {
 }
 
 ///|
+test "parse cloud run job log entry via pubsub" {
+  let inner = "{\"resource\":{\"type\":\"cloud_run_job\",\"labels\":{\"job_name\":\"prod-media-youtube-import\",\"location\":\"asia-northeast1\"}},\"labels\":{\"run.googleapis.com/execution_name\":\"prod-media-youtube-import-xxxxx\"},\"protoPayload\":{\"status\":{\"message\":\"Execution prod-media-youtube-import-xxxxx has failed to complete.\"}}}"
+  let notification = parse_request_body(
+    encode_pubsub(inner),
+    cloud_build_trigger_name="dev-isekai-ci",
+  )
+  guard notification is Some(n) else { fail("expected notification") }
+  assert_eq(n.action, "cloud_run_job")
+  assert_eq(n.status, "failed")
+  assert_eq(n.content, None)
+  guard n.embeds is Some(embeds) else { fail("expected embeds") }
+  guard embeds is [{ "title": String(title), "fields": Array(fields), .. }] else {
+    fail("expected embed")
+  }
+  assert_eq(title, "Cloud Run Job failed: prod-media-youtube-import")
+  assert_eq(fields.length(), 4)
+  guard fields[0] is { "name": String("job"), "value": String(job), .. } else {
+    fail("expected job field")
+  }
+  assert_eq(job, "prod-media-youtube-import")
+  guard fields[1]
+    is { "name": String("execution"), "value": String(execution), .. } else {
+    fail("expected execution field")
+  }
+  assert_eq(execution, "prod-media-youtube-import-xxxxx")
+  guard fields[2]
+    is { "name": String("location"), "value": String(location), .. } else {
+    fail("expected location field")
+  }
+  assert_eq(location, "asia-northeast1")
+  guard fields[3] is { "name": String("message"), "value": String(message), .. } else {
+    fail("expected message field")
+  }
+  assert_eq(
+    message, "Execution prod-media-youtube-import-xxxxx has failed to complete.",
+  )
+}
+
+///|
+test "parse cloud run job prefers textPayload when proto message missing" {
+  let inner = "{\"resource\":{\"type\":\"cloud_run_job\",\"labels\":{\"job_name\":\"dev-job\",\"location\":\"asia-northeast1\"}},\"labels\":{\"run.googleapis.com/execution_name\":\"dev-job-1\"},\"textPayload\":\"task failed\"}"
+  let notification = parse_request_body(
+    encode_pubsub(inner),
+    cloud_build_trigger_name="dev-isekai-ci",
+  )
+  guard notification is Some(n) else { fail("expected notification") }
+  guard n.embeds is Some([{ "fields": Array(fields), .. }]) else {
+    fail("expected embeds")
+  }
+  guard fields[3] is { "name": String("message"), "value": String(message), .. } else {
+    fail("expected message")
+  }
+  assert_eq(message, "task failed")
+}
+
+///|
+test "parse cloud run job truncates long message" {
+  let long = String::make(1200, 'a')
+  let inner = "{\"resource\":{\"type\":\"cloud_run_job\",\"labels\":{\"job_name\":\"dev-job\",\"location\":\"asia-northeast1\"}},\"labels\":{\"run.googleapis.com/execution_name\":\"dev-job-1\"},\"textPayload\":\"\{long}\"}"
+  let notification = parse_request_body(
+    encode_pubsub(inner),
+    cloud_build_trigger_name="dev-isekai-ci",
+  )
+  guard notification is Some(n) else { fail("expected notification") }
+  guard n.embeds is Some([{ "fields": Array(fields), .. }]) else {
+    fail("expected embeds")
+  }
+  guard fields[3] is { "name": String("message"), "value": String(message), .. } else {
+    fail("expected message")
+  }
+  assert_eq(message.length(), 1003)
+  assert_true(message.has_suffix("..."))
+}
+
+///|
+test "parse ignores non cloud_run_job log entry" {
+  let inner = "{\"resource\":{\"type\":\"cloud_run_revision\",\"labels\":{\"service_name\":\"api\"}},\"textPayload\":\"hello\"}"
+  let notification = parse_request_body(
+    encode_pubsub(inner),
+    cloud_build_trigger_name="dev-isekai-ci",
+  )
+  assert_eq(notification, None)
+}
+
+///|
 test "resolve channel from action routing" {
   let config : Config = {
     default_channel: "app",
-    action_routing: { "cloud_build": "build", "ops.alert": "ops" },
+    action_routing: {
+      "cloud_build": "build",
+      "cloud_run_job": "job_fail",
+      "ops.alert": "ops",
+    },
     cloud_build_trigger_name: "dev-isekai-ci",
     port: 8080,
   }
   assert_eq(config.resolve_channel("cloud_build"), "build")
+  assert_eq(config.resolve_channel("cloud_run_job"), "job_fail")
   assert_eq(config.resolve_channel("ops.alert"), "ops")
   assert_eq(config.resolve_channel("media.youtube_import"), "app")
   assert_eq(config.resolve_channel(""), "app")
   assert_eq(webhook_env_name("build"), "DISCORD_WEBHOOK_BUILD")
   assert_eq(webhook_env_name("app"), "DISCORD_WEBHOOK_APP")
+  assert_eq(webhook_env_name("job_fail"), "DISCORD_WEBHOOK_JOB_FAIL")
 }
 
 ///|


### PR DESCRIPTION
## 概要

Cloud Run Job 失敗の Log Sink → Pub/Sub 経路に対応し、discord-notifier が LogEntry を正規化して Discord へ配達できるようにする

## やったこと

- `{env}-cloud-run-job-failures` からの Pub/Sub push で届く LogEntry (`resource.type=cloud_run_job`) を `action=cloud_run_job` / `status=failed` に正規化する
- embed に job / execution / location / message を載せ、長い message は truncate する
- `cloud_run_job` → `job_fail` → `DISCORD_WEBHOOK_JOB_FAIL` の振り分けをテストで確認する
- README / AGENTS を経路と責務に合わせて更新する

## やってないこと

- infra 側の Log Sink / Pub/Sub / secret の apply
- 実環境での失敗 Job による手動確認

## 関連

- 特になし

Made with [Cursor](https://cursor.com)