### PR TITLE
YouTube 取り込み通知に動画リンクを含める

### DIFF
--- a/src/server/packages/Media/Application/Cli/UseCase/ImportYouTube/ChannelImportResult.php
+++ b/src/server/packages/Media/Application/Cli/UseCase/ImportYouTube/ChannelImportResult.php
@@ -8,20 +8,27 @@ use Media\Domain\Models\YouTubeChannel\YouTubeChannel;
 
 readonly class ChannelImportResult
 {
+    /**
+     * @param list<ImportedVideo> $importedVideos
+     */
     private function __construct(
         public YouTubeChannel $channel,
         public int $importedCount,
         public bool $channelFound,
+        public array $importedVideos,
     ) {
     }
 
-    public static function imported(YouTubeChannel $channel, int $importedCount): self
+    /**
+     * @param list<ImportedVideo> $importedVideos
+     */
+    public static function imported(YouTubeChannel $channel, array $importedVideos): self
     {
-        return new self($channel, $importedCount, true);
+        return new self($channel, count($importedVideos), true, $importedVideos);
     }
 
     public static function channelNotFound(YouTubeChannel $channel): self
     {
-        return new self($channel, 0, false);
+        return new self($channel, 0, false, []);
     }
 }

--- a/src/server/packages/Media/Application/Cli/UseCase/ImportYouTube/ImportYouTubeNotifier.php
+++ b/src/server/packages/Media/Application/Cli/UseCase/ImportYouTube/ImportYouTubeNotifier.php
@@ -13,6 +13,18 @@ use Throwable;
 
 readonly class ImportYouTubeNotifier
 {
+    /**
+     * Discord webhook 1 メッセージあたりの embeds 上限
+     *
+     * @see https://discord.com/developers/docs/resources/channel#embed-object
+     */
+    private const int MAX_EMBEDS = 10;
+
+    /**
+     * Discord embed description の文字数上限
+     */
+    private const int MAX_DESCRIPTION_LENGTH = 4096;
+
     public function __construct(private NotificationService $notifier)
     {
     }
@@ -26,10 +38,7 @@ readonly class ImportYouTubeNotifier
             Action::MediaYoutubeImport,
             Status::Succeeded,
             content: 'YouTube からの取り込みを実行しました',
-            embeds: array_map(
-                fn (ChannelImportResult $result): NotificationEmbed => $this->buildEmbed($result),
-                $results,
-            ),
+            embeds: $this->buildSucceededEmbeds($results),
         );
     }
 
@@ -48,12 +57,46 @@ readonly class ImportYouTubeNotifier
         );
     }
 
+    /**
+     * @param list<ChannelImportResult> $results
+     *
+     * @return list<NotificationEmbed>
+     */
+    private function buildSucceededEmbeds(array $results): array
+    {
+        if (count($results) <= self::MAX_EMBEDS) {
+            return array_map(
+                fn (ChannelImportResult $result): NotificationEmbed => $this->buildEmbed($result),
+                $results,
+            );
+        }
+
+        $visibleResults = array_slice($results, 0, self::MAX_EMBEDS - 1);
+        $omittedCount = count($results) - count($visibleResults);
+
+        $embeds = array_map(
+            fn (ChannelImportResult $result): NotificationEmbed => $this->buildEmbed($result),
+            $visibleResults,
+        );
+        $embeds[] = new NotificationEmbed(
+            title: '一部の結果を省略しました',
+            description: sprintf(
+                'Discord の embeds 上限 (%d件) のため、他 %d チャンネル分の結果は省略しています',
+                self::MAX_EMBEDS,
+                $omittedCount,
+            ),
+            color: Color::Warning,
+        );
+
+        return $embeds;
+    }
+
     private function buildEmbed(ChannelImportResult $result): NotificationEmbed
     {
         if ($result->channelFound) {
             return new NotificationEmbed(
                 title: sprintf('%s の取り込みが完了', $result->channel->name->value),
-                description: sprintf('取り込み件数: %d', $result->importedCount),
+                description: $this->buildSuccessDescription($result),
                 color: $result->importedCount === 0 ? Color::Warning : Color::Success,
                 url: $this->buildChannelUrl($result->channel->channelId->value),
             );
@@ -64,6 +107,63 @@ readonly class ImportYouTubeNotifier
             description: 'チャンネルが見つかりませんでした',
             color: Color::Error,
             url: $this->buildChannelUrl($result->channel->channelId->value),
+        );
+    }
+
+    private function buildSuccessDescription(ChannelImportResult $result): string
+    {
+        $header = sprintf('取り込み件数: %d', $result->importedCount);
+
+        if ($result->importedVideos === []) {
+            return $header;
+        }
+
+        $lines = [$header, ''];
+        $includedCount = 0;
+
+        foreach ($result->importedVideos as $index => $video) {
+            $line = $this->formatVideoLine($video);
+            $candidateLines = [...$lines, $line];
+            $candidate = implode("\n", $candidateLines);
+            $remainingAfterThis = count($result->importedVideos) - $index - 1;
+
+            if ($remainingAfterThis > 0) {
+                $withOmissionNotice = $candidate . "\n\n" . $this->buildDescriptionOmissionNotice($remainingAfterThis);
+
+                if (mb_strlen($withOmissionNotice) > self::MAX_DESCRIPTION_LENGTH) {
+                    break;
+                }
+            } elseif (mb_strlen($candidate) > self::MAX_DESCRIPTION_LENGTH) {
+                break;
+            }
+
+            $lines = $candidateLines;
+            $includedCount++;
+        }
+
+        $omittedCount = count($result->importedVideos) - $includedCount;
+
+        if ($omittedCount > 0) {
+            $lines[] = '';
+            $lines[] = $this->buildDescriptionOmissionNotice($omittedCount);
+        }
+
+        return implode("\n", $lines);
+    }
+
+    private function formatVideoLine(ImportedVideo $video): string
+    {
+        $title = str_replace(['[', ']'], ['［', '］'], $video->title);
+
+        return sprintf('- [%s](%s)', $title, $video->url);
+    }
+
+    private function buildDescriptionOmissionNotice(int $omittedCount): string
+    {
+        return sprintf(
+            '…他 %d 件のリンクは Discord の description 上限 (%d文字) のため省略しています',
+            $omittedCount,
+            self::MAX_DESCRIPTION_LENGTH,
         );
     }
 

