### PR TITLE
通知送信の有効/無効を NOTIFICATION_ENABLED で切り替える

### DIFF
--- a/src/server/.env.example
+++ b/src/server/.env.example
@@ -87,4 +87,5 @@ AUTH_PASSKEY_ORIGIN=https://local.admin.isekaijoucho.fan
 
 YOUTUBE_API_KEY=
 
+NOTIFICATION_ENABLED=false
 NOTIFICATION_TOPIC=

--- a/src/server/app/Providers/Domain/SupportServiceProvider.php
+++ b/src/server/app/Providers/Domain/SupportServiceProvider.php
@@ -8,7 +8,6 @@ use CuyZ\Valinor\MapperBuilder;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
 use Override;
-use Support\App\Environment;
 use Support\Contracts\ClockInterface;
 use Support\Contracts\MapperInterface;
 use Support\Contracts\TransactionInterface;
@@ -55,9 +54,9 @@ class SupportServiceProvider extends ServiceProvider
         );
         $this->app->singleton(
             NotificationDriverInterface::class,
-            static fn (Application $app) => in_array(Environment::getEnv(), [Environment::Local, Environment::Testing], true)
-                ? $app->make(NopNotificationPubSubDriver::class)
-                : $app->make(NotificationPubSubDriver::class),
+            static fn (Application $app) => config()->boolean('gc.pubsub.notification.enabled')
+                ? $app->make(NotificationPubSubDriver::class)
+                : $app->make(NopNotificationPubSubDriver::class),
         );
     }
 }

--- a/src/server/config/gc.php
+++ b/src/server/config/gc.php
@@ -7,6 +7,7 @@ return [
 
     'pubsub' => [
         'notification' => [
+            'enabled' => env('NOTIFICATION_ENABLED', false),
             'topic' => env('NOTIFICATION_TOPIC'),
         ],
     ],


### PR DESCRIPTION
## 概要

通知ドライバーの切替を環境名判定から外し、`NOTIFICATION_ENABLED` フラグで制御できるようにする

## やったこと

- `gc.pubsub.notification.enabled` を追加し、`NOTIFICATION_ENABLED` から読む
- 有効時は `NotificationPubSubDriver`、無効時は `NopNotificationPubSubDriver` を使う
- `.env.example` に `NOTIFICATION_ENABLED=false` を追加する

## やってないこと

- 本番 / ステージング環境への実値設定
- 通知送信まわりの追加テスト

## 関連

- 特になし

Made with [Cursor](https://cursor.com)