### PR TITLE
テスト用 .env を不変な DB 接続だけに絞る

### DIFF
--- a/docs/design-docs/local-runtime-topology.md
+++ b/docs/design-docs/local-runtime-topology.md
@@ -22,7 +22,10 @@
 - MySQL / Redis / redis-http / proxy / Astro dev server のポートは worktree ごとに自動採番する
 - 採番した開発用変数は `mise.local.toml` の自動生成ブロックに保存する
 - アプリ設定は `src/server/.env`, `src/server/.env.testing`, `src/admin/.env`, `src/viewer/.env` に書き戻す
-- `src/server/.env` と `.env.testing` の `DB_PORT` は Docker network 向けの `3306` を維持し、host 側 task 用の `ATLAS_DB_PORT` を worktree ごとの MySQL 公開ポートへ更新する
+- `src/server/.env` の `DB_PORT` は Docker network 向けの `3306` を維持し、host 側 task 用の `ATLAS_DB_PORT` を worktree ごとの MySQL 公開ポートへ更新する
+- `src/server/.env.testing` はテスト用 DB 接続など不変値のみを持ち、worktree 差分は `ATLAS_DB_PORT` だけを更新する
+- PHPUnit で変化しうるアプリ設定は `Tests\TestCase` の既定値、または各テストの `config()->set` で都度設定する
+- `phpunit.xml` にはドライバー切替などプロセス全体で固定する値を置く
 - TLS 証明書 (`infra/local/docker/nginx/certs`, `infra/local/docker/php/certs/rootCA.pem`) は共有キャッシュ経由で worktree 間に複製する
 - proxy は同一 worktree の `php` サービスと、その worktree に割り当てられた Admin / Viewer dev server へ接続し、Astro dev server の WebSocket も forward する
 - 現在の割り当ては `mise run worktree:status` で確認する

--- a/docs/design-docs/local-runtime-topology.md
+++ b/docs/design-docs/local-runtime-topology.md
@@ -24,7 +24,7 @@
 - アプリ設定は `src/server/.env`, `src/server/.env.testing`, `src/admin/.env`, `src/viewer/.env` に書き戻す
 - `src/server/.env` の `DB_PORT` は Docker network 向けの `3306` を維持し、host 側 task 用の `ATLAS_DB_PORT` を worktree ごとの MySQL 公開ポートへ更新する
 - `src/server/.env.testing` はテスト用 DB 接続など不変値のみを持ち、worktree 差分は `ATLAS_DB_PORT` だけを更新する
-- PHPUnit で変化しうるアプリ設定は `Tests\TestCase` の既定値、または各テストの `config()->set` で都度設定する
+- PHPUnit で変化しうるアプリ設定 (鍵や `APP_URL` など) はソースに固定せず、各テストの `config()->set` で都度設定する
 - `phpunit.xml` にはドライバー切替などプロセス全体で固定する値を置く
 - TLS 証明書 (`infra/local/docker/nginx/certs`, `infra/local/docker/php/certs/rootCA.pem`) は共有キャッシュ経由で worktree 間に複製する
 - proxy は同一 worktree の `php` サービスと、その worktree に割り当てられた Admin / Viewer dev server へ接続し、Astro dev server の WebSocket も forward する

--- a/src/server/.env.testing.example
+++ b/src/server/.env.testing.example
@@ -1,5 +1,5 @@
 # テスト時に必要かつ不変な値のみを定義する
-# 変化しうるアプリ設定は Tests\TestCase または各テストで都度設定する
+# 変化しうるアプリ設定は各テストで都度設定する
 # ATLAS_DB_PORT のみ worktree:init が worktree ごとの MySQL 公開ポートへ上書きする
 
 DB_CONNECTION=mysql