--- a/src/server/packages/Media/Application/Cli/UseCase/ImportYouTube/ImportYouTubeUseCase.php
+++ b/src/server/packages/Media/Application/Cli/UseCase/ImportYouTube/ImportYouTubeUseCase.php
@@ -98,7 +98,13 @@ readonly class ImportYouTubeUseCase
             }
         });
 
-        return ChannelImportResult::imported($channel, count($mediaList));
+        return ChannelImportResult::imported(
+            $channel,
+            array_map(
+                static fn (YouTubeUploadedVideo $video): ImportedVideo => new ImportedVideo($video->title, $video->url),
+                $videosToImport,
+            ),
+        );
     }
 
     private function resolveType(string $title, bool $isShort): MediaType

--- a/src/server/packages/Media/Application/Cli/UseCase/ImportYouTube/ImportedVideo.php
+++ b/src/server/packages/Media/Application/Cli/UseCase/ImportYouTube/ImportedVideo.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Media\Application\Cli\UseCase\ImportYouTube;
+
+readonly class ImportedVideo
+{
+    public function __construct(
+        public string $title,
+        public string $url,
+    ) {
+    }
+}

--- a/src/server/tests/Unit/Media/Application/Cli/UseCase/ImportYouTube/ImportYouTubeNotifierTest.php
+++ b/src/server/tests/Unit/Media/Application/Cli/UseCase/ImportYouTube/ImportYouTubeNotifierTest.php
@@ -135,7 +135,7 @@ class ImportYouTubeNotifierTest extends TestCase
         for ($i = 0; $i < 80; $i++) {
             $videos[] = new ImportedVideo(
                 str_repeat('あ', 40) . $i,
-                sprintf('https://www.youtube.com/watch?v=%s', str_pad((string) $i, 11, '0', STR_PAD_LEFT)),
+                sprintf('https://www.youtube.com/watch?v=%s', str_pad((string)$i, 11, '0', STR_PAD_LEFT)),
             );
         }
 

--- a/src/server/tests/Unit/Media/Application/Cli/UseCase/ImportYouTube/ImportYouTubeNotifierTest.php
+++ b/src/server/tests/Unit/Media/Application/Cli/UseCase/ImportYouTube/ImportYouTubeNotifierTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Media\Application\Cli\UseCase\ImportYouTube;
 
 use Media\Application\Cli\UseCase\ImportYouTube\ChannelImportResult;
+use Media\Application\Cli\UseCase\ImportYouTube\ImportedVideo;
 use Media\Application\Cli\UseCase\ImportYouTube\ImportYouTubeNotifier;
 use Mockery;
 use Mockery\MockInterface;
