### PR TITLE
admin-proxy を Cloud Run Job イメージ化し CI の substitutions 依存を減らす

### DIFF
--- a/infra/development/README.md
+++ b/infra/development/README.md
@@ -4,7 +4,7 @@
 
 ## Cloud Build
 
-- `cloudbuild/ci.yaml`: API / CLI / DB migrate / Admin / Viewer のコンテナを build / push し、Cloud Run service / job と Cloudflare Worker を deploy する
+- `cloudbuild/ci.yaml`: API / CLI / DB migrate / Admin / Viewer / admin-proxy のコンテナを build / push し、Cloud Run service / job を deploy する
 - Cloud Build から実行する build command は YAML に直接定義する
 
 ## Dockerfiles
@@ -14,25 +14,26 @@
 - `docker/db-migrate/Dockerfile`: migration job 用で Atlas と schema 定義のみを含める
 - `docker/admin/Dockerfile`: Admin 用で build stage では `bun --filter admin build`、runtime stage では Bun slim image を使う
 - `docker/viewer/Dockerfile`: Viewer deploy job 用で `viewer-deploy` を entrypoint にする
+- `docker/admin-proxy/Dockerfile`: admin-proxy deploy job 用で `admin-proxy-deploy` を entrypoint にする
 
 ## 初回構築前提
 
 - Cloud Build trigger に dev 用の substitution value を設定する
-- `_CLOUDFLARE_API_TOKEN_SECRET_ID` が指す Secret Manager secret を作成する
-- Cloud Build service account に Artifact Registry、Cloud Run、Service Account User、Secret Manager の必要権限を付与する
-- API / Admin service と DB migrate / Admin invite / media youtube import job の runtime env / secret は `ci.yaml` で定義しないため初回デプロイ前に別経路で設定する
+- Cloud Build service account に Artifact Registry、Cloud Run、Service Account User の必要権限を付与する
+- API / Admin service と DB migrate / Admin invite / media youtube import / Viewer deploy / admin-proxy deploy job の runtime env / secret は `ci.yaml` で定義しないため初回デプロイ前に別経路で設定する
 - DB migrate job には `DB_USERNAME` / `DB_PASSWORD` / `DB_HOST` / `DB_PORT` / `DB_DATABASE` を設定する
 - media youtube import job (`dev-media-youtube-import`) には DB 接続 env と `YOUTUBE_API_KEY` を設定する
-- `_ADMIN_PROXY_SHARED_SECRET_ID` が指す Secret Manager secret に version を追加する
-- Admin service は同じ secret を参照し、Cloud Build が admin-proxy Worker へ同期する
+- Viewer deploy job (`dev-viewer-deploy`) には `API_URL` / `SITE_URL` / `SITE_NOINDEX=true` / `APP_ENV=development` / Cloudflare Worker 名 / account ID と `CLOUDFLARE_API_TOKEN` secret を設定する
+- admin-proxy deploy job (`dev-admin-proxy-deploy`) には `ADMIN_PROXY_WORKER_NAME` / `ADMIN_PROXY_ORIGIN_URL` / `CLOUDFLARE_ACCOUNT_ID` と `CLOUDFLARE_API_TOKEN` / `PROXY_SHARED_SECRET` secret を設定する
+- Admin service は `PROXY_SHARED_SECRET` と同じ secret を参照する
 
 ## Notes
 
-- `ci.yaml` は Artifact Registry の repository を `_ARTIFACT_REPOSITORY`、image 名を `_API_IMAGE` / `_CLI_IMAGE` / `_DB_MIGRATE_IMAGE` / `_ADMIN_IMAGE` / `_VIEWER_IMAGE` で受け取る
+- `ci.yaml` は Artifact Registry の repository を `_ARTIFACT_REPOSITORY`、image 名を `_API_IMAGE` / `_CLI_IMAGE` / `_DB_MIGRATE_IMAGE` / `_ADMIN_IMAGE` / `_VIEWER_IMAGE` / `_ADMIN_PROXY_IMAGE` で受け取る
 - Cloud Run の service / job 名は `dev-*` の値を YAML に直接定義する
 - Cloud Run jobs の service account は `_JOB_SERVICE_ACCOUNT` で受け取る
 - Admin の `PUBLIC_APP_URL` は Cloud Build substitution の `_PUBLIC_APP_URL` を build arg として渡す
-- Viewer deploy job は `API_URL` / `SITE_URL` / Cloudflare Worker 名 / account ID / API token secret を受け取り、Cloudflare Workers へ deploy する
-- dev はクロール不要のため `SITE_NOINDEX=true` を渡し、robots.txt と meta robots を noindex にする
-- 環境バッジ表示のため `APP_ENV=development` を Admin は Dockerfile の `ENV`、Viewer deploy job は runtime env で渡す
+- Viewer deploy job は runtime env / secret を受け取り、Cloudflare Workers へ deploy する
+- admin-proxy deploy job は Cloud Build が `gcloud run jobs deploy --wait` で image 差し替えと実行完了まで行い、Cloudflare Workers へ deploy する
+- 環境バッジ表示のため `APP_ENV=development` を Admin は Dockerfile の `ENV` で渡す
 - Cloud Build 上で使う tool / base image の版は `mise.toml`(`[tools]` / `[vars]`)を Source of Truth とし、`tools/read-mise-value.sh` 経由で参照する

