### PR TITLE
viewer-deploy 成功時に notify-publish で Pub/Sub へ通知する

### DIFF
--- a/.github/workflows/notify-publish-qa.yaml
+++ b/.github/workflows/notify-publish-qa.yaml
@@ -1,0 +1,52 @@
+name: Notify Publish QA
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  pull_request:
+    # main, stg 向け PR は release-qa 経由で必ず全実行する
+    branches-ignore:
+      - main
+      - stg
+    paths:
+      - "src/notify-publish/**"
+      - "mise.toml"
+      - "mise.ci.toml"
+      - ".github/workflows/notify-publish-qa.yaml"
+      - ".github/actions/setup-mise/**"
+      - ".github/actions/setup-moonbit/**"
+  push:
+    branches:
+      - dev
+    paths:
+      - "src/notify-publish/**"
+      - "mise.toml"
+      - "mise.ci.toml"
+      - ".github/workflows/notify-publish-qa.yaml"
+      - ".github/actions/setup-mise/**"
+      - ".github/actions/setup-moonbit/**"
+  workflow_call:
+
+env:
+  MISE_ENV: ci
+
+jobs:
+  check:
+    name: Check
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Setup mise
+        uses: ./.github/actions/setup-mise
+
+      - name: Setup MoonBit
+        uses: ./.github/actions/setup-moonbit
+
+      - name: Run check / test
+        run: mise run notify-publish:check

--- a/.github/workflows/release-qa.yaml
+++ b/.github/workflows/release-qa.yaml
@@ -35,3 +35,7 @@ jobs:
   discord-notifier:
     name: Discord Notifier QA
     uses: ./.github/workflows/discord-notifier-qa.yaml
+
+  notify-publish:
+    name: Notify Publish QA
+    uses: ./.github/workflows/notify-publish-qa.yaml

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -19,6 +19,7 @@
 - `src/admin/`: Astro / SolidJS / Elysia による管理画面
 - `src/viewer/`: Astro / SolidJS による閲覧サイト
 - `src/discord-notifier/`: MoonBit 製 Discord 通知配達サービス (Cloud Run)
+- `src/notify-publish/`: MoonBit 製の通知 JSON → Pub/Sub publish CLI
 - `mise.toml`: 開発ツール・タスク定義、および CI / インフラ向け版ピンのカタログ(`[tools]` / `[vars]`)
 - `compose.yaml`: ローカルで使う proxy / php / mysql / redis の定義
 
@@ -45,6 +46,7 @@
 | 管理画面の UI / BFF | `src/admin` | 必要なら `src/contracts` | `cd src && bun --filter admin lint:check`, `style:check`, `build` |
 | 閲覧サイトの UI | `src/viewer` | 必要なら `src/contracts` | `cd src && bun --filter viewer lint:check`, `style:check`, `build` |
 | Discord 通知配達 | `src/discord-notifier` | 各 env の `docker/discord-notifier`、Cloud Build | `mise run discord-notifier:check` |
+| 通知 Pub/Sub publish | `src/notify-publish` | 各 env の `docker/viewer` (viewer-deploy から利用) | `mise run notify-publish:check` |
 | 開発環境 | `mise.toml`, `compose.yaml`, `infra/local/docker/` | 関連 docs | 起動確認と影響範囲の明記 |
 | 環境別インフラ | `infra/development/`, `infra/staging/`, `infra/production/` | 関連 docs | Cloud Build 設定、Dockerfile、build context の確認 |
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -15,7 +15,7 @@
 
 ## Key Design Docs
 
-- `design-docs/subproject-boundaries.md`: `contracts` / `server` / `admin` / `viewer` / `discord-notifier` の責務境界
+- `design-docs/subproject-boundaries.md`: `contracts` / `server` / `admin` / `viewer` / `discord-notifier` / `notify-publish` の責務境界
 - `design-docs/local-runtime-topology.md`: ローカル開発時のサービス構成、worktree 分離、並列実装の運用
 
 ## Working Records

--- a/docs/agent-map.md
+++ b/docs/agent-map.md
@@ -15,6 +15,7 @@
 - 管理画面 UI / BFF: `src/admin`
 - 閲覧サイト UI: `src/viewer`
 - Discord 通知配達: `src/discord-notifier`
+- 通知 Pub/Sub publish: `src/notify-publish`
 - それ以外の変更ルート: `ARCHITECTURE.md`
 
 ## 文書の置き場所

--- a/docs/design-docs/INDEX.md
+++ b/docs/design-docs/INDEX.md
@@ -4,4 +4,4 @@
 
 - `core-beliefs.md`: このリポジトリで優先する開発原則
 - `local-runtime-topology.md`: ローカル開発時のサービス構成、worktree 分離、並列実装の運用
-- `subproject-boundaries.md`: `contracts` / `server` / `admin` / `viewer` / `discord-notifier` の責務境界
+- `subproject-boundaries.md`: `contracts` / `server` / `admin` / `viewer` / `discord-notifier` / `notify-publish` の責務境界

--- a/docs/design-docs/subproject-boundaries.md
+++ b/docs/design-docs/subproject-boundaries.md
@@ -51,3 +51,9 @@ UI 実装方針の詳細は `FRONTEND.md` を参照します
 - Pub/Sub push を受け、`action` を環境変数の routing で channel に引き当てて Discord Webhook へ投稿する
 - 業務処理は持たない。振り分けは環境変数で行う
 - 発信元は Discord を直接呼ばず、Pub/Sub に正規化済み JSON を publish する