--- a/src/server/.env.testing.example
+++ b/src/server/.env.testing.example
@@ -1,23 +1,6 @@
-APP_NAME=IsekaiObservatoryAPI
-APP_ENV=local
-APP_KEY=
-APP_DEBUG=true
-APP_TIMEZONE=Asia/Tokyo
-APP_URL=https://local.api.isekaijoucho.fan
-
-APP_LOCALE=ja
-APP_FALLBACK_LOCALE=en
-APP_FAKER_LOCALE=en_US
-
-APP_MAINTENANCE_DRIVER=file
-# APP_MAINTENANCE_STORE=database
-
-BCRYPT_ROUNDS=12
-
-LOG_CHANNEL=stack
-LOG_STACK=single
-LOG_DEPRECATIONS_CHANNEL=null
-LOG_LEVEL=debug
+# テスト時に必要かつ不変な値のみを定義する
+# 変化しうるアプリ設定は Tests\TestCase または各テストで都度設定する
+# ATLAS_DB_PORT のみ worktree:init が worktree ごとの MySQL 公開ポートへ上書きする
 
 DB_CONNECTION=mysql
 DB_HOST=mysql
@@ -27,49 +10,3 @@ DB_DATABASE=isekai_observatory_testing
 DB_USERNAME=app
 DB_PASSWORD=secret
 DB_ROOT_PASSWORD=root
-
-SESSION_DRIVER=file
-SESSION_LIFETIME=120
-SESSION_ENCRYPT=false
-SESSION_PATH=/
-SESSION_DOMAIN=null
-
-BROADCAST_CONNECTION=log
-FILESYSTEM_DISK=local
-QUEUE_CONNECTION=database
-
-CACHE_STORE=database
-CACHE_PREFIX=
-
-MEMCACHED_HOST=127.0.0.1
-
-REDIS_CLIENT=phpredis
-REDIS_HOST=127.0.0.1
-REDIS_PASSWORD=null
-REDIS_PORT=6379
-
-MAIL_MAILER=log
-MAIL_HOST=127.0.0.1
-MAIL_PORT=2525
-MAIL_USERNAME=null
-MAIL_PASSWORD=null
-MAIL_ENCRYPTION=null
-MAIL_FROM_ADDRESS="hello@example.com"
-MAIL_FROM_NAME="${APP_NAME}"
-
-AWS_ACCESS_KEY_ID=
-AWS_SECRET_ACCESS_KEY=
-AWS_DEFAULT_REGION=us-east-1
-AWS_BUCKET=
-AWS_USE_PATH_STYLE_ENDPOINT=false
-
-VITE_APP_NAME="${APP_NAME}"
-
-ASSET_URL=https://local.api.isekaijoucho.fan
-
-API_URL=local.api.isekaijoucho.fan
-
-ROOT_CA=/etc/ssl/certs/ca-certificates.crt
-
-AUTH_JWT_ALG=HS256
-AUTH_JWT_KEY=

--- a/src/server/tests/Feature/Api/Admin/V1/Auth/GenerateRecoveryCodesTest.php
+++ b/src/server/tests/Feature/Api/Admin/V1/Auth/GenerateRecoveryCodesTest.php
@@ -35,6 +35,7 @@ class GenerateRecoveryCodesTest extends DatabaseTestCase
         config()->set([
             'auth.jwt.alg' => 'HS256',
             'auth.jwt.key' => str_repeat('k', 256),
+            'auth.recovery_code.pepper' => bin2hex(random_bytes(16)),
         ]);
     }
 

--- a/src/server/tests/Feature/Api/Admin/V1/Auth/RecoveryTest.php
+++ b/src/server/tests/Feature/Api/Admin/V1/Auth/RecoveryTest.php
@@ -45,6 +45,7 @@ class RecoveryTest extends DatabaseTestCase
         config()->set([
             'auth.jwt.alg' => 'HS256',
             'auth.jwt.key' => str_repeat('k', 256),
+            'auth.recovery_code.pepper' => bin2hex(random_bytes(16)),
         ]);
     }
 

--- a/src/server/tests/README.md
+++ b/src/server/tests/README.md
@@ -9,8 +9,8 @@
 ## 環境変数
 
 - `src/server/.env.testing` にはテスト時に必要かつ不変な値 (主にテスト用 DB 接続) だけを置く
-- 変化しうる値は `Tests\TestCase` の既定、または各テストで `config()->set` する
-- JWT 鍵や Passkey RP などシナリオ依存の設定は、対象テスト側で都度設定する
+- `APP_KEY` / JWT / pepper / Passkey RP など変化しうる値はソースに固定せず、対象テストで都度設定する
+- 起動に必要な `APP_KEY` のみ、未設定時に `Tests\TestCase` が実行時生成する
 - `phpunit.xml` にはドライバー切替などプロセス全体で固定する値を置く
 
 ## Unit

