### PR TITLE
環境別 Docker build と QA の path トリガーを整備する

### DIFF
--- a/.github/workflows/admin-proxy-qa.yaml
+++ b/.github/workflows/admin-proxy-qa.yaml
@@ -1,0 +1,67 @@
+name: Admin Proxy QA
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  pull_request:
+    # main, stg 向け PR は release-qa 経由で必ず全実行する
+    branches-ignore:
+      - main
+      - stg
+    paths:
+      - "src/admin-proxy/**"
+      - "src/package.json"
+      - "src/pnpm-lock.yaml"
+      - "src/pnpm-workspace.yaml"
+      - "src/biome.json"
+      - "mise.toml"
+      - "mise.ci.toml"
+      - ".github/workflows/admin-proxy-qa.yaml"
+      - ".github/actions/setup-mise/**"
+  push:
+    branches:
+      - dev
+    paths:
+      - "src/admin-proxy/**"
+      - "src/package.json"
+      - "src/pnpm-lock.yaml"
+      - "src/pnpm-workspace.yaml"
+      - "src/biome.json"
+      - "mise.toml"
+      - "mise.ci.toml"
+      - ".github/workflows/admin-proxy-qa.yaml"
+      - ".github/actions/setup-mise/**"
+  workflow_call:
+
+env:
+  MISE_ENV: ci
+
+jobs:
+  check:
+    name: Check
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Setup mise
+        uses: ./.github/actions/setup-mise
+
+      - name: Cache node modules
+        id: cache-node-modules
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            src/node_modules
+            src/admin-proxy/node_modules
+          key: admin-proxy-node-modules-${{ hashFiles('**/pnpm-lock.yaml') }}
+
+      - name: Install packages
+        run: mise run pnpm:install
+
+      - name: Run check
+        run: mise run admin-proxy:check

--- a/.github/workflows/admin-qa.yaml
+++ b/.github/workflows/admin-qa.yaml
@@ -18,7 +18,7 @@ on:
       - "mise.toml"
       - "mise.ci.toml"
       - ".github/workflows/admin-qa.yaml"
-      - ".github/actions/**"
+      - ".github/actions/setup-mise/**"
   push:
     branches:
       - dev
@@ -32,7 +32,7 @@ on:
       - "mise.toml"
       - "mise.ci.toml"
       - ".github/workflows/admin-qa.yaml"
-      - ".github/actions/**"
+      - ".github/actions/setup-mise/**"
   workflow_call:
 
 env:

--- a/.github/workflows/contracts-qa.yaml
+++ b/.github/workflows/contracts-qa.yaml
@@ -11,10 +11,11 @@ on:
       - "src/package.json"
       - "src/pnpm-lock.yaml"
       - "src/pnpm-workspace.yaml"
+      - "src/biome.json"
       - "mise.toml"
       - "mise.ci.toml"
       - ".github/workflows/contracts-qa.yaml"
-      - ".github/actions/**"
+      - ".github/actions/setup-mise/**"
   push:
     branches:
       - dev
@@ -23,10 +24,11 @@ on:
       - "src/package.json"
       - "src/pnpm-lock.yaml"
       - "src/pnpm-workspace.yaml"
+      - "src/biome.json"
       - "mise.toml"
       - "mise.ci.toml"
       - ".github/workflows/contracts-qa.yaml"
-      - ".github/actions/**"
+      - ".github/actions/setup-mise/**"
   workflow_call:
 
 jobs:

--- a/.github/workflows/discord-notifier-qa.yaml
+++ b/.github/workflows/discord-notifier-qa.yaml
@@ -10,6 +10,7 @@ on:
       - stg
     paths:
       - "src/discord-notifier/**"
+      - "src/notify-contract/**"
       - "mise.toml"
       - "mise.ci.toml"
       - ".github/workflows/discord-notifier-qa.yaml"
@@ -20,6 +21,7 @@ on:
       - dev
     paths:
       - "src/discord-notifier/**"
+      - "src/notify-contract/**"
       - "mise.toml"
       - "mise.ci.toml"
       - ".github/workflows/discord-notifier-qa.yaml"

