### PR TITLE
MoonBit native 成果物パスの Dockerfile 参照を修正する

### DIFF
--- a/infra/development/docker/discord-notifier/Dockerfile
+++ b/infra/development/docker/discord-notifier/Dockerfile
@@ -43,7 +43,7 @@ RUN apt-get update \
   && useradd --system --gid app --home-dir /home/app --create-home \
     --shell /usr/sbin/nologin app
 
-COPY --from=builder /workspace/discord-notifier/_build/native/release/build/cmd/main/main.exe /usr/local/bin/discord-notifier
+COPY --from=builder /workspace/discord-notifier/_build/native/release/build/isekai-observatory/discord-notifier/cmd/main/main.exe /usr/local/bin/discord-notifier
 
 USER app
 

--- a/infra/development/docker/viewer/Dockerfile
+++ b/infra/development/docker/viewer/Dockerfile
@@ -44,7 +44,7 @@ RUN apt-get update \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
-COPY --from=notify-publish-builder /workspace/notify-publish/_build/native/release/build/cmd/main/main.exe \
+COPY --from=notify-publish-builder /workspace/notify-publish/_build/native/release/build/isekai-observatory/notify-publish/cmd/main/main.exe \
   /usr/local/bin/notify-publish
 COPY infra/development/docker/viewer/viewer-deploy /usr/local/bin/viewer-deploy
 COPY mise.toml ./

--- a/infra/production/docker/discord-notifier/Dockerfile
+++ b/infra/production/docker/discord-notifier/Dockerfile
@@ -43,7 +43,7 @@ RUN apt-get update \
   && useradd --system --gid app --home-dir /home/app --create-home \
     --shell /usr/sbin/nologin app
 
-COPY --from=builder /workspace/discord-notifier/_build/native/release/build/cmd/main/main.exe /usr/local/bin/discord-notifier
+COPY --from=builder /workspace/discord-notifier/_build/native/release/build/isekai-observatory/discord-notifier/cmd/main/main.exe /usr/local/bin/discord-notifier
 
 USER app
 

--- a/infra/production/docker/viewer/Dockerfile
+++ b/infra/production/docker/viewer/Dockerfile
@@ -44,7 +44,7 @@ RUN apt-get update \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
-COPY --from=notify-publish-builder /workspace/notify-publish/_build/native/release/build/cmd/main/main.exe \
+COPY --from=notify-publish-builder /workspace/notify-publish/_build/native/release/build/isekai-observatory/notify-publish/cmd/main/main.exe \
   /usr/local/bin/notify-publish
 COPY infra/production/docker/viewer/viewer-deploy /usr/local/bin/viewer-deploy
 COPY mise.toml ./

--- a/infra/staging/docker/discord-notifier/Dockerfile
+++ b/infra/staging/docker/discord-notifier/Dockerfile
@@ -43,7 +43,7 @@ RUN apt-get update \
   && useradd --system --gid app --home-dir /home/app --create-home \
     --shell /usr/sbin/nologin app
 
-COPY --from=builder /workspace/discord-notifier/_build/native/release/build/cmd/main/main.exe /usr/local/bin/discord-notifier
+COPY --from=builder /workspace/discord-notifier/_build/native/release/build/isekai-observatory/discord-notifier/cmd/main/main.exe /usr/local/bin/discord-notifier
 
 USER app
 

--- a/infra/staging/docker/viewer/Dockerfile
+++ b/infra/staging/docker/viewer/Dockerfile
@@ -44,7 +44,7 @@ RUN apt-get update \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
-COPY --from=notify-publish-builder /workspace/notify-publish/_build/native/release/build/cmd/main/main.exe \
+COPY --from=notify-publish-builder /workspace/notify-publish/_build/native/release/build/isekai-observatory/notify-publish/cmd/main/main.exe \
   /usr/local/bin/notify-publish
 COPY infra/staging/docker/viewer/viewer-deploy /usr/local/bin/viewer-deploy
 COPY mise.toml ./


### PR DESCRIPTION
## 概要

MoonBit の native release 成果物パスがモジュール名付きに変わったことで、Cloud Build の `COPY` が失敗していたのを直す

## やったこと

- `discord-notifier` の Dockerfile (development / staging / production) で `main.exe` の COPY 先を `isekai-observatory/discord-notifier/...` に更新
- viewer イメージ内の `notify-publish` も同様に `isekai-observatory/notify-publish/...` へ更新

## やってないこと

- MoonBit のビルド設定やモジュール名そのものの変更

## 関連

- 特になし

Made with [Cursor](https://cursor.com)