+
+## Notify Publish
+
+- `src/notify-publish/`: MoonBit 製の通知 JSON → Pub/Sub publish CLI
+- stdin のアプリ通知契約を検証し、`NOTIFICATION_TOPIC` へ publish する
+- Discord 配達や channel 振り分けは持たない。bash Job などから使う発信側ツール

--- a/infra/development/README.md
+++ b/infra/development/README.md
@@ -13,7 +13,7 @@
 - `docker/cli/Dockerfile`: artisan job 用で PHP CLI と Laravel application を含める
 - `docker/db-migrate/Dockerfile`: migration job 用で Atlas と schema 定義のみを含める
 - `docker/admin/Dockerfile`: Admin 用で build stage では `bun --filter admin build`、runtime stage では Bun slim image を使う
-- `docker/viewer/Dockerfile`: Viewer deploy job 用で `viewer-deploy` を entrypoint にする
+- `docker/viewer/Dockerfile`: Viewer deploy job 用で `viewer-deploy` を entrypoint にし、`notify-publish` を同梱する
 - `docker/admin-proxy/Dockerfile`: admin-proxy deploy job 用で `admin-proxy-deploy` を entrypoint にする
 - `docker/discord-notifier/Dockerfile`: MoonBit 製 Discord Notifier を native ビルドして載せる
 
@@ -24,7 +24,7 @@
 - API / Admin service と DB migrate / Admin invite / media youtube import / Viewer deploy / admin-proxy deploy job の runtime env / secret は `ci.yaml` で定義しないため初回デプロイ前に別経路で設定する
 - DB migrate job には `DB_USERNAME` / `DB_PASSWORD` / `DB_HOST` / `DB_PORT` / `DB_DATABASE` を設定する
 - media youtube import job (`dev-media-youtube-import`) には DB 接続 env と `YOUTUBE_API_KEY` を設定する
-- Viewer deploy job (`dev-viewer-deploy`) には `API_URL` / `SITE_URL` / `SITE_NOINDEX=true` / `APP_ENV=development` / Cloudflare Worker 名 / account ID と `CLOUDFLARE_API_TOKEN` secret を設定する
+- Viewer deploy job (`dev-viewer-deploy`) には `API_URL` / `SITE_URL` / `SITE_NOINDEX=true` / `APP_ENV=development` / Cloudflare Worker 名 / account ID / `GOOGLE_CLOUD_PROJECT` / `NOTIFICATION_TOPIC` と `CLOUDFLARE_API_TOKEN` secret を設定する
 - admin-proxy deploy job (`dev-admin-proxy-deploy`) には `ADMIN_PROXY_WORKER_NAME` / `ADMIN_PROXY_ORIGIN_URL` / `CLOUDFLARE_ACCOUNT_ID` と `CLOUDFLARE_API_TOKEN` / `PROXY_SHARED_SECRET` secret を設定する
 - Admin service は `PROXY_SHARED_SECRET` と同じ secret を参照する
 
@@ -36,6 +36,7 @@
 - Discord Notifier の runtime service account は `_NOTIFY_SERVICE_ACCOUNT` で受け取る
 - Admin の `PUBLIC_APP_URL` は Cloud Build substitution の `_PUBLIC_APP_URL` を build arg として渡す
 - Viewer deploy job は runtime env / secret を受け取り、Cloudflare Workers へ deploy する
+- Viewer deploy 成功時は `notify-publish` で通知 JSON を publish する。`NOTIFICATION_TOPIC` / `GOOGLE_CLOUD_PROJECT` は infra 側で Job に設定し、Job SA に topic publish 権限を付ける
 - admin-proxy deploy job は Cloud Build が `gcloud run jobs deploy --wait` で image 差し替えと実行完了まで行い、Cloudflare Workers へ deploy する
 - 環境バッジ表示のため `APP_ENV=development` を Admin は Dockerfile の `ENV` で渡す
 - Cloud Build 上で使う tool / base image の版は `mise.toml`(`[tools]` / `[vars]`)を Source of Truth とし、`tools/read-mise-value.sh` 経由で参照する

--- a/infra/development/cloudbuild/ci.yaml
+++ b/infra/development/cloudbuild/ci.yaml
@@ -159,6 +159,7 @@ steps:
         set -euo pipefail
 
         NODE_VERSION=$$(./tools/read-mise-value.sh node)
+        MOONBIT_VERSION=$$(./tools/read-mise-value.sh moonbit_version)
 
         docker build \
           -f infra/development/docker/viewer/Dockerfile \
@@ -166,6 +167,7 @@ steps:
           -t ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_VIEWER_IMAGE}:latest \
           --cache-from ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_VIEWER_IMAGE}:latest \
           --build-arg "NODE_VERSION=$${NODE_VERSION}" \
+          --build-arg "MOONBIT_VERSION=$${MOONBIT_VERSION}" \
           .
 
   - id: build-admin-proxy-image

