### PR TITLE
管理画面の一覧とリリース編集をスマホ幅に対応する

### DIFF
--- a/src/admin/src/components/Sidebar.tsx
+++ b/src/admin/src/components/Sidebar.tsx
@@ -136,7 +136,7 @@ const navSections: NavSection[] = [
     title: '楽曲',
     items: [
       { href: '/songs', label: '楽曲', icon: MusicNoteIcon },
-      { href: '/release-groups', label: 'リリース', icon: DiscIcon },
+      { href: '/release-groups', label: 'リリースグループ', icon: DiscIcon },
       { href: '/media', label: 'メディア', icon: PlayIcon },
       { href: '/song-types', label: '楽曲種別', icon: TagIcon },
       { href: '/song-tags', label: '楽曲タグ', icon: SwatchIcon },

--- a/src/admin/src/components/media/SearchList.tsx
+++ b/src/admin/src/components/media/SearchList.tsx
@@ -27,6 +27,15 @@ const DEFAULT_PARAMS = {
   perPage: 25 as PerPage,
 };
 
+/** 一覧では URL 全体は幅に見合わないため、投稿先が分かるホスト名だけを出す(解析できない値は素のまま表示する) */
+const toHostLabel = (url: string): string => {
+  try {
+    return new URL(url).hostname.replace(/^www\./, '');
+  } catch {
+    return url;
+  }
+};
+
 const getInitialParams = () => {
   const params = new URLSearchParams(window.location.search);
   const perPageRaw = Number(params.get('per_page'));
@@ -247,20 +256,19 @@ export const SearchList = () => {
               <th>公開日</th>
               <th>種別</th>
               <th>表示設定</th>
-              <th>URL</th>
-              <th>操作</th>
+              <th>リンク</th>
             </tr>
           </thead>
           <tbody>
             <Switch>
               <Match when={data.loading}>
-                <ListState state="loading" colSpan={6} />
+                <ListState state="loading" colSpan={5} />
               </Match>
               <Match when={fetchError()}>
-                {message => <ListState state="error" colSpan={6} message={message()} onRetry={() => refetch()} />}
+                {message => <ListState state="error" colSpan={5} message={message()} onRetry={() => refetch()} />}
               </Match>
               <Match when={data() && data()!.media.length === 0}>
-                <ListState state="empty" colSpan={6} message="条件に一致するメディアはありません。" />
+                <ListState state="empty" colSpan={5} message="条件に一致するメディアはありません。" />
               </Match>
               <Match when={data()}>
                 {result => (
@@ -268,33 +276,31 @@ export const SearchList = () => {
                     {media => (
                       <tr class="transition-colors hover:bg-primary/30 focus-within:bg-primary/30">
                         <td class="min-w-44 max-w-56">
-                          <p class="truncate">{media.title}</p>
+                          <a
+                            href={`/media/${media.mediaId}?back=${encodeURIComponent(window.location.search)}`}
+                            class="link link-hover block truncate font-medium"
+                          >
+                            {media.title}
+                          </a>
                         </td>
                         <td class="whitespace-nowrap text-sm">{normalizeDateTimeDisplayValue(media.publishedAt)}</td>
-                        <td>{media.type.name}</td>
-                        <td>
+                        <td class="whitespace-nowrap">{media.type.name}</td>
+                        <td class="whitespace-nowrap">
                           <span
                             class={`badge badge-sm ${media.isDisplay ? 'badge-success badge-soft' : 'badge-ghost'}`}
                           >
                             {media.isDisplay ? '表示する' : '表示しない'}
                           </span>
                         </td>
-                        <td class="max-w-xl">
+                        <td class="max-w-40">
                           <a
                             href={media.url}
                             target="_blank"
                             rel="noreferrer"
-                            class="link link-hover break-all text-sm"
+                            title={media.url}
+                            class="link link-hover block truncate whitespace-nowrap text-sm"
                           >
-                            {media.url}
-                          </a>
-                        </td>
-                        <td>
-                          <a
-                            href={`/media/${media.mediaId}?back=${encodeURIComponent(window.location.search)}`}
-                            class="btn btn-ghost btn-xs"
-                          >
-                            編集
+                            {toHostLabel(media.url)}
                           </a>
                         </td>
                       </tr>

--- a/src/admin/src/components/person/SearchList.tsx
+++ b/src/admin/src/components/person/SearchList.tsx
@@ -212,35 +212,33 @@ export const SearchList = () => {
             <tr>
               <th>人物名</th>
               <th>表示順</th>
-              <th>操作</th>
             </tr>
           </thead>
           <tbody>
             <Switch>
               <Match when={data.loading}>
-                <ListState state="loading" colSpan={3} />
+                <ListState state="loading" colSpan={2} />
               </Match>
               <Match when={fetchError()}>
-                {message => <ListState state="error" colSpan={3} message={message()} onRetry={() => refetch()} />}
+                {message => <ListState state="error" colSpan={2} message={message()} onRetry={() => refetch()} />}
               </Match>
               <Match when={data() && data()!.persons.length === 0}>
-                <ListState state="empty" colSpan={3} />
+                <ListState state="empty" colSpan={2} />
               </Match>
               <Match when={data()}>
                 {result => (
                   <For each={result().persons}>
                     {person => (
                       <tr class="transition-colors hover:bg-primary/30 focus-within:bg-primary/30">
-                        <td>{person.name}</td>
-                        <td>{person.orderNo}</td>
                         <td>
                           <a
                             href={`/persons/${person.personId}?back=${encodeURIComponent(window.location.search)}`}
-                            class="btn btn-ghost btn-xs"
+                            class="link link-hover font-medium"
                           >
-                            編集
+                            {person.name}
                           </a>
                         </td>
+                        <td>{person.orderNo}</td>
                       </tr>
                     )}
                   </For>

--- a/src/admin/src/components/release-group/DetailView.tsx
+++ b/src/admin/src/components/release-group/DetailView.tsx
@@ -1,5 +1,10 @@
 import { For, Match, Show, Switch, createResource, createSignal } from 'solid-js';
-import type { ReleaseFormatValue, ReleaseGroupGetResponse, ReleaseGroupTypeValue } from '../../generated';
+import type {
+  ReleaseFormatValue,
+  ReleaseGroupGetResponse,
+  ReleaseGroupReferencedRelease,
+  ReleaseGroupTypeValue,
+} from '../../generated';
 import { client } from '../../utils/client';
 import { createFormErrors } from '../../utils/form-error';
 import { createSubmitting } from '../../utils/use-submitting';
@@ -20,6 +25,45 @@ const RELEASE_FORMAT_LABELS: Record<ReleaseFormatValue, string> = {
   4: 'Blu-ray',
   99: 'その他',
 };
+
+/** 版名は空になりうるため、リンクのラベルとして意味を持つ代替文言を出す */
+const ReleaseNameLink = (props: { release: ReleaseGroupReferencedRelease }) => (
+  <a href={`/releases/${props.release.releaseId}`} class="link link-hover font-medium">
+    <Show when={props.release.name !== ''} fallback={<span class="text-base-content/60">版名なし</span>}>
+      {props.release.name}
+    </Show>
+  </a>
+);
+
+const ReleaseFormatBadges = (props: { release: ReleaseGroupReferencedRelease }) => (
+  <div class="flex flex-wrap gap-1">
+    <Show
+      when={props.release.formatValues.length > 0}
+      fallback={<span class="text-sm text-base-content/60">—</span>}
+    >
+      <For each={props.release.formatValues}>
+        {formatValue => (
+          <span class="badge badge-outline badge-sm">{RELEASE_FORMAT_LABELS[formatValue] ?? '不明'}</span>
+        )}
+      </For>
+    </Show>
+  </div>
+);
+
+const ReleaseDisplayBadge = (props: { release: ReleaseGroupReferencedRelease }) => (
+  <span class={`badge badge-sm ${props.release.isDisplay ? 'badge-success badge-soft' : 'badge-ghost'}`}>
+    {props.release.isDisplay ? '表示する' : '表示しない'}
+  </span>
+);
+
+const CopyReleaseLink = (props: { releaseGroupId: string; releaseId: string }) => (
+  <a
+    href={`/releases/create?releaseGroupId=${props.releaseGroupId}&sourceReleaseId=${props.releaseId}`}
+    class="btn btn-ghost btn-xs whitespace-nowrap"
+  >
+    コピーして追加
+  </a>
+);
 
 interface DetailViewProps {
   releaseGroupId: string;
@@ -300,11 +344,33 @@ const ReleaseGroupForm = (props: ReleaseGroupFormProps) => {
             when={props.data.releases.length > 0}
             fallback={<p class="text-sm text-base-content/60">リリースはまだ登録されていません。</p>}
           >
-            <div class="overflow-x-auto rounded-box border border-base-300 bg-base-100">
+            <ul class="flex flex-col gap-2 md:hidden">
+              <For each={props.data.releases}>
+                {release => (
+                  <li
+                    class="rounded-box border-y border-r border-l-4 border-base-300 bg-base-100 p-3"
+                    style={{ 'border-left-color': release.color }}
+                  >
+                    <ReleaseNameLink release={release} />
+                    <div class="mt-1 flex flex-wrap gap-x-3 text-sm text-base-content/60">
+                      <span>{normalizeDateValue(release.releasedOn)}</span>
+                      <span>表示順 {release.orderNo}</span>
+                    </div>
+                    <div class="mt-2 flex flex-wrap gap-1">
+                      <ReleaseFormatBadges release={release} />
+                      <ReleaseDisplayBadge release={release} />
+                    </div>
+                    <div class="mt-2 flex justify-end">
+                      <CopyReleaseLink releaseGroupId={releaseGroupId} releaseId={release.releaseId} />
+                    </div>
+                  </li>
+                )}
+              </For>
+            </ul>
+            <div class="hidden overflow-x-auto rounded-box border border-base-300 bg-base-100 md:block">
               <table class="table table-sm">
                 <thead>
                   <tr>
-                    <th>代表色</th>
                     <th>版名</th>
                     <th>発売日</th>
                     <th>表示順</th>
@@ -317,55 +383,24 @@ const ReleaseGroupForm = (props: ReleaseGroupFormProps) => {
                   <For each={props.data.releases}>
                     {release => (
                       <tr>
-                        <td>
-                          <div
-                            class="size-12 rounded-box border border-base-300"
-                            style={{ 'background-color': release.color }}
-                            title={release.color}
-                            aria-label={`${release.name !== '' ? release.name : '版名なし'} の代表色 ${release.color}`}
-                          />
-                        </td>
-                        <td class="min-w-40 font-medium">
-                          <Show when={release.name !== ''} fallback={<span class="text-base-content/60">—</span>}>
-                            {release.name}
-                          </Show>
+                        <td
+                          class="min-w-40 border-l-4 font-medium"
+                          style={{ 'border-left-color': release.color }}
+                          title={`代表色 ${release.color}`}
+                        >
+                          <ReleaseNameLink release={release} />
                         </td>
                         <td class="whitespace-nowrap text-sm">{normalizeDateValue(release.releasedOn)}</td>
                         <td class="text-sm">{release.orderNo}</td>
                         <td>
-                          <div class="flex flex-wrap gap-1">
-                            <Show
-                              when={release.formatValues.length > 0}
-                              fallback={<span class="text-sm text-base-content/60">—</span>}
-                            >
-                              <For each={release.formatValues}>
-                                {formatValue => (
-                                  <span class="badge badge-outline badge-sm">
-                                    {RELEASE_FORMAT_LABELS[formatValue] ?? '不明'}
-                                  </span>
-                                )}
-                              </For>
-                            </Show>
-                          </div>
+                          <ReleaseFormatBadges release={release} />
                         </td>
-                        <td>
-                          <span
-                            class={`badge badge-sm ${release.isDisplay ? 'badge-success badge-soft' : 'badge-ghost'}`}
-                          >
-                            {release.isDisplay ? '表示する' : '表示しない'}
-                          </span>
+                        <td class="whitespace-nowrap">
+                          <ReleaseDisplayBadge release={release} />
                         </td>
                         <td class="text-right">
-                          <div class="flex justify-end gap-2">
-                            <a href={`/releases/${release.releaseId}`} class="btn btn-ghost btn-xs">
-                              編集
-                            </a>
-                            <a
-                              href={`/releases/create?releaseGroupId=${releaseGroupId}&sourceReleaseId=${release.releaseId}`}
-                              class="btn btn-ghost btn-xs"
-                            >
-                              コピーして追加
-                            </a>
+                          <div class="flex justify-end">
+                            <CopyReleaseLink releaseGroupId={releaseGroupId} releaseId={release.releaseId} />
                           </div>
                         </td>
                       </tr>

--- a/src/admin/src/components/release-group/SearchList.tsx
+++ b/src/admin/src/components/release-group/SearchList.tsx
@@ -268,27 +268,30 @@ export const SearchList = () => {
               <th>種別</th>
               <th>初リリース日</th>
               <th>表示設定</th>
-              <th>操作</th>
             </tr>
           </thead>
           <tbody>
             <Switch>
               <Match when={data.loading}>
-                <ListState state="loading" colSpan={5} />
+                <ListState state="loading" colSpan={4} />
               </Match>
               <Match when={fetchError()}>
-                {message => <ListState state="error" colSpan={5} message={message()} onRetry={() => refetch()} />}
+                {message => <ListState state="error" colSpan={4} message={message()} onRetry={() => refetch()} />}
               </Match>
               <Match when={data() && data()!.releaseGroups.length === 0}>
-                <ListState state="empty" colSpan={5} message="条件に一致するリリースグループはありません。" />
+                <ListState state="empty" colSpan={4} message="条件に一致するリリースグループはありません。" />
               </Match>
               <Match when={data()}>
                 {result => (
                   <For each={result().releaseGroups}>
                     {releaseGroup => (
-                      <tr>
-                        <td class="min-w-56 font-medium">{releaseGroup.title}</td>
-                        <td>
+                      <tr class="transition-colors hover:bg-primary/30 focus-within:bg-primary/30">
+                        <td class="min-w-56">
+                          <a href={buildDetailHref(releaseGroup.releaseGroupId)} class="link link-hover font-medium">
+                            {releaseGroup.title}
+                          </a>
+                        </td>
+                        <td class="whitespace-nowrap">
                           {RELEASE_GROUP_TYPE_OPTIONS.find(
                             option => option.value === String(releaseGroup.typeValue),
                           )?.label ?? '不明'}
@@ -298,7 +301,7 @@ export const SearchList = () => {
                             ? normalizeDateDisplayValue(releaseGroup.firstReleasedOn)
                             : '—'}
                         </td>
-                        <td>
+                        <td class="whitespace-nowrap">
                           <span
                             class={`badge badge-sm ${
                               releaseGroup.isDisplay ? 'badge-success badge-soft' : 'badge-ghost'
@@ -306,11 +309,6 @@ export const SearchList = () => {
                           >
                             {releaseGroup.isDisplay ? '表示する' : '表示しない'}
                           </span>
-                        </td>
-                        <td>
-                          <a href={buildDetailHref(releaseGroup.releaseGroupId)} class="btn btn-ghost btn-xs">
-                            編集
-                          </a>
                         </td>
                       </tr>
                     )}

--- a/src/admin/src/components/release/CreateForm.tsx
+++ b/src/admin/src/components/release/CreateForm.tsx
@@ -126,7 +126,7 @@ export const CreateForm = () => {
         <div class="flex flex-col items-start gap-3">
           <p class="text-error">リリースグループが指定されていません。グループ詳細から追加してください。</p>
           <a href="/release-groups" class="btn btn-outline btn-sm">
-            リリース一覧へ
+            リリースグループ一覧へ
           </a>
         </div>
       )}

--- a/src/admin/src/components/release/MediaEditor.tsx
+++ b/src/admin/src/components/release/MediaEditor.tsx
@@ -46,6 +46,55 @@ export const toMediaPayload = (media: MediumForm[]) =>
     })),
   }));
 
+const TrackSongLabel = (props: { track: TrackForm }) => (
+  <Show when={props.track.songId !== null} fallback={<span class="badge badge-ghost badge-sm">対象外</span>}>
+    {props.track.songTitle}
+  </Show>
+);
+
+interface TrackActionsProps {
+  label: string;
+  songId: string | null;
+  canMoveUp: boolean;
+  canMoveDown: boolean;
+  onMoveUp: () => void;
+  onMoveDown: () => void;
+  onRemove: () => void;
+}
+
+const TrackActions = (props: TrackActionsProps) => (
+  <div class="flex flex-wrap justify-end gap-2">
+    <button
+      type="button"
+      class="btn btn-ghost btn-xs"
+      aria-label={`${props.label}を上へ移動`}
+      disabled={!props.canMoveUp}
+      onClick={props.onMoveUp}
+    >
+      ↑
+    </button>
+    <button
+      type="button"
+      class="btn btn-ghost btn-xs"
+      aria-label={`${props.label}を下へ移動`}
+      disabled={!props.canMoveDown}
+      onClick={props.onMoveDown}
+    >
+      ↓
+    </button>
+    <Show when={props.songId}>
+      {songId => (
+        <a href={`/songs/${songId()}`} class="btn btn-ghost btn-xs">
+          楽曲を見る
+        </a>
+      )}
+    </Show>
+    <button type="button" class="btn btn-outline btn-error btn-xs" onClick={props.onRemove}>
+      削除
+    </button>
+  </div>
+);
+
 interface MediaEditorProps {
   media: MediumForm[];
   onChange: (updater: (prev: MediumForm[]) => MediumForm[]) => void;
@@ -194,7 +243,7 @@ export const MediaEditor = (props: MediaEditorProps) => {
                 }}
               >
                 <div class="flex flex-wrap items-end justify-between gap-4">
-                  <div class="flex items-end gap-4">
+                  <div class="flex flex-wrap items-end gap-4">
                     <button
                       {...mediaSortable.dragHandleProps('release-media', mediumIndex, `媒体${mediumIndex + 1}`)}
                       class="btn btn-ghost btn-sm mb-1 cursor-grab active:cursor-grabbing"
@@ -247,7 +296,52 @@ export const MediaEditor = (props: MediaEditorProps) => {
                     when={medium().tracks.length > 0}
                     fallback={<p class="text-sm text-base-content/60">収録楽曲はまだ登録されていません。</p>}
                   >
-                    <div class="overflow-x-auto rounded-box border border-base-300">
+                    {/* For はオブジェクト同一性でキーするため、入力のたびに行が再生成されて IME が中断される。Index で DOM を保つ */}
+                    <ul class="rounded-box border border-base-300 md:hidden">
+                      <Index each={medium().tracks}>
+                        {(track, trackIndex) => (
+                          <li
+                            {...trackSortable.dropTargetProps(mediumIndex, trackIndex)}
+                            class="border-b border-base-300 p-3 last:border-b-0"
+                            classList={{
+                              'opacity-50': trackSortable.isDragging(mediumIndex, trackIndex),
+                              'bg-primary/5': trackSortable.isDropTarget(mediumIndex, trackIndex),
+                            }}
+                          >
+                            <div class="flex items-center gap-2">
+                              <button
+                                {...trackSortable.dragHandleProps(mediumIndex, trackIndex, `曲順${trackIndex + 1}`)}
+                              >
+                                ⠿
+                              </button>
+                              <span class="text-sm">{trackIndex + 1}</span>
+                              <span class="min-w-0 flex-1 truncate text-sm">
+                                <TrackSongLabel track={track()} />
+                              </span>
+                            </div>
+                            <input
+                              type="text"
+                              class="input input-bordered input-sm mt-2 w-full"
+                              value={track().title}
+                              onInput={e => setTrackTitle(mediumIndex, trackIndex, e.currentTarget.value)}
+                              placeholder={track().songId !== null ? track().songTitle ?? '' : 'トラック名を入力'}
+                            />
+                            <div class="mt-2">
+                              <TrackActions
+                                label={`曲順${trackIndex + 1}`}
+                                songId={track().songId}
+                                canMoveUp={trackIndex > 0}
+                                canMoveDown={trackIndex < medium().tracks.length - 1}
+                                onMoveUp={() => reorderTracks(mediumIndex, trackIndex, trackIndex - 1)}
+                                onMoveDown={() => reorderTracks(mediumIndex, trackIndex, trackIndex + 1)}
+                                onRemove={() => removeTrack(mediumIndex, trackIndex)}
+                              />
+                            </div>
+                          </li>
+                        )}
+                      </Index>
+                    </ul>
+                    <div class="hidden overflow-x-auto rounded-box border border-base-300 md:block">
                       <table class="table table-sm">
                         <thead>
                           <tr>
@@ -258,7 +352,6 @@ export const MediaEditor = (props: MediaEditorProps) => {
                           </tr>
                         </thead>
                         <tbody>
-                          {/* For はオブジェクト同一性でキーするため、入力のたびに行が再生成されて IME が中断される。Index で DOM を保つ */}
                           <Index each={medium().tracks}>
                             {(track, trackIndex) => (
                               <tr
@@ -283,12 +376,7 @@ export const MediaEditor = (props: MediaEditorProps) => {
                                   </div>
                                 </td>
                                 <td>
-                                  <Show
-                                    when={track().songId !== null}
-                                    fallback={<span class="badge badge-ghost badge-sm">対象外</span>}
-                                  >
-                                    {track().songTitle}
-                                  </Show>
+                                  <TrackSongLabel track={track()} />
                                 </td>
                                 <td>
                                   <input
@@ -300,40 +388,15 @@ export const MediaEditor = (props: MediaEditorProps) => {
                                   />
                                 </td>
                                 <td>
-                                  <div class="flex justify-end gap-2">
-                                    <button
-                                      type="button"
-                                      class="btn btn-ghost btn-xs"
-                                      aria-label={`曲順${trackIndex + 1}を上へ移動`}
-                                      disabled={trackIndex === 0}
-                                      onClick={() => reorderTracks(mediumIndex, trackIndex, trackIndex - 1)}
-                                    >
-                                      ↑
-                                    </button>
-                                    <button
-                                      type="button"
-                                      class="btn btn-ghost btn-xs"
-                                      aria-label={`曲順${trackIndex + 1}を下へ移動`}
-                                      disabled={trackIndex === medium().tracks.length - 1}
-                                      onClick={() => reorderTracks(mediumIndex, trackIndex, trackIndex + 1)}
-                                    >
-                                      ↓
-                                    </button>
-                                    <Show when={track().songId}>
-                                      {songId => (
-                                        <a href={`/songs/${songId()}`} class="btn btn-ghost btn-xs">
-                                          楽曲を見る
-                                        </a>
-                                      )}
-                                    </Show>
-                                    <button
-                                      type="button"
-                                      class="btn btn-outline btn-error btn-xs"
-                                      onClick={() => removeTrack(mediumIndex, trackIndex)}
-                                    >
-                                      削除
-                                    </button>
-                                  </div>
+                                  <TrackActions
+                                    label={`曲順${trackIndex + 1}`}
+                                    songId={track().songId}
+                                    canMoveUp={trackIndex > 0}
+                                    canMoveDown={trackIndex < medium().tracks.length - 1}
+                                    onMoveUp={() => reorderTracks(mediumIndex, trackIndex, trackIndex - 1)}
+                                    onMoveDown={() => reorderTracks(mediumIndex, trackIndex, trackIndex + 1)}
+                                    onRemove={() => removeTrack(mediumIndex, trackIndex)}
+                                  />
                                 </td>
                               </tr>
                             )}
@@ -398,7 +461,33 @@ export const MediaEditor = (props: MediaEditorProps) => {
             <Show when={searchError()}>{message => <p class="mt-3 text-sm text-error">{message()}</p>}</Show>
 
             <Show when={hasSearched()}>
-              <div class="mt-4 overflow-x-auto rounded-box border border-base-300 bg-base-100">
+              <ul class="mt-4 rounded-box border border-base-300 bg-base-100 md:hidden">
+                <Show
+                  when={searchResults().length > 0}
+                  fallback={(
+                    <li class="p-3 text-center text-sm text-base-content/60">条件に一致する楽曲はありません。</li>
+                  )}
+                >
+                  <For each={searchResults()}>
+                    {song => (
+                      <li class="flex items-center justify-between gap-3 border-b border-base-300 p-3 last:border-b-0">
+                        <div class="min-w-0">
+                          <p class="truncate text-sm font-medium">{song.title}</p>
+                          <p class="mt-1 text-xs text-base-content/60">
+                            {song.type.name}
+                            {' · '}
+                            {song.isDisplay ? '表示する' : '表示しない'}
+                          </p>
+                        </div>
+                        <button type="button" class="btn btn-primary btn-xs shrink-0" onClick={() => addTrack(song)}>
+                          追加
+                        </button>
+                      </li>
+                    )}
+                  </For>
+                </Show>
+              </ul>
+              <div class="mt-4 hidden overflow-x-auto rounded-box border border-base-300 bg-base-100 md:block">
                 <table class="table table-sm">
                   <thead>
                     <tr>

--- a/src/admin/src/components/release/SearchList.tsx
+++ b/src/admin/src/components/release/SearchList.tsx
@@ -310,26 +310,29 @@ export const SearchList = () => {
               <th>流通形態</th>
               <th>発売日</th>
               <th>表示設定</th>
-              <th>操作</th>
             </tr>
           </thead>
           <tbody>
             <Switch>
               <Match when={data.loading}>
-                <ListState state="loading" colSpan={6} />
+                <ListState state="loading" colSpan={5} />
               </Match>
               <Match when={fetchError()}>
-                {message => <ListState state="error" colSpan={6} message={message()} onRetry={() => refetch()} />}
+                {message => <ListState state="error" colSpan={5} message={message()} onRetry={() => refetch()} />}
               </Match>
               <Match when={data() && data()!.releases.length === 0}>
-                <ListState state="empty" colSpan={6} message="条件に一致するリリースはありません。" />
+                <ListState state="empty" colSpan={5} message="条件に一致するリリースはありません。" />
               </Match>
               <Match when={data()}>
                 {result => (
                   <For each={result().releases}>
                     {release => (
-                      <tr>
-                        <td class="min-w-56 font-medium">{release.title}</td>
+                      <tr class="transition-colors hover:bg-primary/30 focus-within:bg-primary/30">
+                        <td class="min-w-56">
+                          <a href={buildDetailHref(release.releaseId)} class="link link-hover font-medium">
+                            {release.title}
+                          </a>
+                        </td>
                         <td>
                           {RELEASE_TYPE_OPTIONS.find(option => option.value === String(release.typeValue))?.label
                             ?? '不明'}
@@ -346,11 +349,6 @@ export const SearchList = () => {
                           >
                             {release.isDisplay ? '表示する' : '表示しない'}
                           </span>
-                        </td>
-                        <td>
-                          <a href={buildDetailHref(release.releaseId)} class="btn btn-ghost btn-xs">
-                            編集
-                          </a>
                         </td>
                       </tr>
                     )}

--- a/src/admin/src/components/song-tag/SearchList.tsx
+++ b/src/admin/src/components/song-tag/SearchList.tsx
@@ -210,35 +210,33 @@ export const SearchList = () => {
             <tr>
               <th>楽曲タグ名</th>
               <th>表示順</th>
-              <th>操作</th>
             </tr>
           </thead>
           <tbody>
             <Switch>
               <Match when={data.loading}>
-                <ListState state="loading" colSpan={3} />
+                <ListState state="loading" colSpan={2} />
               </Match>
               <Match when={fetchError()}>
-                {message => <ListState state="error" colSpan={3} message={message()} onRetry={() => refetch()} />}
+                {message => <ListState state="error" colSpan={2} message={message()} onRetry={() => refetch()} />}
               </Match>
               <Match when={data() && data()!.tags.length === 0}>
-                <ListState state="empty" colSpan={3} message="条件に一致する楽曲タグはありません。" />
+                <ListState state="empty" colSpan={2} message="条件に一致する楽曲タグはありません。" />
               </Match>
               <Match when={data()}>
                 {result => (
                   <For each={result().tags}>
                     {tag => (
                       <tr class="hover:bg-primary/30 focus-within:bg-primary/30 transition-colors">
-                        <td>{tag.name}</td>
-                        <td>{tag.orderNo}</td>
                         <td>
                           <a
                             href={`/song-tags/${tag.songTagId}?back=${encodeURIComponent(window.location.search)}`}
-                            class="btn btn-ghost btn-xs"
+                            class="link link-hover font-medium"
                           >
-                            編集
+                            {tag.name}
                           </a>
                         </td>
+                        <td>{tag.orderNo}</td>
                       </tr>
                     )}
                   </For>

--- a/src/admin/src/components/song/SearchList.tsx
+++ b/src/admin/src/components/song/SearchList.tsx
@@ -324,45 +324,43 @@ export const SearchList = () => {
               <th>楽曲種別</th>
               <th>表示設定</th>
               <th>表示順</th>
-              <th>操作</th>
             </tr>
           </thead>
           <tbody>
             <Switch>
               <Match when={data.loading}>
-                <ListState state="loading" colSpan={5} />
+                <ListState state="loading" colSpan={4} />
               </Match>
               <Match when={fetchError()}>
-                {message => <ListState state="error" colSpan={5} message={message()} onRetry={() => refetch()} />}
+                {message => <ListState state="error" colSpan={4} message={message()} onRetry={() => refetch()} />}
               </Match>
               <Match when={data() && data()!.songs.length === 0}>
-                <ListState state="empty" colSpan={5} />
+                <ListState state="empty" colSpan={4} />
               </Match>
               <Match when={data()}>
                 {result => (
                   <For each={result().songs}>
                     {song => (
                       <tr class="hover:bg-primary/30 focus-within:bg-primary/30 transition-colors">
-                        <td>{song.title}</td>
                         <td>
+                          <a
+                            href={`/songs/${song.songId}?back=${encodeURIComponent(window.location.search)}`}
+                            class="link link-hover font-medium"
+                          >
+                            {song.title}
+                          </a>
+                        </td>
+                        <td class="whitespace-nowrap">
                           <span class={`badge badge-sm badge-soft ${SONG_TYPE_BADGE_CLASS[song.type.value]}`}>
                             {song.type.name}
                           </span>
                         </td>
-                        <td>
+                        <td class="whitespace-nowrap">
                           <span class={`badge badge-sm ${song.isDisplay ? 'badge-success badge-soft' : 'badge-ghost'}`}>
                             {song.isDisplay ? '表示する' : '表示しない'}
                           </span>
                         </td>
                         <td>{song.orderNo}</td>
-                        <td>
-                          <a
-                            href={`/songs/${song.songId}?back=${encodeURIComponent(window.location.search)}`}
-                            class="btn btn-ghost btn-xs"
-                          >
-                            編集
-                          </a>
-                        </td>
                       </tr>
                     )}
                   </For>

--- a/src/admin/src/pages/release-groups/index.astro
+++ b/src/admin/src/pages/release-groups/index.astro
@@ -4,7 +4,7 @@ import { SearchList } from '../../components/release-group/SearchList';
 import Layout from '../../layouts/Layout.astro';
 ---
 
-<Layout pageTitle="リリース一覧">
+<Layout pageTitle="リリースグループ一覧">
   <FlashMessage client:only="solid-js" />
   <SearchList client:only="solid-js" />
 </Layout>


### PR DESCRIPTION
## 概要

管理画面の各一覧テーブルとリリースグループ詳細・媒体編集が、スマホ幅で横に伸びて収まらない状態を解消します

425px を基準にしています

## やったこと

- 一覧テーブル 6 画面の操作列を廃止し、先頭の識別子列を編集ページへのリンクにする
  - 操作列は全画面が編集リンク 1 本だけを持ち、横スクロールの右端にあるためスマホから一番遠かった
- 楽曲 / リリースグループ / メディア一覧の種別と表示設定を 1 行に固定する
- メディア一覧の URL 列をホスト名だけの表示にし、フル URL は `title` に退避する
- `/release-groups` を指しているのに「リリース」と表示していた 3 箇所の呼称を揃える
- リリースグループ詳細のリリース一覧を調整する
  - 代表色の列を廃止し、viewer と同じく版名セルの左境界を代表色で塗る
  - 版名をリンク化し、操作列はコピーして追加だけにする
  - md 未満はカードの縦積み、md 以上は従来のテーブルにする
- 媒体と収録楽曲を調整する
  - 媒体ヘッダーの行に `flex-wrap` がなく、`overflow-x-auto` の外でページごと横に伸びていたのを直す
  - 収録楽曲と楽曲検索結果を md 未満でカード表示にする
  - カードとテーブルで重複しないよう `TrackSongLabel` と `TrackActions` を切り出す

## やってないこと

- 楽曲 / メディア / 人物などの一覧のカード表示化
  - 横スクロールを許容する方針にしたため、テーブルのまま据え置き
- 監査ログ一覧
  - こちらの操作列は操作種別を表すデータ列で、ボタン置き場ではないため対象外
- リリース詳細画面そのもののレイアウト調整

## 関連

- 特になし