--- a/infra/development/cloudbuild/ci.yaml
+++ b/infra/development/cloudbuild/ci.yaml
@@ -39,6 +39,14 @@ steps:
       - -c
       - docker pull ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_VIEWER_IMAGE}:latest || exit 0
 
+  - id: pull-admin-proxy-image
+    name: gcr.io/cloud-builders/docker
+    entrypoint: bash
+    waitFor: ["-"]
+    args:
+      - -c
+      - docker pull ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_ADMIN_PROXY_IMAGE}:latest || exit 0
+
   - id: build-api-image
     name: gcr.io/cloud-builders/docker
     waitFor:
@@ -132,6 +140,26 @@ steps:
           --build-arg "NODE_VERSION=$${NODE_VERSION}" \
           .
 
+  - id: build-admin-proxy-image
+    name: gcr.io/cloud-builders/docker
+    entrypoint: bash
+    waitFor:
+      - pull-admin-proxy-image
+    args:
+      - -c
+      - |
+        set -euo pipefail
+
+        NODE_VERSION=$$(./tools/read-mise-value.sh node)
+
+        docker build \
+          -f infra/development/docker/admin-proxy/Dockerfile \
+          -t ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_ADMIN_PROXY_IMAGE}:$COMMIT_SHA \
+          -t ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_ADMIN_PROXY_IMAGE}:latest \
+          --cache-from ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_ADMIN_PROXY_IMAGE}:latest \
+          --build-arg "NODE_VERSION=$${NODE_VERSION}" \
+          .
+
   - id: push-api-image
     name: gcr.io/cloud-builders/docker
     waitFor:
@@ -176,6 +204,15 @@ steps:
       - push
       - --all-tags
       - ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_VIEWER_IMAGE}
+
+  - id: push-admin-proxy-image
+    name: gcr.io/cloud-builders/docker
+    waitFor:
+      - build-admin-proxy-image
+    args:
+      - push
+      - --all-tags
+      - ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_ADMIN_PROXY_IMAGE}
 
   # TODO マイグレーションを別で行う
   - id: deploy-db-migrate-job
@@ -290,36 +327,27 @@ steps:
       - ${_REGION}
       - --service-account
       - ${_JOB_SERVICE_ACCOUNT}
-      - --set-env-vars
-      # dev はクロール不要のため SITE_NOINDEX で robots.txt と meta robots を noindex にする
-      - API_URL=${_API_URL},SITE_URL=${_SITE_URL},SITE_NOINDEX=true,APP_ENV=development,CLOUDFLARE_WORKER_NAME=${_CLOUDFLARE_WORKER_NAME},CLOUDFLARE_ACCOUNT_ID=${_CLOUDFLARE_ACCOUNT_ID}
-      - --set-secrets
-      - CLOUDFLARE_API_TOKEN=${_CLOUDFLARE_API_TOKEN_SECRET_ID}:latest
       # - --wait
       - --quiet
 
-  # admin-proxy Worker はイメージ不要のため Cloud Build から直接 wrangler でデプロイする
   - id: deploy-admin-proxy
-    name: node:24-slim
-    entrypoint: bash
-    waitFor: ["-"]
-    env:
-      - CLOUDFLARE_ACCOUNT_ID=${_CLOUDFLARE_ACCOUNT_ID}
-      - ADMIN_PROXY_WORKER_NAME=${_ADMIN_PROXY_WORKER_NAME}
-      - ADMIN_PROXY_ORIGIN_URL=${_ADMIN_PROXY_ORIGIN_URL}
-    secretEnv:
-      - CLOUDFLARE_API_TOKEN
-      - PROXY_SHARED_SECRET
+    name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    entrypoint: gcloud
+    waitFor:
+      - push-admin-proxy-image
     args:
-      - -c
-      - bash infra/development/cloudbuild/admin-proxy-deploy "$$(date --iso-8601=seconds)"
-
-availableSecrets:
-  secretManager:
-    - versionName: projects/$PROJECT_ID/secrets/${_CLOUDFLARE_API_TOKEN_SECRET_ID}/versions/latest
-      env: CLOUDFLARE_API_TOKEN
-    - versionName: projects/$PROJECT_ID/secrets/${_ADMIN_PROXY_SHARED_SECRET_ID}/versions/latest
-      env: PROXY_SHARED_SECRET
+      - run
+      - jobs
+      - deploy
+      - dev-admin-proxy-deploy
+      - --image
+      - ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_ADMIN_PROXY_IMAGE}:$COMMIT_SHA
+      - --region
+      - ${_REGION}
+      - --service-account
+      - ${_JOB_SERVICE_ACCOUNT}
+      - --wait
+      - --quiet
 
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/infra/development/docker/admin-proxy/Dockerfile
+++ b/infra/development/docker/admin-proxy/Dockerfile
@@ -1,0 +1,33 @@
+ARG NODE_VERSION
+FROM node:${NODE_VERSION}-slim
+
+ENV TZ=Asia/Tokyo
+ENV PNPM_HOME=/pnpm
+ENV PATH=${PNPM_HOME}:${PATH}
+
+WORKDIR /app
+
+RUN apt-get update \
+  && apt-get install -y \
+    ca-certificates \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY infra/development/docker/admin-proxy/admin-proxy-deploy /usr/local/bin/admin-proxy-deploy
+COPY mise.toml ./
+
+RUN corepack enable \
+  && corepack prepare "pnpm@$(sed -n 's/^pnpm = "\(.*\)"$/\1/p' mise.toml)" --activate \
+  && chmod +x /usr/local/bin/admin-proxy-deploy
+
+WORKDIR /app/src
+
+COPY src/package.json src/pnpm-lock.yaml src/pnpm-workspace.yaml ./
+COPY src/admin-proxy/package.json admin-proxy/package.json
+
+RUN pnpm install --frozen-lockfile --filter admin-proxy --prod \
+  && rm -rf /pnpm/store
+
+COPY src/admin-proxy admin-proxy
+
+ENTRYPOINT ["admin-proxy-deploy"]