@@ -43,7 +44,12 @@ class ImportYouTubeNotifierTest extends TestCase
             embeds: [
                 new NotificationEmbed(
                     title: '成功ch の取り込みが完了',
-                    description: '取り込み件数: 2',
+                    description: implode("\n", [
+                        '取り込み件数: 2',
+                        '',
+                        '- [動画A](https://www.youtube.com/watch?v=aaaaaaaaaaa)',
+                        '- [動画B](https://www.youtube.com/watch?v=bbbbbbbbbbb)',
+                    ]),
                     color: Color::Success,
                     url: 'https://www.youtube.com/channel/UCabcdefghijklmnopqrstuv',
                 ),
@@ -71,14 +77,89 @@ class ImportYouTubeNotifierTest extends TestCase
         $this->getInstance()->succeeded([
             ChannelImportResult::imported(
                 $this->createYouTubeChannel('UCabcdefghijklmnopqrstuv', '成功ch'),
-                2,
+                [
+                    new ImportedVideo('動画A', 'https://www.youtube.com/watch?v=aaaaaaaaaaa'),
+                    new ImportedVideo('動画B', 'https://www.youtube.com/watch?v=bbbbbbbbbbb'),
+                ],
             ),
             ChannelImportResult::channelNotFound(
                 $this->createYouTubeChannel('UCabcdefghijklmnopqrstuw', '失敗ch'),
             ),
             ChannelImportResult::imported(
                 $this->createYouTubeChannel('UCabcdefghijklmnopqrstux', '0件ch'),
-                0,
+                [],
+            ),
+        ]);
+    }
+
+    #[Test]
+    public function succeededOmitsOverflowEmbedsWithLimitNotice(): void
+    {
+        $results = [];
+
+        for ($i = 0; $i < 12; $i++) {
+            $channelId = sprintf('UCabcdefghijklmnopqrstu%c', 97 + $i);
+            $results[] = ChannelImportResult::imported(
+                $this->createYouTubeChannel($channelId, sprintf('ch%d', $i)),
+                [],
+            );
+        }
+
+        $this->driver->shouldReceive('notice')
+            ->once()
+            ->with(Mockery::on(function (NotificationMessage $message): bool {
+                $payload = json_decode($message->toJson(), true);
+                $this->assertSame(Action::MediaYoutubeImport->value, $payload['action']);
+                $this->assertSame(Status::Succeeded->value, $payload['status']);
+                $this->assertCount(10, $payload['embeds']);
+                $this->assertSame('ch0 の取り込みが完了', $payload['embeds'][0]['title']);
+                $this->assertSame('ch8 の取り込みが完了', $payload['embeds'][8]['title']);
+                $this->assertSame('一部の結果を省略しました', $payload['embeds'][9]['title']);
+                $this->assertSame(
+                    'Discord の embeds 上限 (10件) のため、他 3 チャンネル分の結果は省略しています',
+                    $payload['embeds'][9]['description'],
+                );
+                $this->assertSame(Color::Warning->value, $payload['embeds'][9]['color']);
+
+                return true;
+            }));
+
+        $this->getInstance()->succeeded($results);
+    }
+
+    #[Test]
+    public function succeededOmitsOverflowVideoLinksWithDescriptionLimitNotice(): void
+    {
+        $videos = [];
+
+        for ($i = 0; $i < 80; $i++) {
+            $videos[] = new ImportedVideo(
+                str_repeat('あ', 40) . $i,
+                sprintf('https://www.youtube.com/watch?v=%s', str_pad((string) $i, 11, '0', STR_PAD_LEFT)),
+            );
+        }
+
+        $this->driver->shouldReceive('notice')
+            ->once()
+            ->with(Mockery::on(function (NotificationMessage $message) use ($videos): bool {
+                $payload = json_decode($message->toJson(), true);
+                $description = $payload['embeds'][0]['description'];
+                $this->assertLessThanOrEqual(4096, mb_strlen($description));
+                $this->assertStringStartsWith('取り込み件数: 80', $description);
+                $this->assertStringContainsString(
+                    'Discord の description 上限 (4096文字) のため省略しています',
+                    $description,
+                );
+                $this->assertStringContainsString($videos[0]->url, $description);
+                $this->assertStringNotContainsString($videos[79]->url, $description);
+
+                return true;
+            }));
+
+        $this->getInstance()->succeeded([
+            ChannelImportResult::imported(
+                $this->createYouTubeChannel('UCabcdefghijklmnopqrstuv', '長文ch'),
+                $videos,
             ),
         ]);
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

自動取り込み通知に取り込んだ動画のリンクを含め、Discord の embeds / description 上限を超える場合はその旨が分かる通知にする

## やったこと

- `ChannelImportResult` に取り込み動画 (`ImportedVideo`) を持たせる
- `ImportYouTubeNotifier` の成功通知に動画タイトル付きリンクを載せる
- Discord embeds 上限 (10件) 超過時は、省略理由を明示する Warning embed を末尾に付ける
- Discord description 上限 (4096文字) 超過時は、省略件数と理由を description 末尾に付ける
- ユニットテストを追加・更新する
- ECS (`CastSpacesFixer`) を適用する

## やってないこと

- 上限超過時に複数メッセージへ分割する対応
- discord-notifier 側での防御的な truncate

## 関連

- Closes #1036

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec358a00-89ad-47c0-8fed-a6f4b0e021c4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec358a00-89ad-47c0-8fed-a6f4b0e021c4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