--- a/.github/workflows/infra-docker-qa.yaml
+++ b/.github/workflows/infra-docker-qa.yaml
@@ -1,0 +1,120 @@
+name: Infra Docker QA
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  pull_request:
+    # main, stg 向け PR は release-qa 経由で必ず全実行する
+    branches-ignore:
+      - main
+      - stg
+    paths:
+      - "infra/development/**"
+      - "infra/staging/**"
+      - "infra/production/**"
+      - "tools/read-mise-value.sh"
+      - ".github/workflows/infra-docker-qa.yaml"
+  push:
+    branches:
+      - dev
+    paths:
+      - "infra/development/**"
+      - "infra/staging/**"
+      - "infra/production/**"
+      - "tools/read-mise-value.sh"
+      - ".github/workflows/infra-docker-qa.yaml"
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  docker-build:
+    name: ${{ matrix.env }} / ${{ matrix.image }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        env:
+          - development
+          - staging
+          - production
+        image:
+          - api
+          - cli
+          - db-migrate
+          - discord-notifier
+          - admin
+          - viewer
+          - admin-proxy
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Build image
+        env:
+          ENV_NAME: ${{ matrix.env }}
+          IMAGE: ${{ matrix.image }}
+        run: |
+          set -euo pipefail
+
+          dockerfile="infra/${ENV_NAME}/docker/${IMAGE}/Dockerfile"
+          tag="infra-qa-${ENV_NAME}-${IMAGE}:local"
+
+          case "${IMAGE}" in
+            api|cli)
+              docker build \
+                -f "${dockerfile}" \
+                -t "${tag}" \
+                .
+              ;;
+            db-migrate)
+              MISE_VERSION="$(./tools/read-mise-value.sh mise_version)"
+              docker build \
+                -f "${dockerfile}" \
+                -t "${tag}" \
+                --build-arg "MISE_VERSION=${MISE_VERSION}" \
+                .
+              ;;
+            discord-notifier)
+              MOONBIT_VERSION="$(./tools/read-mise-value.sh moonbit_version)"
+              docker build \
+                -f "${dockerfile}" \
+                -t "${tag}" \
+                --build-arg "MOONBIT_VERSION=${MOONBIT_VERSION}" \
+                .
+              ;;
+            admin)
+              BUN_VERSION="$(./tools/read-mise-value.sh bun)"
+              docker build \
+                -f "${dockerfile}" \
+                -t "${tag}" \
+                --build-arg "BUN_VERSION=${BUN_VERSION}" \
+                --build-arg "PUBLIC_APP_URL=https://example.invalid" \
+                .
+              ;;
+            viewer)
+              NODE_VERSION="$(./tools/read-mise-value.sh node)"
+              MOONBIT_VERSION="$(./tools/read-mise-value.sh moonbit_version)"
+              docker build \
+                -f "${dockerfile}" \
+                -t "${tag}" \
+                --build-arg "NODE_VERSION=${NODE_VERSION}" \
+                --build-arg "MOONBIT_VERSION=${MOONBIT_VERSION}" \
+                .
+              ;;
+            admin-proxy)
+              NODE_VERSION="$(./tools/read-mise-value.sh node)"
+              docker build \
+                -f "${dockerfile}" \
+                -t "${tag}" \
+                --build-arg "NODE_VERSION=${NODE_VERSION}" \
+                .
+              ;;
+            *)
+              echo "unknown image: ${IMAGE}" >&2
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/notify-contract-qa.yaml
+++ b/.github/workflows/notify-contract-qa.yaml
@@ -1,4 +1,4 @@
-name: Notify Publish QA
+name: Notify Contract QA
 
 on:
   schedule:
@@ -9,22 +9,20 @@ on:
       - main
       - stg
     paths:
-      - "src/notify-publish/**"
       - "src/notify-contract/**"
       - "mise.toml"
       - "mise.ci.toml"
-      - ".github/workflows/notify-publish-qa.yaml"
+      - ".github/workflows/notify-contract-qa.yaml"
       - ".github/actions/setup-mise/**"
       - ".github/actions/setup-moonbit/**"
   push:
     branches:
       - dev
     paths:
-      - "src/notify-publish/**"
       - "src/notify-contract/**"
       - "mise.toml"
       - "mise.ci.toml"
-      - ".github/workflows/notify-publish-qa.yaml"
+      - ".github/workflows/notify-contract-qa.yaml"
       - ".github/actions/setup-mise/**"
       - ".github/actions/setup-moonbit/**"
   workflow_call:
@@ -51,4 +49,4 @@ jobs:
         uses: ./.github/actions/setup-moonbit
 
       - name: Run check / test
-        run: mise run notify-publish:check
+        run: mise run notify-contract:check

--- a/.github/workflows/release-qa.yaml
+++ b/.github/workflows/release-qa.yaml
@@ -39,3 +39,15 @@ jobs:
   notify-publish:
     name: Notify Publish QA
     uses: ./.github/workflows/notify-publish-qa.yaml
+
+  notify-contract:
+    name: Notify Contract QA
+    uses: ./.github/workflows/notify-contract-qa.yaml
+
+  admin-proxy:
+    name: Admin Proxy QA
+    uses: ./.github/workflows/admin-proxy-qa.yaml
+
+  infra-docker:
+    name: Infra Docker QA
+    uses: ./.github/workflows/infra-docker-qa.yaml