--- a/infra/development/docker/admin-proxy/admin-proxy-deploy
+++ b/infra/development/docker/admin-proxy/admin-proxy-deploy
@@ -7,16 +7,7 @@ set -euo pipefail
 : "${ADMIN_PROXY_ORIGIN_URL:?}"
 : "${PROXY_SHARED_SECRET:?}"
 
-DEPLOY_DATE="${1:?usage: admin-proxy-deploy <deploy-date>}"
-
-corepack enable
-corepack prepare "pnpm@$(sed -n 's/^pnpm = "\(.*\)"$/\1/p' mise.toml)" --activate
-
-cd src
-
-pnpm install --frozen-lockfile --filter admin-proxy --prod
-
-DEPLOY_MESSAGE="staging admin-proxy deploy ${DEPLOY_DATE}"
+DEPLOY_MESSAGE="dev admin-proxy deploy $(date --iso-8601=seconds)"
 SECRETS_FILE="$(mktemp --suffix=.json)"
 trap 'rm -f "${SECRETS_FILE}"' EXIT
 
@@ -32,5 +23,5 @@ pnpm --filter admin-proxy run deploy \
   --name "${ADMIN_PROXY_WORKER_NAME}" \
   --var "ORIGIN_URL:${ADMIN_PROXY_ORIGIN_URL}" \
   --secrets-file "${SECRETS_FILE}" \
-  --compatibility-date "${DEPLOY_DATE%%T*}" \
+  --compatibility-date "$(date -u '+%Y-%m-%d')" \
   --message "${DEPLOY_MESSAGE}"

--- a/infra/development/docker/viewer/viewer-deploy
+++ b/infra/development/docker/viewer/viewer-deploy
@@ -13,5 +13,5 @@ DEPLOY_MESSAGE="dev viewer deploy $(date --iso-8601=seconds)"
 
 pnpm --filter viewer run deploy \
   --name "${CLOUDFLARE_WORKER_NAME}" \
-  --compatibility-date "$(date '+%Y-%m-%d')" \
+  --compatibility-date "$(date -u '+%Y-%m-%d')" \
   --message "${DEPLOY_MESSAGE}"

--- a/infra/production/README.md
+++ b/infra/production/README.md
@@ -4,7 +4,7 @@
 
 ## Cloud Build
 
-- `cloudbuild/ci.yaml`: API / CLI / DB migrate / Admin / Viewer のコンテナを build / push し、Cloud Run service / job と Cloudflare Worker を deploy する
+- `cloudbuild/ci.yaml`: API / CLI / DB migrate / Admin / Viewer / admin-proxy のコンテナを build / push し、Cloud Run service / job を deploy する
 - Cloud Build から実行する build command は YAML に直接定義する
 
 ## Dockerfiles
@@ -14,24 +14,26 @@
 - `docker/db-migrate/Dockerfile`: migration job 用で Atlas と schema 定義のみを含める
 - `docker/admin/Dockerfile`: Admin 用で build stage では `bun --filter admin build`、runtime stage では Bun slim image を使う
 - `docker/viewer/Dockerfile`: Viewer deploy job 用で `viewer-deploy` を entrypoint にする
+- `docker/admin-proxy/Dockerfile`: admin-proxy deploy job 用で `admin-proxy-deploy` を entrypoint にする
 
 ## 初回構築前提
 
 - Cloud Build trigger には stg と同じ substitution key を prod 用の値で設定する
-- `_CLOUDFLARE_API_TOKEN_SECRET_ID` が指す Secret Manager secret を作成する
-- Cloud Build service account に Artifact Registry、Cloud Run、Service Account User、Secret Manager の必要権限を付与する
-- API / Admin service と DB migrate / Admin invite / media youtube import job の runtime env / secret は `ci.yaml` で定義しないため初回デプロイ前に別経路で設定する
+- Cloud Build service account に Artifact Registry、Cloud Run、Service Account User の必要権限を付与する
+- API / Admin service と DB migrate / Admin invite / media youtube import / Viewer deploy / admin-proxy deploy job の runtime env / secret は `ci.yaml` で定義しないため初回デプロイ前に別経路で設定する
 - DB migrate job には `DB_USERNAME` / `DB_PASSWORD` / `DB_HOST` / `DB_PORT` / `DB_DATABASE` を設定する
 - media youtube import job (`prod-media-youtube-import`) には DB 接続 env と `YOUTUBE_API_KEY` を設定する