--- a/infra/development/docker/viewer/Dockerfile
+++ b/infra/development/docker/viewer/Dockerfile
@@ -1,4 +1,31 @@
-ARG NODE_VERSION=24
+FROM debian:bookworm-slim AS notify-publish-builder
+
+ARG MOONBIT_VERSION
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    bash \
+    build-essential \
+    ca-certificates \
+    curl \
+    git \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV PATH="/root/.moon/bin:${PATH}"
+
+RUN curl -fsSL https://cli.moonbitlang.com/install/unix.sh \
+  | bash -s -- "${MOONBIT_VERSION}"
+
+WORKDIR /src
+
+COPY src/notify-publish/moon.mod src/notify-publish/moon.pkg ./
+COPY src/notify-publish/*.mbt ./
+COPY src/notify-publish/cmd ./cmd
+
+RUN moon update \
+  && moon build --target native --release
+
+ARG NODE_VERSION
 FROM node:${NODE_VERSION}-slim
 
 ENV TZ=Asia/Tokyo
@@ -13,12 +40,14 @@ RUN apt-get update \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
+COPY --from=notify-publish-builder /src/_build/native/release/build/cmd/main/main.exe \
+  /usr/local/bin/notify-publish
 COPY infra/development/docker/viewer/viewer-deploy /usr/local/bin/viewer-deploy
 COPY mise.toml ./
 
 RUN corepack enable \
   && corepack prepare "pnpm@$(sed -n 's/^pnpm = "\(.*\)"$/\1/p' mise.toml)" --activate \
-  && chmod +x /usr/local/bin/viewer-deploy
+  && chmod +x /usr/local/bin/viewer-deploy /usr/local/bin/notify-publish
 
 WORKDIR /app/src
 

--- a/infra/development/docker/viewer/viewer-deploy
+++ b/infra/development/docker/viewer/viewer-deploy
@@ -6,6 +6,8 @@ set -euo pipefail
 : "${CLOUDFLARE_WORKER_NAME:?}"
 : "${CLOUDFLARE_ACCOUNT_ID:?}"
 : "${CLOUDFLARE_API_TOKEN:?}"
+: "${GOOGLE_CLOUD_PROJECT:?}"
+: "${NOTIFICATION_TOPIC:?}"
 
 pnpm --filter viewer build
 
@@ -15,3 +17,7 @@ pnpm --filter viewer run deploy \
   --name "${CLOUDFLARE_WORKER_NAME}" \
   --compatibility-date "$(date -u '+%Y-%m-%d')" \
   --message "${DEPLOY_MESSAGE}"
+
+notify-publish <<EOF
+{"action":"viewer.deploy","status":"succeeded","embeds":[{"title":"Viewer deploy succeeded","fields":[{"name":"site_url","value":"${SITE_URL}","inline":true},{"name":"env","value":"development","inline":true}]}]}
+EOF

--- a/infra/production/README.md
+++ b/infra/production/README.md
@@ -13,7 +13,7 @@
 - `docker/cli/Dockerfile`: artisan job 用で PHP CLI と Laravel application を含める
 - `docker/db-migrate/Dockerfile`: migration job 用で Atlas と schema 定義のみを含める
 - `docker/admin/Dockerfile`: Admin 用で build stage では `bun --filter admin build`、runtime stage では Bun slim image を使う
-- `docker/viewer/Dockerfile`: Viewer deploy job 用で `viewer-deploy` を entrypoint にする
+- `docker/viewer/Dockerfile`: Viewer deploy job 用で `viewer-deploy` を entrypoint にし、`notify-publish` を同梱する
 - `docker/admin-proxy/Dockerfile`: admin-proxy deploy job 用で `admin-proxy-deploy` を entrypoint にする
 - `docker/discord-notifier/Dockerfile`: MoonBit 製 Discord Notifier を native ビルドして載せる
 
@@ -24,7 +24,7 @@
 - API / Admin service と DB migrate / Admin invite / media youtube import / Viewer deploy / admin-proxy deploy job の runtime env / secret は `ci.yaml` で定義しないため初回デプロイ前に別経路で設定する
 - DB migrate job には `DB_USERNAME` / `DB_PASSWORD` / `DB_HOST` / `DB_PORT` / `DB_DATABASE` を設定する
 - media youtube import job (`prod-media-youtube-import`) には DB 接続 env と `YOUTUBE_API_KEY` を設定する
-- Viewer deploy job (`prod-viewer-deploy`) には `API_URL` / `SITE_URL` / `APP_ENV=production` / Cloudflare Worker 名 / account ID と `CLOUDFLARE_API_TOKEN` secret を設定する
+- Viewer deploy job (`prod-viewer-deploy`) には `API_URL` / `SITE_URL` / `APP_ENV=production` / Cloudflare Worker 名 / account ID / `GOOGLE_CLOUD_PROJECT` / `NOTIFICATION_TOPIC` と `CLOUDFLARE_API_TOKEN` secret を設定する
 - admin-proxy deploy job (`prod-admin-proxy-deploy`) には `ADMIN_PROXY_WORKER_NAME` / `ADMIN_PROXY_ORIGIN_URL` / `CLOUDFLARE_ACCOUNT_ID` と `CLOUDFLARE_API_TOKEN` / `PROXY_SHARED_SECRET` secret を設定する
 - Admin service は `PROXY_SHARED_SECRET` と同じ secret を参照する
 
@@ -36,6 +36,7 @@
 - Discord Notifier の runtime service account は `_NOTIFY_SERVICE_ACCOUNT` で受け取る
 - Admin の `PUBLIC_APP_URL` は Cloud Build substitution の `_PUBLIC_APP_URL` を build arg として渡す
 - Viewer deploy job は runtime env / secret を受け取り、Cloudflare Workers へ deploy する
+- Viewer deploy 成功時は `notify-publish` で通知 JSON を publish する。`NOTIFICATION_TOPIC` / `GOOGLE_CLOUD_PROJECT` は infra 側で Job に設定し、Job SA に topic publish 権限を付ける
 - admin-proxy deploy job は Cloud Build が `gcloud run jobs deploy --wait` で image 差し替えと実行完了まで行い、Cloudflare Workers へ deploy する
 - `APP_ENV=production` を Admin は Dockerfile の `ENV` で渡す。production では環境バッジを表示しない
 - Cloud Build 上で使う tool / base image の版は `mise.toml`(`[tools]` / `[vars]`)を Source of Truth とし、`tools/read-mise-value.sh` 経由で参照する

--- a/infra/production/cloudbuild/ci.yaml
+++ b/infra/production/cloudbuild/ci.yaml
@@ -159,6 +159,7 @@ steps:
         set -euo pipefail
 
         NODE_VERSION=$$(./tools/read-mise-value.sh node)
+        MOONBIT_VERSION=$$(./tools/read-mise-value.sh moonbit_version)
 
         docker build \
           -f infra/production/docker/viewer/Dockerfile \
@@ -166,6 +167,7 @@ steps:
           -t ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_VIEWER_IMAGE}:latest \
           --cache-from ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_VIEWER_IMAGE}:latest \
           --build-arg "NODE_VERSION=$${NODE_VERSION}" \
+          --build-arg "MOONBIT_VERSION=$${MOONBIT_VERSION}" \
           .
 
   - id: build-admin-proxy-image

--- a/infra/production/docker/viewer/Dockerfile
+++ b/infra/production/docker/viewer/Dockerfile
@@ -1,4 +1,31 @@
-ARG NODE_VERSION=24
+FROM debian:bookworm-slim AS notify-publish-builder
+
+ARG MOONBIT_VERSION
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    bash \
+    build-essential \
+    ca-certificates \
+    curl \
+    git \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV PATH="/root/.moon/bin:${PATH}"
+
+RUN curl -fsSL https://cli.moonbitlang.com/install/unix.sh \
+  | bash -s -- "${MOONBIT_VERSION}"
+
+WORKDIR /src
+
+COPY src/notify-publish/moon.mod src/notify-publish/moon.pkg ./
+COPY src/notify-publish/*.mbt ./
+COPY src/notify-publish/cmd ./cmd
+
+RUN moon update \
+  && moon build --target native --release
+
+ARG NODE_VERSION
 FROM node:${NODE_VERSION}-slim
 
 ENV TZ=Asia/Tokyo
@@ -13,12 +40,14 @@ RUN apt-get update \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
+COPY --from=notify-publish-builder /src/_build/native/release/build/cmd/main/main.exe \
+  /usr/local/bin/notify-publish
 COPY infra/production/docker/viewer/viewer-deploy /usr/local/bin/viewer-deploy
 COPY mise.toml ./
 
 RUN corepack enable \
   && corepack prepare "pnpm@$(sed -n 's/^pnpm = "\(.*\)"$/\1/p' mise.toml)" --activate \
-  && chmod +x /usr/local/bin/viewer-deploy
+  && chmod +x /usr/local/bin/viewer-deploy /usr/local/bin/notify-publish
 
 WORKDIR /app/src
 

--- a/infra/production/docker/viewer/viewer-deploy
+++ b/infra/production/docker/viewer/viewer-deploy
@@ -6,6 +6,8 @@ set -euo pipefail
 : "${CLOUDFLARE_WORKER_NAME:?}"
 : "${CLOUDFLARE_ACCOUNT_ID:?}"
 : "${CLOUDFLARE_API_TOKEN:?}"
+: "${GOOGLE_CLOUD_PROJECT:?}"
+: "${NOTIFICATION_TOPIC:?}"
 
 pnpm --filter viewer build
 
@@ -15,3 +17,7 @@ pnpm --filter viewer run deploy \
   --name "${CLOUDFLARE_WORKER_NAME}" \
   --compatibility-date "$(date -u '+%Y-%m-%d')" \
   --message "${DEPLOY_MESSAGE}"
+
+notify-publish <<EOF
+{"action":"viewer.deploy","status":"succeeded","embeds":[{"title":"Viewer deploy succeeded","fields":[{"name":"site_url","value":"${SITE_URL}","inline":true},{"name":"env","value":"production","inline":true}]}]}
+EOF

--- a/infra/staging/README.md
+++ b/infra/staging/README.md
@@ -13,7 +13,7 @@
 - `docker/cli/Dockerfile`: artisan job 用で PHP CLI と Laravel application を含める
 - `docker/db-migrate/Dockerfile`: migration job 用で Atlas と schema 定義のみを含める
 - `docker/admin/Dockerfile`: Admin 用で build stage では `bun --filter admin build`、runtime stage では Bun slim image を使う
-- `docker/viewer/Dockerfile`: Viewer deploy job 用で `viewer-deploy` を entrypoint にする
+- `docker/viewer/Dockerfile`: Viewer deploy job 用で `viewer-deploy` を entrypoint にし、`notify-publish` を同梱する
 - `docker/admin-proxy/Dockerfile`: admin-proxy deploy job 用で `admin-proxy-deploy` を entrypoint にする
 - `docker/discord-notifier/Dockerfile`: MoonBit 製 Discord Notifier を native ビルドして載せる
 
@@ -24,7 +24,7 @@
 - API / Admin service と DB migrate / Admin invite / media youtube import / Viewer deploy / admin-proxy deploy job の runtime env / secret は `ci.yaml` で定義しないため初回デプロイ前に別経路で設定する
 - DB migrate job には `DB_USERNAME` / `DB_PASSWORD` / `DB_HOST` / `DB_PORT` / `DB_DATABASE` を設定する
 - media youtube import job (`stg-media-youtube-import`) には DB 接続 env と `YOUTUBE_API_KEY` を設定する
-- Viewer deploy job (`stg-viewer-deploy`) には `API_URL` / `SITE_URL` / `SITE_NOINDEX=true` / `APP_ENV=staging` / Cloudflare Worker 名 / account ID と `CLOUDFLARE_API_TOKEN` secret を設定する
+- Viewer deploy job (`stg-viewer-deploy`) には `API_URL` / `SITE_URL` / `SITE_NOINDEX=true` / `APP_ENV=staging` / Cloudflare Worker 名 / account ID / `GOOGLE_CLOUD_PROJECT` / `NOTIFICATION_TOPIC` と `CLOUDFLARE_API_TOKEN` secret を設定する
 - admin-proxy deploy job (`stg-admin-proxy-deploy`) には `ADMIN_PROXY_WORKER_NAME` / `ADMIN_PROXY_ORIGIN_URL` / `CLOUDFLARE_ACCOUNT_ID` と `CLOUDFLARE_API_TOKEN` / `PROXY_SHARED_SECRET` secret を設定する
 - Admin service は `PROXY_SHARED_SECRET` と同じ secret を参照する
 
@@ -36,6 +36,7 @@
 - Discord Notifier の runtime service account は `_NOTIFY_SERVICE_ACCOUNT` で受け取る
 - Admin の `PUBLIC_APP_URL` は Cloud Build substitution の `_PUBLIC_APP_URL` を build arg として渡す
 - Viewer deploy job は runtime env / secret を受け取り、Cloudflare Workers へ deploy する
+- Viewer deploy 成功時は `notify-publish` で通知 JSON を publish する。`NOTIFICATION_TOPIC` / `GOOGLE_CLOUD_PROJECT` は infra 側で Job に設定し、Job SA に topic publish 権限を付ける
 - admin-proxy deploy job は Cloud Build が `gcloud run jobs deploy --wait` で image 差し替えと実行完了まで行い、Cloudflare Workers へ deploy する
 - 環境バッジ表示のため `APP_ENV=staging` を Admin は Dockerfile の `ENV` で渡す
 - Cloud Build 上で使う tool / base image の版は `mise.toml`(`[tools]` / `[vars]`)を Source of Truth とし、`tools/read-mise-value.sh` 経由で参照する

--- a/infra/staging/cloudbuild/ci.yaml
+++ b/infra/staging/cloudbuild/ci.yaml
@@ -159,6 +159,7 @@ steps:
         set -euo pipefail
 
         NODE_VERSION=$$(./tools/read-mise-value.sh node)
+        MOONBIT_VERSION=$$(./tools/read-mise-value.sh moonbit_version)
 
         docker build \
           -f infra/staging/docker/viewer/Dockerfile \
@@ -166,6 +167,7 @@ steps:
           -t ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_VIEWER_IMAGE}:latest \
           --cache-from ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_VIEWER_IMAGE}:latest \
           --build-arg "NODE_VERSION=$${NODE_VERSION}" \
+          --build-arg "MOONBIT_VERSION=$${MOONBIT_VERSION}" \
           .
 
   - id: build-admin-proxy-image

--- a/infra/staging/docker/viewer/Dockerfile
+++ b/infra/staging/docker/viewer/Dockerfile
@@ -1,4 +1,31 @@
-ARG NODE_VERSION=24
+FROM debian:bookworm-slim AS notify-publish-builder
+
+ARG MOONBIT_VERSION
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    bash \
+    build-essential \
+    ca-certificates \
+    curl \
+    git \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV PATH="/root/.moon/bin:${PATH}"
+
+RUN curl -fsSL https://cli.moonbitlang.com/install/unix.sh \
+  | bash -s -- "${MOONBIT_VERSION}"
+
+WORKDIR /src
+
+COPY src/notify-publish/moon.mod src/notify-publish/moon.pkg ./
+COPY src/notify-publish/*.mbt ./
+COPY src/notify-publish/cmd ./cmd
+
+RUN moon update \
+  && moon build --target native --release
+
+ARG NODE_VERSION
 FROM node:${NODE_VERSION}-slim
 
 ENV TZ=Asia/Tokyo
@@ -13,12 +40,14 @@ RUN apt-get update \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
+COPY --from=notify-publish-builder /src/_build/native/release/build/cmd/main/main.exe \
+  /usr/local/bin/notify-publish
 COPY infra/staging/docker/viewer/viewer-deploy /usr/local/bin/viewer-deploy
 COPY mise.toml ./
 
 RUN corepack enable \
   && corepack prepare "pnpm@$(sed -n 's/^pnpm = "\(.*\)"$/\1/p' mise.toml)" --activate \
-  && chmod +x /usr/local/bin/viewer-deploy
+  && chmod +x /usr/local/bin/viewer-deploy /usr/local/bin/notify-publish
 
 WORKDIR /app/src
 

--- a/infra/staging/docker/viewer/viewer-deploy
+++ b/infra/staging/docker/viewer/viewer-deploy
@@ -6,6 +6,8 @@ set -euo pipefail
 : "${CLOUDFLARE_WORKER_NAME:?}"
 : "${CLOUDFLARE_ACCOUNT_ID:?}"
 : "${CLOUDFLARE_API_TOKEN:?}"
+: "${GOOGLE_CLOUD_PROJECT:?}"
+: "${NOTIFICATION_TOPIC:?}"
 
 pnpm --filter viewer build
 
@@ -15,3 +17,7 @@ pnpm --filter viewer run deploy \
   --name "${CLOUDFLARE_WORKER_NAME}" \
   --compatibility-date "$(date -u '+%Y-%m-%d')" \
   --message "${DEPLOY_MESSAGE}"
+
+notify-publish <<EOF
+{"action":"viewer.deploy","status":"succeeded","embeds":[{"title":"Viewer deploy succeeded","fields":[{"name":"site_url","value":"${SITE_URL}","inline":true},{"name":"env","value":"staging","inline":true}]}]}
+EOF

--- a/mise.toml
+++ b/mise.toml
@@ -481,3 +481,23 @@ run = [
   "moon check",
   "moon test",
 ]
+
+# -- Notify Publish --
+
+[tasks."notify-publish:test"]
+description = "notify-publish の moon test を実行する"
+dir = "src/notify-publish"
+run = "moon test"
+
+[tasks."notify-publish:build"]
+description = "notify-publish を native release ビルドする"
+dir = "src/notify-publish"
+run = "moon build --target native --release"
+
+[tasks."notify-publish:check"]
+description = "notify-publish の check / test を実行する"
+dir = "src/notify-publish"
+run = [
+  "moon check",
+  "moon test",
+]

--- a/src/notify-publish/.gitignore
+++ b/src/notify-publish/.gitignore
@@ -1,0 +1,6 @@
+.DS_Store
+_build/
+target/
+target
+.mooncakes/
+.moonagent/

--- a/src/notify-publish/AGENTS.md
+++ b/src/notify-publish/AGENTS.md
@@ -1,0 +1,22 @@
+# notify-publish
+
+MoonBit 製の通知 publish CLI
+
+## 構成
+
+- `payload.mbt`: アプリ通知 JSON の検証と Pub/Sub PublishRequest body 生成
+- `config.mbt`: env から project / topic / metadata host を読む
+- `pubsub.mbt`: metadata token 取得と Pub/Sub publish
+- `publish.mbt`: stdin → 検証 → publish の一連処理
+
+## コマンド
+
+```bash
+moon check
+moon test
+moon fmt
+moon info
+moon build --target native --release
+```
+
+最後に `moon info && moon fmt` を回す

--- a/src/notify-publish/README.md
+++ b/src/notify-publish/README.md
@@ -1,0 +1,57 @@
+# notify-publish
+
+通知 JSON を Pub/Sub topic へ publish する MoonBit native CLI
+
+Discord 配達はしない。発信側から `{env}-discord-notify` へ載せる入口
+
+## 責務
+
+- stdin のアプリ通知 JSON (`action` / `status` / `content?` / `embeds?`) を検証する
+- GCE metadata から default SA の access token を取る
+- `NOTIFICATION_TOPIC` へ `topics:publish` する
+
+## 契約
+
+`discord-notifier` と同じアプリ通知 JSON
+
+```json
+{
+  "action": "viewer.deploy",
+  "status": "succeeded",
+  "embeds": [
+    {
+      "title": "Viewer deploy succeeded",
+      "fields": [
+        { "name": "site_url", "value": "https://example.com", "inline": true }
+      ]
+    }
+  ]
+}
+```
+
+## 使い方
+
+```bash
+export GOOGLE_CLOUD_PROJECT=my-project
+export NOTIFICATION_TOPIC=dev-discord-notify
+
+notify-publish <<'EOF'
+{"action":"viewer.deploy","status":"succeeded","content":"ok"}
+EOF
+```
+
+ローカルビルド:
+
+```bash
+cd src/notify-publish
+moon test
+moon build --target native --release
+```
+
+## 環境変数
+
+| 名前 | 用途 |
+|---|---|
+| `GOOGLE_CLOUD_PROJECT` | GCP project id |
+| `NOTIFICATION_TOPIC` | publish 先 topic 名 |
+| `GCE_METADATA_HOST` | metadata host (任意。Cloud が付ける値を使う) |

--- a/src/notify-publish/cmd/main/main.mbt
+++ b/src/notify-publish/cmd/main/main.mbt
@@ -1,0 +1,6 @@
+///|
+async fn main {
+  @lib.run() catch {
+    err => abort("notify-publish failed: \{err}")
+  }
+}

--- a/src/notify-publish/cmd/main/moon.pkg
+++ b/src/notify-publish/cmd/main/moon.pkg
@@ -1,0 +1,6 @@
+import {
+  "isekai-observatory/notify-publish" @lib,
+  "moonbitlang/async",
+}
+
+pkgtype(kind: "executable")

--- a/src/notify-publish/cmd/main/pkg.generated.mbti
+++ b/src/notify-publish/cmd/main/pkg.generated.mbti
@@ -1,0 +1,12 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "isekai-observatory/notify-publish/cmd/main"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits

--- a/src/notify-publish/config.mbt
+++ b/src/notify-publish/config.mbt
@@ -1,0 +1,45 @@
+///|
+pub(all) struct Config {
+  project : String
+  topic : String
+  metadata_base_url : String
+} derive(Eq, Debug)
+
+///|
+pub fn Config::from_env() -> Config raise {
+  let project = required_env("GOOGLE_CLOUD_PROJECT")
+  let topic = required_env("NOTIFICATION_TOPIC")
+  let metadata_base_url = match @env.get_env_var("GCE_METADATA_HOST") {
+    Some(host) =>
+      if host == "" {
+        "http://metadata.google.internal"
+      } else {
+        "http://\{host}"
+      }
+    None => "http://metadata.google.internal"
+  }
+  { project, topic, metadata_base_url }
+}
+
+///|
+fn required_env(name : String) -> String raise {
+  match @env.get_env_var(name) {
+    Some(value) =>
+      if value == "" {
+        raise Failure("\{name} must not be empty")
+      } else {
+        value
+      }
+    None => raise Failure("\{name} is required")
+  }
+}
+
+///|
+pub fn Config::publish_url(self : Config) -> String {
+  "https://pubsub.googleapis.com/v1/projects/\{self.project}/topics/\{self.topic}:publish"
+}
+
+///|
+pub fn Config::access_token_url(self : Config) -> String {
+  "\{self.metadata_base_url}/computeMetadata/v1/instance/service-accounts/default/token"
+}

--- a/src/notify-publish/moon.mod
+++ b/src/notify-publish/moon.mod
@@ -1,0 +1,17 @@
+name = "isekai-observatory/notify-publish"
+
+version = "0.1.0"
+
+readme = "README.md"
+
+repository = ""
+
+keywords = [ ]
+
+preferred_target = "native"
+
+description = "通知 JSON を Pub/Sub topic へ publish する CLI"
+
+import {
+  "moonbitlang/async@0.20.4",
+}

--- a/src/notify-publish/moon.pkg
+++ b/src/notify-publish/moon.pkg
@@ -1,0 +1,14 @@
+import {
+  "moonbitlang/async/http",
+  "moonbitlang/async/io",
+  "moonbitlang/async/stdio",
+  "moonbitlang/core/encoding/base64",
+  "moonbitlang/core/encoding/utf8",
+  "moonbitlang/core/env",
+  "moonbitlang/core/json",
+  "moonbitlang/core/string",
+}
+
+import {
+  "moonbitlang/core/test",
+} for "wbtest"

--- a/src/notify-publish/payload.mbt
+++ b/src/notify-publish/payload.mbt
@@ -1,0 +1,69 @@
+///|
+/// discord-notifier と同じアプリ通知契約を検証する
+/// action / status と content または非空 embeds が必須
+pub fn validate_notification_json(text : String) -> Unit raise PayloadError {
+  let root = @json.parse(text) catch {
+    err => raise InvalidJson(err.to_string())
+  }
+  match root {
+    { "action": String(action), "status": String(status), .. } => {
+      guard action != "" else {
+        raise InvalidPayload("action must not be empty")
+      }
+      guard status != "" else {
+        raise InvalidPayload("status must not be empty")
+      }
+      let content = extract_content(root)
+      let embeds = extract_embeds(root)
+      guard content is Some(_) || embeds is Some(_) else {
+        raise InvalidPayload("content or non-empty embeds is required")
+      }
+    }
+    _ => raise InvalidPayload("expected notification with action/status")
+  }
+}
+
+///|
+fn extract_content(payload : Json) -> String? {
+  match payload {
+    { "content": String(content), .. } =>
+      if content == "" {
+        None
+      } else {
+        Some(content)
+      }
+    _ => None
+  }
+}
+
+///|
+fn extract_embeds(payload : Json) -> Json? raise PayloadError {
+  match payload {
+    { "embeds": embeds, .. } => {
+      guard embeds is Array(_) else {
+        raise InvalidPayload("embeds must be an array")
+      }
+      if has_embeds(embeds) {
+        Some(embeds)
+      } else {
+        None
+      }
+    }
+    _ => None
+  }
+}
+
+///|
+fn has_embeds(embeds : Json) -> Bool {
+  match embeds {
+    Array(items) => items.length() > 0
+    _ => false
+  }
+}
+
+///|
+/// Pub/Sub PublishRequest の body を作る
+pub fn build_publish_body(payload_text : String) -> Json {
+  let data = @base64.encode(@utf8.encode(payload_text))
+  { "messages": [{ "data": data }] }
+}

--- a/src/notify-publish/payload_wbtest.mbt
+++ b/src/notify-publish/payload_wbtest.mbt
@@ -1,0 +1,72 @@
+///|
+test "validate accepts content only" {
+  validate_notification_json(
+    "{\"action\":\"viewer.deploy\",\"status\":\"succeeded\",\"content\":\"ok\"}",
+  )
+}
+
+///|
+test "validate accepts embeds only" {
+  validate_notification_json(
+    "{\"action\":\"viewer.deploy\",\"status\":\"succeeded\",\"embeds\":[{\"title\":\"ok\"}]}",
+  )
+}
+
+///|
+test "validate rejects missing content and embeds" {
+  let err = @test.expect_error(() => {
+    validate_notification_json(
+      "{\"action\":\"viewer.deploy\",\"status\":\"succeeded\"}",
+    )
+  })
+  guard err is InvalidPayload("content or non-empty embeds is required") else {
+    fail("expected InvalidPayload")
+  }
+}
+
+///|
+test "validate rejects empty embeds" {
+  let err = @test.expect_error(() => {
+    validate_notification_json(
+      "{\"action\":\"viewer.deploy\",\"status\":\"succeeded\",\"embeds\":[]}",
+    )
+  })
+  guard err is InvalidPayload("content or non-empty embeds is required") else {
+    fail("expected InvalidPayload")
+  }
+}
+
+///|
+test "validate rejects invalid json" {
+  let err = @test.expect_error(() => validate_notification_json("{"))
+  guard err is InvalidJson(_) else { fail("expected InvalidJson") }
+}
+
+///|
+test "build_publish_body encodes payload" {
+  let payload = "{\"action\":\"viewer.deploy\",\"status\":\"succeeded\",\"content\":\"ok\"}"
+  let body = build_publish_body(payload)
+  guard body is { "messages": [{ "data": String(data), .. }], .. } else {
+    fail("unexpected publish body shape")
+  }
+  let decoded = @base64.decode(data)
+  let text = @utf8.decode(decoded)
+  assert_eq(text, payload)
+}
+
+///|
+test "config urls" {
+  let config : Config = {
+    project: "my-project",
+    topic: "dev-discord-notify",
+    metadata_base_url: "http://metadata.google.internal",
+  }
+  assert_eq(
+    config.publish_url(),
+    "https://pubsub.googleapis.com/v1/projects/my-project/topics/dev-discord-notify:publish",
+  )
+  assert_eq(
+    config.access_token_url(),
+    "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token",
+  )
+}

--- a/src/notify-publish/pkg.generated.mbti
+++ b/src/notify-publish/pkg.generated.mbti
@@ -1,0 +1,38 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "isekai-observatory/notify-publish"
+
+import {
+  "moonbitlang/core/debug",
+}
+
+// Values
+pub fn build_publish_body(String) -> Json
+
+pub async fn fetch_access_token(Config) -> String
+
+pub async fn publish_notification(Config, String) -> Unit
+
+pub async fn run() -> Unit
+
+pub fn validate_notification_json(String) -> Unit raise PayloadError
+
+// Errors
+pub suberror PayloadError {
+  InvalidJson(String)
+  InvalidPayload(String)
+} derive(Eq, @debug.Debug)
+pub fn PayloadError::to_string(Self) -> String
+
+// Types and methods
+pub(all) struct Config {
+  project : String
+  topic : String
+  metadata_base_url : String
+} derive(Eq, @debug.Debug)
+pub fn Config::access_token_url(Self) -> String
+pub fn Config::from_env() -> Self raise
+pub fn Config::publish_url(Self) -> String
+
+// Type aliases
+
+// Traits

--- a/src/notify-publish/publish.mbt
+++ b/src/notify-publish/publish.mbt
@@ -1,0 +1,21 @@
+///|
+/// stdin の通知 JSON を読み、Pub/Sub へ publish する
+pub async fn run() -> Unit {
+  let config = Config::from_env()
+  let payload_text = read_stdin_text()
+  guard payload_text != "" else {
+    raise Failure("stdin is empty; expected notification JSON")
+  }
+  validate_notification_json(payload_text) catch {
+    err => raise Failure(err.to_string())
+  }
+  publish_notification(config, payload_text)
+}
+
+///|
+async fn read_stdin_text() -> String {
+  let data = @stdio.stdin.read_all()
+  data.text() catch {
+    err => raise Failure("stdin is not valid utf8: \{err}")
+  }
+}

--- a/src/notify-publish/pubsub.mbt
+++ b/src/notify-publish/pubsub.mbt
@@ -1,0 +1,47 @@
+///|
+/// GCE metadata から default SA の access token を取る
+pub async fn fetch_access_token(config : Config) -> String {
+  let (response, body) = @http.get(config.access_token_url(), headers={
+    "Metadata-Flavor": "Google",
+  })
+  defer ignore(body)
+  guard response.code is (200..<300) else {
+    let body_text = body.text() catch { _ => "" }
+    raise Failure(
+      "metadata token request failed: \{response.code} \{response.reason} \{body_text}",
+    )
+  }
+  let json = body.json() catch {
+    err => raise Failure("metadata token response is not json: \{err}")
+  }
+  match json {
+    { "access_token": String(token), .. } =>
+      if token == "" {
+        raise Failure("metadata token response has empty access_token")
+      } else {
+        token
+      }
+    _ => raise Failure("metadata token response missing access_token")
+  }
+}
+
+///|
+/// 検証済み通知 JSON を Pub/Sub topic へ publish する
+pub async fn publish_notification(
+  config : Config,
+  payload_text : String,
+) -> Unit {
+  let token = fetch_access_token(config)
+  let body = build_publish_body(payload_text)
+  let (response, response_body) = @http.post(config.publish_url(), body, headers={
+    "Authorization": "Bearer \{token}",
+    "Content-Type": "application/json",
+  })
+  defer ignore(response_body)
+  guard response.code is (200..<300) else {
+    let body_text = response_body.text() catch { _ => "" }
+    raise Failure(
+      "pubsub publish failed: \{response.code} \{response.reason} \{body_text}",
+    )
+  }
+}

--- a/src/notify-publish/types.mbt
+++ b/src/notify-publish/types.mbt
@@ -1,0 +1,14 @@
+///|
+/// 通知 JSON の検証エラー
+pub suberror PayloadError {
+  InvalidJson(String)
+  InvalidPayload(String)
+} derive(Eq, Debug)
+
+///|
+pub fn PayloadError::to_string(self : PayloadError) -> String {
+  match self {
+    InvalidJson(msg) => "invalid json: \{msg}"
+    InvalidPayload(msg) => "invalid payload: \{msg}"
+  }
+}


### PR DESCRIPTION
## 概要

viewer-deploy 成功時に Discord 通知契約の JSON を Pub/Sub へ載せる MoonBit CLI (`notify-publish`) を追加し、viewer イメージから利用できるようにする

## やったこと

- `src/notify-publish` に通知 JSON 検証〜 Pub/Sub publish の native CLI を追加する
- viewer Dockerfile に `notify-publish` を同梱し、`viewer-deploy` 成功後に呼び出す
- GitHub Actions の QA workflow と mise タスク、文書を追加する


## 関連

- 特になし

Made with [Cursor](https://cursor.com)