--- a/.github/workflows/server-qa.yaml
+++ b/.github/workflows/server-qa.yaml
@@ -11,24 +11,24 @@ on:
     paths:
       - "src/server/**"
       - "src/contracts/**"
-      - "infra/**"
+      - "infra/local/**"
       - "compose.yaml"
       - "mise.toml"
       - "mise.ci.toml"
       - ".github/workflows/server-qa.yaml"
-      - ".github/actions/**"
+      - ".github/actions/setup-mise/**"
   push:
     branches:
       - dev
     paths:
       - "src/server/**"
       - "src/contracts/**"
-      - "infra/**"
+      - "infra/local/**"
       - "compose.yaml"
       - "mise.toml"
       - "mise.ci.toml"
       - ".github/workflows/server-qa.yaml"
-      - ".github/actions/**"
+      - ".github/actions/setup-mise/**"
   workflow_call:
 
 env:

--- a/.github/workflows/viewer-qa.yaml
+++ b/.github/workflows/viewer-qa.yaml
@@ -18,7 +18,7 @@ on:
       - "mise.toml"
       - "mise.ci.toml"
       - ".github/workflows/viewer-qa.yaml"
-      - ".github/actions/**"
+      - ".github/actions/setup-mise/**"
   push:
     branches:
       - dev
@@ -32,7 +32,7 @@ on:
       - "mise.toml"
       - "mise.ci.toml"
       - ".github/workflows/viewer-qa.yaml"
-      - ".github/actions/**"
+      - ".github/actions/setup-mise/**"
   workflow_call:
 
 env:

--- a/mise.toml
+++ b/mise.toml
@@ -490,11 +490,12 @@ dir = "src/discord-notifier"
 run = "moon build --target native --release"
 
 [tasks."discord-notifier:check"]
-description = "discord-notifier の check / test を実行する"
+description = "discord-notifier の check / test / native build を実行する"
 dir = "src/discord-notifier"
 run = [
   "moon check",
   "moon test",
+  "moon build --target native --release",
 ]
 
 # -- Notify Publish --
@@ -510,9 +511,37 @@ dir = "src/notify-publish"
 run = "moon build --target native --release"
 
 [tasks."notify-publish:check"]
-description = "notify-publish の check / test を実行する"
+description = "notify-publish の check / test / native build を実行する"
 dir = "src/notify-publish"
 run = [
   "moon check",
   "moon test",
+  "moon build --target native --release",
 ]
+
+# -- Admin Proxy --
+
+[tasks."admin-proxy:format"]
+description = "admin-proxy の formatter を実行し、フォーマットを自動修正する"
+dir = "src/admin-proxy"
+run = "bun run format"
+
+[tasks."admin-proxy:format:check"]
+description = "admin-proxy の formatter をチェックする"
+dir = "src/admin-proxy"
+run = "bun run format:check"
+
+[tasks."admin-proxy:lint"]
+description = "admin-proxy の linter を実行する"
+dir = "src/admin-proxy"
+run = "bun run lint:check"
+
+[tasks."admin-proxy:typecheck"]
+description = "admin-proxy の TypeScript をチェックする"
+dir = "src/admin-proxy"
+run = "bun run typecheck"
+
+[tasks."admin-proxy:check"]
+description = "admin-proxy の format / lint / typecheck を実行する"
+depends = ["admin-proxy:format:check", "admin-proxy:lint", "admin-proxy:typecheck"]
+


### PR DESCRIPTION
## 概要

環境別 Dockerfile の壊れを PR 時点で検知できるようにし、足りない QA を足しつつ過剰な path トリガーを整理する

## やったこと

- `infra-docker-qa` を追加し、development / staging / production の 7 イメージを matrix で `docker build`
- `release-qa` から infra-docker / notify-contract / admin-proxy を呼び出し
- `notify-contract-qa` と `admin-proxy-qa` を追加
- `notify-contract` 変更で discord-notifier / notify-publish QA も起動
- MoonBit の `discord-notifier:check` / `notify-publish:check` に native release build を追加
- `server-qa` の paths を `infra/local/**` に絞り、他 QA の `.github/actions/**` を `setup-mise/**` に絞る
- `infra-docker-qa` から無関係な `mise.toml` トリガーを外す
- `contracts-qa` に `src/biome.json` を追加

## やってないこと

- 変更された env / image だけに絞る path filter
- src 変更だけで infra Docker QA を起動すること

## 関連

- 特になし

Made with [Cursor](https://cursor.com)