-- `_ADMIN_PROXY_SHARED_SECRET_ID` が指す Secret Manager secret に version を追加する
-- Admin service は同じ secret を参照し、Cloud Build が admin-proxy Worker へ同期する
+- Viewer deploy job (`prod-viewer-deploy`) には `API_URL` / `SITE_URL` / `APP_ENV=production` / Cloudflare Worker 名 / account ID と `CLOUDFLARE_API_TOKEN` secret を設定する
+- admin-proxy deploy job (`prod-admin-proxy-deploy`) には `ADMIN_PROXY_WORKER_NAME` / `ADMIN_PROXY_ORIGIN_URL` / `CLOUDFLARE_ACCOUNT_ID` と `CLOUDFLARE_API_TOKEN` / `PROXY_SHARED_SECRET` secret を設定する
+- Admin service は `PROXY_SHARED_SECRET` と同じ secret を参照する
 
 ## Notes
 
-- `ci.yaml` は Artifact Registry の repository を `_ARTIFACT_REPOSITORY`、image 名を `_API_IMAGE` / `_CLI_IMAGE` / `_DB_MIGRATE_IMAGE` / `_ADMIN_IMAGE` / `_VIEWER_IMAGE` で受け取る
+- `ci.yaml` は Artifact Registry の repository を `_ARTIFACT_REPOSITORY`、image 名を `_API_IMAGE` / `_CLI_IMAGE` / `_DB_MIGRATE_IMAGE` / `_ADMIN_IMAGE` / `_VIEWER_IMAGE` / `_ADMIN_PROXY_IMAGE` で受け取る
 - Cloud Run の service / job 名は `prod-*` の値を YAML に直接定義する
 - Cloud Run jobs の service account は `_JOB_SERVICE_ACCOUNT` で受け取る
 - Admin の `PUBLIC_APP_URL` は Cloud Build substitution の `_PUBLIC_APP_URL` を build arg として渡す
-- Viewer deploy job は `API_URL` / `SITE_URL` / Cloudflare Worker 名 / account ID / API token secret を受け取り、Cloudflare Workers へ deploy する
-- `APP_ENV=production` を Admin は Dockerfile の `ENV`、Viewer deploy job は runtime env で渡す。production では環境バッジを表示しない
+- Viewer deploy job は runtime env / secret を受け取り、Cloudflare Workers へ deploy する
+- admin-proxy deploy job は Cloud Build が `gcloud run jobs deploy --wait` で image 差し替えと実行完了まで行い、Cloudflare Workers へ deploy する
+- `APP_ENV=production` を Admin は Dockerfile の `ENV` で渡す。production では環境バッジを表示しない
 - Cloud Build 上で使う tool / base image の版は `mise.toml`(`[tools]` / `[vars]`)を Source of Truth とし、`tools/read-mise-value.sh` 経由で参照する

--- a/infra/production/cloudbuild/ci.yaml
+++ b/infra/production/cloudbuild/ci.yaml
@@ -39,6 +39,14 @@ steps:
       - -c
       - docker pull ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_VIEWER_IMAGE}:latest || exit 0
 
+  - id: pull-admin-proxy-image
+    name: gcr.io/cloud-builders/docker
+    entrypoint: bash
+    waitFor: ["-"]
+    args:
+      - -c
+      - docker pull ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_ADMIN_PROXY_IMAGE}:latest || exit 0
+
   - id: build-api-image
     name: gcr.io/cloud-builders/docker
     waitFor:
@@ -132,6 +140,26 @@ steps:
           --build-arg "NODE_VERSION=$${NODE_VERSION}" \
           .
 
+  - id: build-admin-proxy-image
+    name: gcr.io/cloud-builders/docker
+    entrypoint: bash
+    waitFor:
+      - pull-admin-proxy-image
+    args:
+      - -c
+      - |
+        set -euo pipefail
+
+        NODE_VERSION=$$(./tools/read-mise-value.sh node)
+
+        docker build \
+          -f infra/production/docker/admin-proxy/Dockerfile \
+          -t ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_ADMIN_PROXY_IMAGE}:$COMMIT_SHA \
+          -t ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_ADMIN_PROXY_IMAGE}:latest \
+          --cache-from ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_ADMIN_PROXY_IMAGE}:latest \
+          --build-arg "NODE_VERSION=$${NODE_VERSION}" \
+          .
+
   - id: push-api-image
     name: gcr.io/cloud-builders/docker
     waitFor:
@@ -176,6 +204,15 @@ steps:
       - push
       - --all-tags
       - ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_VIEWER_IMAGE}