--- a/src/server/tests/README.md
+++ b/src/server/tests/README.md
@@ -6,6 +6,13 @@
 2. Integration
 3. Feature
 
+## 環境変数
+
+- `src/server/.env.testing` にはテスト時に必要かつ不変な値 (主にテスト用 DB 接続) だけを置く
+- 変化しうる値は `Tests\TestCase` の既定、または各テストで `config()->set` する
+- JWT 鍵や Passkey RP などシナリオ依存の設定は、対象テスト側で都度設定する
+- `phpunit.xml` にはドライバー切替などプロセス全体で固定する値を置く
+
 ## Unit
 
 ### テスト対象

--- a/src/server/tests/TestCase.php
+++ b/src/server/tests/TestCase.php
@@ -10,15 +10,38 @@ use AdminUser\Domain\Models\Role;
 use Auth\Domain\Models\AuthContext;
 use Auth\Infrastructures\Auth\UseCaseAuthorizationContext;
 use DateTimeImmutable;
+use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+use Override;
 use Support\Contracts\Uuid\UuidConverterInterface;
 use Support\Contracts\Uuid\UuidGeneratorInterface;
 use Support\UseCase\Authorizer\UseCaseAuthorizer;
 
 abstract class TestCase extends BaseTestCase
 {
+    /**
+     * .env.testing には置かないテスト用の既定値
+     * シナリオ依存の値 (JWT 鍵など) は各テストで config()->set する
+     *
+     * @var array<string, string>
+     */
+    private const array TESTING_ENV_DEFAULTS = [
+        'APP_KEY' => 'base64:AUMNxw7cx4uYZgywdQxCzOiVA9gmSwMJohPE21aWGDM=',
+        'APP_URL' => 'https://api.example.test',
+        'APP_TIMEZONE' => 'Asia/Tokyo',
+        'AUTH_RECOVERY_CODE_PEPPER' => 'testing-recovery-code-pepper',
+    ];
+
     private ?AuthContext $privilegedAuthContext = null;
+
+    #[Override]
+    public function createApplication(): Application
+    {
+        $this->ensureTestingEnvironment();
+
+        return parent::createApplication();
+    }
 
     protected function generateUuid(): string
     {
@@ -68,5 +91,21 @@ abstract class TestCase extends BaseTestCase
     protected function authorizer(?AuthContext $context = null): UseCaseAuthorizer
     {
         return new UseCaseAuthorizer(new UseCaseAuthorizationContext($context ?? $this->privilegedContext()));
+    }
+
+    private function ensureTestingEnvironment(): void
+    {
+        foreach (self::TESTING_ENV_DEFAULTS as $key => $value) {
+            $current = $_ENV[$key] ?? $_SERVER[$key] ?? getenv($key);
+
+            // phpunit.xml などで既に実値が入っている場合は尊重する
+            if (is_string($current) && $current !== '') {
+                continue;
+            }
+
+            putenv("{$key}={$value}");
+            $_ENV[$key] = $value;
+            $_SERVER[$key] = $value;
+        }
     }
 }

--- a/src/server/tests/TestCase.php
+++ b/src/server/tests/TestCase.php
@@ -20,25 +20,13 @@ use Support\UseCase\Authorizer\UseCaseAuthorizer;
 
 abstract class TestCase extends BaseTestCase
 {
-    /**
-     * .env.testing には置かないテスト用の既定値
-     * シナリオ依存の値 (JWT 鍵など) は各テストで config()->set する
-     *
-     * @var array<string, string>
-     */
-    private const array TESTING_ENV_DEFAULTS = [
-        'APP_KEY' => 'base64:AUMNxw7cx4uYZgywdQxCzOiVA9gmSwMJohPE21aWGDM=',
-        'APP_URL' => 'https://api.example.test',
-        'APP_TIMEZONE' => 'Asia/Tokyo',
-        'AUTH_RECOVERY_CODE_PEPPER' => 'testing-recovery-code-pepper',
-    ];
-
     private ?AuthContext $privilegedAuthContext = null;
 
     #[Override]
     public function createApplication(): Application
     {
-        $this->ensureTestingEnvironment();
+        // .env.testing には鍵を置かない。未設定時のみ起動用に都度生成する
+        $this->ensureAppKey();
 
         return parent::createApplication();
     }
@@ -93,19 +81,17 @@ abstract class TestCase extends BaseTestCase
         return new UseCaseAuthorizer(new UseCaseAuthorizationContext($context ?? $this->privilegedContext()));
     }
 
-    private function ensureTestingEnvironment(): void
+    private function ensureAppKey(): void
     {
-        foreach (self::TESTING_ENV_DEFAULTS as $key => $value) {
-            $current = $_ENV[$key] ?? $_SERVER[$key] ?? getenv($key);
+        $current = $_ENV['APP_KEY'] ?? $_SERVER['APP_KEY'] ?? getenv('APP_KEY');
 
-            // phpunit.xml などで既に実値が入っている場合は尊重する
-            if (is_string($current) && $current !== '') {
-                continue;
-            }
-
-            putenv("{$key}={$value}");
-            $_ENV[$key] = $value;
-            $_SERVER[$key] = $value;
+        if (is_string($current) && $current !== '') {
+            return;
         }
+
+        $key = 'base64:' . base64_encode(random_bytes(32));
+        putenv('APP_KEY=' . $key);
+        $_ENV['APP_KEY'] = $key;
+        $_SERVER['APP_KEY'] = $key;
     }
 }

--- a/tools/worktree/init.sh
+++ b/tools/worktree/init.sh
@@ -375,10 +375,7 @@ set_env_value "${repo_root}/src/server/.env" "DB_PORT" "3306"
 set_env_value "${repo_root}/src/server/.env" "ATLAS_DB_PORT" "$WORKTREE_MYSQL_PORT"
 
 ensure_env_file "${repo_root}/src/server/.env.testing" "${repo_root}/src/server/.env.testing.example"
-set_env_value "${repo_root}/src/server/.env.testing" "APP_URL" "$WORKTREE_API_BASE_URL"
-set_env_value "${repo_root}/src/server/.env.testing" "ASSET_URL" "$WORKTREE_API_BASE_URL"
-set_env_value "${repo_root}/src/server/.env.testing" "API_URL" "local.api.isekaijoucho.fan:${WORKTREE_PROXY_HTTPS_PORT}"
-set_env_value "${repo_root}/src/server/.env.testing" "DB_PORT" "3306"
+# .env.testing は不変な DB 接続が本体。worktree 差分は host 向け ATLAS_DB_PORT のみ書き戻す
 set_env_value "${repo_root}/src/server/.env.testing" "ATLAS_DB_PORT" "$WORKTREE_MYSQL_PORT"
 
 if [[ "${1:-}" == "--status" ]]; then


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

`.env.testing.example` にテスト時に必要かつ不変な値だけを残し、変化しうるアプリ設定はテスト側で都度設定するようにした

## やったこと

- `.env.testing.example` をテスト用 DB 接続 (と `ATLAS_DB_PORT`) のみに削減した
- `APP_KEY` / `APP_URL` / pepper などをソースに固定しない
  - 起動に必要な `APP_KEY` のみ、未設定時に `Tests\TestCase` が実行時生成する
  - recovery pepper は対象 Feature テストで `config()->set` する
- JWT 鍵などシナリオ依存の値は、従来どおり各テストの `config()->set` で都度設定する
- `worktree:init` が `.env.testing` に書き戻す値を `ATLAS_DB_PORT` のみにした
- `local-runtime-topology.md` と `tests/README.md` に方針を追記した

## やってないこと

- 既存ローカルの `.env.testing` の自動移行 (ファイルがある場合は `worktree:init` は上書きしない)
- この Cloud Agent 環境に Docker / mise が無く、`mise run api:test` は未実行

## 関連

- 特になし

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0eb18abd-66aa-44c4-a67c-4f0f699650b8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0eb18abd-66aa-44c4-a67c-4f0f699650b8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

