### PR TITLE
viewer の description と Twitter meta を強化する

### DIFF
--- a/src/viewer/src/layouts/Layout.astro
+++ b/src/viewer/src/layouts/Layout.astro
@@ -37,10 +37,11 @@ const generateTitle = (title: string) => {
 };
 
 const title = generateTitle(pageTitle);
-const canonicalUrl = new URL(Astro.url.pathname, Astro.site);
+const siteOrigin = Astro.site?.href ?? Astro.url.origin;
+const canonicalUrl = new URL(Astro.url.pathname, siteOrigin);
 // ページ固有の画像がないページはサイトアイコンで代替し、カードの大きさは固有画像の有無で切り替える
 const cardImage = ogImage ?? DEFAULT_OG_IMAGE;
-const cardImageUrl = new URL(cardImage.url, Astro.site).href;
+const cardImageUrl = new URL(cardImage.url, siteOrigin).href;
 const twitterCard = ogImage === null ? 'summary' : 'summary_large_image';
 const noindex = pageNoindex || import.meta.env.SITE_NOINDEX === 'true';
 
@@ -66,6 +67,9 @@ const trail: readonly BreadcrumbItem[] = breadcrumbs.length > 0 ? [{ label: 'ホ
     <meta property="og:image" content={cardImageUrl} />
     <meta property="og:image:alt" content={cardImage.alt} />
     <meta name="twitter:card" content={twitterCard} />
+    <meta name="twitter:title" content={title} />
+    <meta name="twitter:description" content={pageDescription} />
+    <meta name="twitter:image" content={cardImageUrl} />
     <title>{title}</title>
     {/* FOUC 防止のため描画前に palette を適用する。保存値は既知のテーマのみ許可し、廃止テーマ等の不正値は既定に修復する */}
     <script

--- a/src/viewer/src/pages/changelog.md
+++ b/src/viewer/src/pages/changelog.md
@@ -1,7 +1,7 @@
 ---
 layout: ../layouts/DocLayout.astro
 pageTitle: 更新履歴
-pageDescription: ヰ世界観測所の更新履歴
+pageDescription: ヰ世界観測所の更新履歴。公開内容や機能の変更を記録しています
 ---
 
 ## v1.0.0

--- a/src/viewer/src/pages/contact.astro
+++ b/src/viewer/src/pages/contact.astro
@@ -4,7 +4,10 @@ import Layout from '../layouts/Layout.astro';
 import { CONTACT_X_HANDLE, CONTACT_X_URL } from '../shared/contact';
 ---
 
-<Layout pageTitle="お問い合わせ" pageDescription="ヰ世界観測所のお問い合わせ">
+<Layout
+  pageTitle="お問い合わせ"
+  pageDescription="ヰ世界観測所へのお問い合わせ窓口。掲載内容のご指摘や権利者からのご連絡を受け付けています"
+>
   <section class="shell page-section">
     <SectionHead title="お問い合わせ" level={1} />
 

--- a/src/viewer/src/pages/index.astro
+++ b/src/viewer/src/pages/index.astro
@@ -8,6 +8,7 @@ import { representativeColor } from '../features/releases/types';
 import { siteStatsRepository } from '../features/site-stats/api';
 import { songContentRepository } from '../features/songs/content';
 import Layout from '../layouts/Layout.astro';
+import { SITE_DESCRIPTION } from '../shared/site';
 
 const latestReleaseGroup = await releaseGroupContentRepository.latest();
 const latestSong = await songContentRepository.latest();
@@ -19,11 +20,11 @@ const preconnect = latestSong?.media.some(entry => youtubeThumbnailFromUrl(entry
   : [];
 ---
 
-<Layout pageTitle="" preconnect={preconnect}>
+<Layout pageTitle="" pageDescription={SITE_DESCRIPTION} preconnect={preconnect}>
   <section class="hero-data">
     <div class="shell">
       <h1 class="hero-mark hero-mark-data">ヰ世界観測所</h1>
-      <div class="hero-tagline">ヰ世界情緒の非公式ファンサイト</div>
+      <p class="hero-tagline">{SITE_DESCRIPTION}</p>
       <div class="hero-ledger">
         <div class="hero-ledger-row">
           <span class="hero-ledger-label">観測開始</span>

--- a/src/viewer/src/pages/releases/index.astro
+++ b/src/viewer/src/pages/releases/index.astro
@@ -13,7 +13,10 @@ const releaseGroups = await releaseGroupContentRepository.all();
 const years = [...new Set(releaseGroups.map(releaseGroup => releaseGroup.firstReleasedOn.slice(0, 4)))];
 ---
 
-<Layout pageTitle="リリース" pageDescription="ヰ世界情緒のリリース一覧">
+<Layout
+  pageTitle="リリース"
+  pageDescription="ヰ世界情緒のリリース一覧。アルバム・シングルなどを記録しています"
+>
   <section class="shell page-section">
     <SectionHead title="リリース" level={1} />
 

--- a/src/viewer/src/pages/site-policy.astro
+++ b/src/viewer/src/pages/site-policy.astro
@@ -5,7 +5,10 @@ import Layout from '../layouts/Layout.astro';
 const LAST_UPDATED = '2026年8月8日';
 ---
 
-<Layout pageTitle="サイトポリシー" pageDescription="ヰ世界観測所のサイトポリシー">
+<Layout
+  pageTitle="サイトポリシー"
+  pageDescription="ヰ世界観測所のサイトポリシー。非公式ファンサイトであることの明示と免責事項を記載しています"
+>
   <section class="shell page-section">
     <SectionHead title="サイトポリシー" level={1} />
 

--- a/src/viewer/src/pages/songs/index.astro
+++ b/src/viewer/src/pages/songs/index.astro
@@ -10,7 +10,11 @@ import Layout from '../../layouts/Layout.astro';
 const songs = await songContentRepository.all();
 ---
 
-<Layout pageTitle="楽曲" pageDescription="ヰ世界情緒の楽曲一覧" preconnect={[YOUTUBE_THUMBNAIL_ORIGIN]}>
+<Layout
+  pageTitle="楽曲"
+  pageDescription="ヰ世界情緒の楽曲一覧。オリジナル曲とカバー曲を記録しています"
+  preconnect={[YOUTUBE_THUMBNAIL_ORIGIN]}
+>
   <section class="shell page-section">
     <SectionHead title="楽曲" level={1} />
 

--- a/src/viewer/src/shared/site.ts
+++ b/src/viewer/src/shared/site.ts
@@ -3,7 +3,8 @@
 
 export const SITE_TITLE = 'ヰ世界観測所';
 
-export const SITE_DESCRIPTION = 'ヰ世界情緒の非公式ファンサイト';
+export const SITE_DESCRIPTION
+  = 'ヰ世界情緒の楽曲・リリース情報を記録する非公式ファンサイトです';
 
 export type OgImage = {
   url: string;


### PR DESCRIPTION
## 概要

検索結果スニペットや SNS シェア向けに、viewer の description と Twitter meta を強化します。

## やったこと

- サイト共通 description を具体化し、ホーム先頭でも同じ文言を表示する
- Twitter Card 用に `title` / `description` / `image` を追加する
- 楽曲・リリース・お問い合わせ・サイトポリシー・更新履歴の description を具体化する

## やってないこと

- JSON-LD の導入
- 代表色ベースの OG 画像生成
- Search Console 側の設定変更

## 関連

- 特になし

Made with [Cursor](https://cursor.com)