+
+  - id: push-admin-proxy-image
+    name: gcr.io/cloud-builders/docker
+    waitFor:
+      - build-admin-proxy-image
+    args:
+      - push
+      - --all-tags
+      - ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_ADMIN_PROXY_IMAGE}
 
   # TODO マイグレーションを別で行う
   - id: deploy-db-migrate-job
@@ -290,36 +327,27 @@ steps:
       - ${_REGION}
       - --service-account
       - ${_JOB_SERVICE_ACCOUNT}
-      - --set-env-vars
-      # APP_ENV は環境バッジの表示判定に使う。production ではバッジを表示しない
-      - API_URL=${_API_URL},SITE_URL=${_SITE_URL},APP_ENV=production,CLOUDFLARE_WORKER_NAME=${_CLOUDFLARE_WORKER_NAME},CLOUDFLARE_ACCOUNT_ID=${_CLOUDFLARE_ACCOUNT_ID}
-      - --set-secrets
-      - CLOUDFLARE_API_TOKEN=${_CLOUDFLARE_API_TOKEN_SECRET_ID}:latest
       # - --wait
       - --quiet
 
-  # admin-proxy Worker はイメージ不要のため Cloud Build から直接 wrangler でデプロイする
   - id: deploy-admin-proxy
-    name: node:24-slim
-    entrypoint: bash
-    waitFor: ["-"]
-    env:
-      - CLOUDFLARE_ACCOUNT_ID=${_CLOUDFLARE_ACCOUNT_ID}
-      - ADMIN_PROXY_WORKER_NAME=${_ADMIN_PROXY_WORKER_NAME}
-      - ADMIN_PROXY_ORIGIN_URL=${_ADMIN_PROXY_ORIGIN_URL}
-    secretEnv:
-      - CLOUDFLARE_API_TOKEN
-      - PROXY_SHARED_SECRET
+    name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    entrypoint: gcloud
+    waitFor:
+      - push-admin-proxy-image
     args:
-      - -c
-      - bash infra/production/cloudbuild/admin-proxy-deploy "$$(date --iso-8601=seconds)"
-
-availableSecrets:
-  secretManager:
-    - versionName: projects/$PROJECT_ID/secrets/${_CLOUDFLARE_API_TOKEN_SECRET_ID}/versions/latest
-      env: CLOUDFLARE_API_TOKEN
-    - versionName: projects/$PROJECT_ID/secrets/${_ADMIN_PROXY_SHARED_SECRET_ID}/versions/latest
-      env: PROXY_SHARED_SECRET
+      - run
+      - jobs
+      - deploy
+      - prod-admin-proxy-deploy
+      - --image
+      - ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_ADMIN_PROXY_IMAGE}:$COMMIT_SHA
+      - --region
+      - ${_REGION}
+      - --service-account
+      - ${_JOB_SERVICE_ACCOUNT}
+      - --wait
+      - --quiet
 
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/infra/production/docker/admin-proxy/Dockerfile
+++ b/infra/production/docker/admin-proxy/Dockerfile
@@ -1,0 +1,33 @@
+ARG NODE_VERSION
+FROM node:${NODE_VERSION}-slim
+
+ENV TZ=Asia/Tokyo
+ENV PNPM_HOME=/pnpm
+ENV PATH=${PNPM_HOME}:${PATH}
+
+WORKDIR /app
+
+RUN apt-get update \
+  && apt-get install -y \
+    ca-certificates \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY infra/production/docker/admin-proxy/admin-proxy-deploy /usr/local/bin/admin-proxy-deploy
+COPY mise.toml ./
+
+RUN corepack enable \
+  && corepack prepare "pnpm@$(sed -n 's/^pnpm = "\(.*\)"$/\1/p' mise.toml)" --activate \
+  && chmod +x /usr/local/bin/admin-proxy-deploy
+
+WORKDIR /app/src
+
+COPY src/package.json src/pnpm-lock.yaml src/pnpm-workspace.yaml ./
+COPY src/admin-proxy/package.json admin-proxy/package.json
+
+RUN pnpm install --frozen-lockfile --filter admin-proxy --prod \
+  && rm -rf /pnpm/store
+
+COPY src/admin-proxy admin-proxy
+
+ENTRYPOINT ["admin-proxy-deploy"]

--- a/infra/production/docker/admin-proxy/admin-proxy-deploy
+++ b/infra/production/docker/admin-proxy/admin-proxy-deploy
@@ -7,16 +7,7 @@ set -euo pipefail
 : "${ADMIN_PROXY_ORIGIN_URL:?}"
 : "${PROXY_SHARED_SECRET:?}"
 
-DEPLOY_DATE="${1:?usage: admin-proxy-deploy <deploy-date>}"
-
-corepack enable
-corepack prepare "pnpm@$(sed -n 's/^pnpm = "\(.*\)"$/\1/p' mise.toml)" --activate
-
-cd src
-
-pnpm install --frozen-lockfile --filter admin-proxy --prod
-
-DEPLOY_MESSAGE="dev admin-proxy deploy ${DEPLOY_DATE}"
+DEPLOY_MESSAGE="production admin-proxy deploy $(date --iso-8601=seconds)"
 SECRETS_FILE="$(mktemp --suffix=.json)"
 trap 'rm -f "${SECRETS_FILE}"' EXIT
 
@@ -32,5 +23,5 @@ pnpm --filter admin-proxy run deploy \
   --name "${ADMIN_PROXY_WORKER_NAME}" \
   --var "ORIGIN_URL:${ADMIN_PROXY_ORIGIN_URL}" \
   --secrets-file "${SECRETS_FILE}" \
-  --compatibility-date "${DEPLOY_DATE%%T*}" \
+  --compatibility-date "$(date -u '+%Y-%m-%d')" \
   --message "${DEPLOY_MESSAGE}"

--- a/infra/production/docker/viewer/viewer-deploy
+++ b/infra/production/docker/viewer/viewer-deploy
@@ -13,5 +13,5 @@ DEPLOY_MESSAGE="production viewer deploy $(date --iso-8601=seconds)"
 
 pnpm --filter viewer run deploy \
   --name "${CLOUDFLARE_WORKER_NAME}" \
-  --compatibility-date "$(date '+%Y-%m-%d')" \
+  --compatibility-date "$(date -u '+%Y-%m-%d')" \
   --message "${DEPLOY_MESSAGE}"

--- a/infra/staging/README.md
+++ b/infra/staging/README.md
@@ -4,7 +4,7 @@
 
 ## Cloud Build
 
-- `cloudbuild/ci.yaml`: API / CLI / DB migrate / Admin / Viewer のコンテナを build / push し、Cloud Run service / job と Cloudflare Worker を deploy する
+- `cloudbuild/ci.yaml`: API / CLI / DB migrate / Admin / Viewer / admin-proxy のコンテナを build / push し、Cloud Run service / job を deploy する
 - Cloud Build から実行する build command は YAML に直接定義する
 
 ## Dockerfiles
@@ -14,25 +14,26 @@
 - `docker/db-migrate/Dockerfile`: migration job 用で Atlas と schema 定義のみを含める
 - `docker/admin/Dockerfile`: Admin 用で build stage では `bun --filter admin build`、runtime stage では Bun slim image を使う
 - `docker/viewer/Dockerfile`: Viewer deploy job 用で `viewer-deploy` を entrypoint にする
+- `docker/admin-proxy/Dockerfile`: admin-proxy deploy job 用で `admin-proxy-deploy` を entrypoint にする
 
 ## 初回構築前提
 
 - Cloud Build trigger に staging 用の substitution value を設定する
-- `_CLOUDFLARE_API_TOKEN_SECRET_ID` が指す Secret Manager secret を作成する
-- Cloud Build service account に Artifact Registry、Cloud Run、Service Account User、Secret Manager の必要権限を付与する
-- API / Admin service と DB migrate / Admin invite / media youtube import job の runtime env / secret は `ci.yaml` で定義しないため初回デプロイ前に別経路で設定する
+- Cloud Build service account に Artifact Registry、Cloud Run、Service Account User の必要権限を付与する
+- API / Admin service と DB migrate / Admin invite / media youtube import / Viewer deploy / admin-proxy deploy job の runtime env / secret は `ci.yaml` で定義しないため初回デプロイ前に別経路で設定する
 - DB migrate job には `DB_USERNAME` / `DB_PASSWORD` / `DB_HOST` / `DB_PORT` / `DB_DATABASE` を設定する
 - media youtube import job (`stg-media-youtube-import`) には DB 接続 env と `YOUTUBE_API_KEY` を設定する
-- `_ADMIN_PROXY_SHARED_SECRET_ID` が指す Secret Manager secret に version を追加する
-- Admin service は同じ secret を参照し、Cloud Build が admin-proxy Worker へ同期する
+- Viewer deploy job (`stg-viewer-deploy`) には `API_URL` / `SITE_URL` / `SITE_NOINDEX=true` / `APP_ENV=staging` / Cloudflare Worker 名 / account ID と `CLOUDFLARE_API_TOKEN` secret を設定する
+- admin-proxy deploy job (`stg-admin-proxy-deploy`) には `ADMIN_PROXY_WORKER_NAME` / `ADMIN_PROXY_ORIGIN_URL` / `CLOUDFLARE_ACCOUNT_ID` と `CLOUDFLARE_API_TOKEN` / `PROXY_SHARED_SECRET` secret を設定する
+- Admin service は `PROXY_SHARED_SECRET` と同じ secret を参照する
 
 ## Notes
 
-- `ci.yaml` は Artifact Registry の repository を `_ARTIFACT_REPOSITORY`、image 名を `_API_IMAGE` / `_CLI_IMAGE` / `_DB_MIGRATE_IMAGE` / `_ADMIN_IMAGE` / `_VIEWER_IMAGE` で受け取る
+- `ci.yaml` は Artifact Registry の repository を `_ARTIFACT_REPOSITORY`、image 名を `_API_IMAGE` / `_CLI_IMAGE` / `_DB_MIGRATE_IMAGE` / `_ADMIN_IMAGE` / `_VIEWER_IMAGE` / `_ADMIN_PROXY_IMAGE` で受け取る
 - Cloud Run の service / job 名は `stg-*` の値を YAML に直接定義する
 - Cloud Run jobs の service account は `_JOB_SERVICE_ACCOUNT` で受け取る
 - Admin の `PUBLIC_APP_URL` は Cloud Build substitution の `_PUBLIC_APP_URL` を build arg として渡す
-- Viewer deploy job は `API_URL` / `SITE_URL` / Cloudflare Worker 名 / account ID / API token secret を受け取り、Cloudflare Workers へ deploy する
-- staging はクロール不要のため `SITE_NOINDEX=true` を渡し、robots.txt と meta robots を noindex にする
-- 環境バッジ表示のため `APP_ENV=staging` を Admin は Dockerfile の `ENV`、Viewer deploy job は runtime env で渡す
+- Viewer deploy job は runtime env / secret を受け取り、Cloudflare Workers へ deploy する
+- admin-proxy deploy job は Cloud Build が `gcloud run jobs deploy --wait` で image 差し替えと実行完了まで行い、Cloudflare Workers へ deploy する
+- 環境バッジ表示のため `APP_ENV=staging` を Admin は Dockerfile の `ENV` で渡す
 - Cloud Build 上で使う tool / base image の版は `mise.toml`(`[tools]` / `[vars]`)を Source of Truth とし、`tools/read-mise-value.sh` 経由で参照する

--- a/infra/staging/cloudbuild/ci.yaml
+++ b/infra/staging/cloudbuild/ci.yaml
@@ -39,6 +39,14 @@ steps:
       - -c
       - docker pull ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_VIEWER_IMAGE}:latest || exit 0
 
+  - id: pull-admin-proxy-image
+    name: gcr.io/cloud-builders/docker
+    entrypoint: bash
+    waitFor: ["-"]
+    args:
+      - -c
+      - docker pull ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_ADMIN_PROXY_IMAGE}:latest || exit 0
+
   - id: build-api-image
     name: gcr.io/cloud-builders/docker
     waitFor:
@@ -132,6 +140,26 @@ steps:
           --build-arg "NODE_VERSION=$${NODE_VERSION}" \
           .
 
+  - id: build-admin-proxy-image
+    name: gcr.io/cloud-builders/docker
+    entrypoint: bash
+    waitFor:
+      - pull-admin-proxy-image
+    args:
+      - -c
+      - |
+        set -euo pipefail
+
+        NODE_VERSION=$$(./tools/read-mise-value.sh node)
+
+        docker build \
+          -f infra/staging/docker/admin-proxy/Dockerfile \
+          -t ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_ADMIN_PROXY_IMAGE}:$COMMIT_SHA \
+          -t ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_ADMIN_PROXY_IMAGE}:latest \
+          --cache-from ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_ADMIN_PROXY_IMAGE}:latest \
+          --build-arg "NODE_VERSION=$${NODE_VERSION}" \
+          .
+
   - id: push-api-image
     name: gcr.io/cloud-builders/docker
     waitFor:
@@ -176,6 +204,15 @@ steps:
       - push
       - --all-tags
       - ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_VIEWER_IMAGE}
+
+  - id: push-admin-proxy-image
+    name: gcr.io/cloud-builders/docker
+    waitFor:
+      - build-admin-proxy-image
+    args:
+      - push
+      - --all-tags
+      - ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_ADMIN_PROXY_IMAGE}
 
   # TODO マイグレーションを別で行う
   - id: deploy-db-migrate-job
@@ -290,36 +327,27 @@ steps:
       - ${_REGION}
       - --service-account
       - ${_JOB_SERVICE_ACCOUNT}
-      - --set-env-vars
-      # staging はクロール不要のため SITE_NOINDEX で robots.txt と meta robots を noindex にする
-      - API_URL=${_API_URL},SITE_URL=${_SITE_URL},SITE_NOINDEX=true,APP_ENV=staging,CLOUDFLARE_WORKER_NAME=${_CLOUDFLARE_WORKER_NAME},CLOUDFLARE_ACCOUNT_ID=${_CLOUDFLARE_ACCOUNT_ID}
-      - --set-secrets
-      - CLOUDFLARE_API_TOKEN=${_CLOUDFLARE_API_TOKEN_SECRET_ID}:latest
       # - --wait
       - --quiet
 
-  # admin-proxy Worker はイメージ不要のため Cloud Build から直接 wrangler でデプロイする
   - id: deploy-admin-proxy
-    name: node:24-slim
-    entrypoint: bash
-    waitFor: ["-"]
-    env:
-      - CLOUDFLARE_ACCOUNT_ID=${_CLOUDFLARE_ACCOUNT_ID}
-      - ADMIN_PROXY_WORKER_NAME=${_ADMIN_PROXY_WORKER_NAME}
-      - ADMIN_PROXY_ORIGIN_URL=${_ADMIN_PROXY_ORIGIN_URL}
-    secretEnv:
-      - CLOUDFLARE_API_TOKEN
-      - PROXY_SHARED_SECRET
+    name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    entrypoint: gcloud
+    waitFor:
+      - push-admin-proxy-image
     args:
-      - -c
-      - bash infra/staging/cloudbuild/admin-proxy-deploy "$$(date --iso-8601=seconds)"
-
-availableSecrets:
-  secretManager:
-    - versionName: projects/$PROJECT_ID/secrets/${_CLOUDFLARE_API_TOKEN_SECRET_ID}/versions/latest
-      env: CLOUDFLARE_API_TOKEN
-    - versionName: projects/$PROJECT_ID/secrets/${_ADMIN_PROXY_SHARED_SECRET_ID}/versions/latest
-      env: PROXY_SHARED_SECRET
+      - run
+      - jobs
+      - deploy
+      - stg-admin-proxy-deploy
+      - --image
+      - ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REPOSITORY}/${_ADMIN_PROXY_IMAGE}:$COMMIT_SHA
+      - --region
+      - ${_REGION}
+      - --service-account
+      - ${_JOB_SERVICE_ACCOUNT}
+      - --wait
+      - --quiet
 
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/infra/staging/docker/admin-proxy/Dockerfile
+++ b/infra/staging/docker/admin-proxy/Dockerfile
@@ -1,0 +1,33 @@
+ARG NODE_VERSION
+FROM node:${NODE_VERSION}-slim
+
+ENV TZ=Asia/Tokyo
+ENV PNPM_HOME=/pnpm
+ENV PATH=${PNPM_HOME}:${PATH}
+
+WORKDIR /app
+
+RUN apt-get update \
+  && apt-get install -y \
+    ca-certificates \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY infra/staging/docker/admin-proxy/admin-proxy-deploy /usr/local/bin/admin-proxy-deploy
+COPY mise.toml ./
+
+RUN corepack enable \
+  && corepack prepare "pnpm@$(sed -n 's/^pnpm = "\(.*\)"$/\1/p' mise.toml)" --activate \
+  && chmod +x /usr/local/bin/admin-proxy-deploy
+
+WORKDIR /app/src
+
+COPY src/package.json src/pnpm-lock.yaml src/pnpm-workspace.yaml ./
+COPY src/admin-proxy/package.json admin-proxy/package.json
+
+RUN pnpm install --frozen-lockfile --filter admin-proxy --prod \
+  && rm -rf /pnpm/store
+
+COPY src/admin-proxy admin-proxy
+
+ENTRYPOINT ["admin-proxy-deploy"]

--- a/infra/staging/docker/admin-proxy/admin-proxy-deploy
+++ b/infra/staging/docker/admin-proxy/admin-proxy-deploy
@@ -7,16 +7,7 @@ set -euo pipefail
 : "${ADMIN_PROXY_ORIGIN_URL:?}"
 : "${PROXY_SHARED_SECRET:?}"
 
-DEPLOY_DATE="${1:?usage: admin-proxy-deploy <deploy-date>}"
-
-corepack enable
-corepack prepare "pnpm@$(sed -n 's/^pnpm = "\(.*\)"$/\1/p' mise.toml)" --activate
-
-cd src
-
-pnpm install --frozen-lockfile --filter admin-proxy --prod
-
-DEPLOY_MESSAGE="production admin-proxy deploy ${DEPLOY_DATE}"
+DEPLOY_MESSAGE="staging admin-proxy deploy $(date --iso-8601=seconds)"
 SECRETS_FILE="$(mktemp --suffix=.json)"
 trap 'rm -f "${SECRETS_FILE}"' EXIT
 
@@ -32,5 +23,5 @@ pnpm --filter admin-proxy run deploy \
   --name "${ADMIN_PROXY_WORKER_NAME}" \
   --var "ORIGIN_URL:${ADMIN_PROXY_ORIGIN_URL}" \
   --secrets-file "${SECRETS_FILE}" \
-  --compatibility-date "${DEPLOY_DATE%%T*}" \
+  --compatibility-date "$(date -u '+%Y-%m-%d')" \
   --message "${DEPLOY_MESSAGE}"

--- a/infra/staging/docker/viewer/viewer-deploy
+++ b/infra/staging/docker/viewer/viewer-deploy
@@ -13,5 +13,5 @@ DEPLOY_MESSAGE="staging viewer deploy $(date --iso-8601=seconds)"
 
 pnpm --filter viewer run deploy \
   --name "${CLOUDFLARE_WORKER_NAME}" \
-  --compatibility-date "$(date '+%Y-%m-%d')" \
+  --compatibility-date "$(date -u '+%Y-%m-%d')" \
   --message "${DEPLOY_MESSAGE}"


### PR DESCRIPTION
## 概要

admin-proxy の Cloudflare Worker デプロイを viewer-deploy と同じ Cloud Run Job イメージ方式に移し、Cloud Build の substitutions / availableSecrets 依存を減らす。

## やったこと

- 環境別の `docker/admin-proxy` (Dockerfile + entrypoint) を追加し、`cloudbuild/admin-proxy-deploy` を削除した
- `ci.yaml` で admin-proxy の build / push / Cloud Run Job deploy に切り替え、`availableSecrets` を削除した
- `gcloud run jobs deploy --wait` で image 差し替えと Job 実行完了まで待つようにした
- Admin の `PUBLIC_APP_URL` は Dockerfile に書かず、Cloud Build substitution 経由の build arg で渡すようにした
- README を上記方針に合わせて更新した

## 関連

- 特になし